### PR TITLE
Issue8 spawn integration

### DIFF
--- a/geojson_modelica_translator/model_connectors/templates/spawn_fmu.mot
+++ b/geojson_modelica_translator/model_connectors/templates/spawn_fmu.mot
@@ -30,10 +30,7 @@ model building
     zoneName="{{zone['spawn_object_name']}}") "Thermal zone"
     {% raw %} annotation (Placement(transformation(extent={{20,40},{60,80}}))); {% endraw %}
   {% endfor %}
-  Buildings.BoundaryConditions.WeatherData.ReaderTMY3 weaDat(filNam=
-    Modelica.Utilities.Files.loadResource("modelica://{{project_name}}/Loads/{{data['load_resources_path']}}/{{data['mos_weather']['filename']}}"))
-    "Weather data reader"
-    {% raw %}annotation (Placement(transformation(extent={{-80,80},{-60,100}})));
+{% raw %}
 equation
   connect(qRadGai_flow.y,multiplex3_1. u1[1])  annotation (Line(
       points={{-53,40},{-40,40},{-40,7},{-30,7}},
@@ -44,8 +41,7 @@ equation
       color={0,0,127},
       smooth=Smooth.None));
   connect(multiplex3_1.u3[1],qLatGai_flow. y)
-    annotation (Line(points={{-30,-7},{-40,-7},{-40,-40},{-53,-40}},color={0,0,127}));
-  {% endraw %}
+    annotation (Line(points={{-30,-7},{-40,-7},{-40,-40},{-53,-40}},color={0,0,127}));{% endraw %}
   {% for zone in data['thermal_zones'] %}
   connect(multiplex3_1.y, {{zone['modelica_object_name']}}.qGai_flow)
     {% raw %}  annotation (Line(points={{-7,0},{20,0},{20,12},{38,12}}, color={0,0,127}));{% endraw %}

--- a/geojson_modelica_translator/model_connectors/templates/spawn_fmu.mot
+++ b/geojson_modelica_translator/model_connectors/templates/spawn_fmu.mot
@@ -8,7 +8,7 @@ model building
     "modelica://{{project_name}}/Loads/{{data['load_resources_path']}}/{{data['idf']['filename']}}")
     "Name of the IDF file";
   parameter String weaName = Modelica.Utilities.Files.loadResource(
-    "modelica://{{project_name}}/Loads/{{data['load_resources_path']}}/{{data['epw']['epw_filename']}}")
+    "modelica://{{project_name}}/Loads/{{data['load_resources_path']}}/{{data['epw']['filename']}}")
     "Name of the weather file";
 
   {% raw %}Modelica.Blocks.Sources.Constant qConGai_flow(k=0) "Convective heat gain"
@@ -20,7 +20,7 @@ model building
   Modelica.Blocks.Sources.Constant qLatGai_flow(k=0) "Latent heat gain"
     annotation (Placement(transformation(extent={{-74,-50},{-54,-30}})));{% endraw %}
   {% for zone in data['thermal_zones'] %}
-  ThermalZone {{zone['modelica_object_name']}}(
+  Buildings.Experimental.EnergyPlus.ThermalZone {{zone['modelica_object_name']}}(
     redeclare package Medium = Medium,
     idfName=idfName,
     weaName=weaName,
@@ -30,8 +30,8 @@ model building
     zoneName="{{zone['spawn_object_name']}}") "Thermal zone"
     {% raw %} annotation (Placement(transformation(extent={{20,40},{60,80}}))); {% endraw %}
   {% endfor %}
-  BoundaryConditions.WeatherData.ReaderTMY3 weaDat(filNam=
-    Modelica.Utilities.Files.loadResource("modelica://{{project_name}}/Loads/{{data['load_resources_path']}}/{{data['mos_weather']['mos_weather_filename']}}"))
+  Buildings.BoundaryConditions.WeatherData.ReaderTMY3 weaDat(filNam=
+    Modelica.Utilities.Files.loadResource("modelica://{{project_name}}/Loads/{{data['load_resources_path']}}/{{data['mos_weather']['filename']}}"))
     "Weather data reader"
     {% raw %}annotation (Placement(transformation(extent={{-80,80},{-60,100}})));
 equation


### PR DESCRIPTION
This closes #8 
It also includes the removal of `ReaderTMY3` instance in `spawn_fmu.mot` as it is not used by EnergyPlus FMU.
With those updates each exported Spawn model can be simulated with JModelica.
