### PR TITLE
Remove redundant weather bus

### DIFF
--- a/geojson_modelica_translator/model_connectors/teaser.py
+++ b/geojson_modelica_translator/model_connectors/teaser.py
@@ -204,7 +204,6 @@ class TeaserConnector(model_connector_base):
                 # Now remove the redundant weaBus -> weaBus connection
                 mofile.remove_connect_string('weaBus', 'weaBus')
 
-
                 # add new port connections
                 if self.system_parameters.get_param('buildings.default.load_model_parameters.rc.order', default=2) == 1:  # noqa
                     data = 'annotation (Line(points={{0,100},{96,100},{96,20},{92,20}}, color={191,0,0}))'

--- a/geojson_modelica_translator/model_connectors/teaser.py
+++ b/geojson_modelica_translator/model_connectors/teaser.py
@@ -199,8 +199,11 @@ class TeaserConnector(model_connector_base):
                 ]
                 mofile.add_model_object('Buildings.Controls.OBC.CDL.Interfaces.RealOutput', instance, data)
 
-                # update the weaBus connectors
+                # All existing weaDat.weaBus connections need to be updated to simply weaBus
                 mofile.replace_connect_string('weaDat.weaBus', None, 'weaBus', None, True)
+                # Now remove the redundant weaBus -> weaBus connection
+                mofile.remove_connect_string('weaDat.weaBus', 'weaBus')
+
 
                 # add new port connections
                 if self.system_parameters.get_param('buildings.default.load_model_parameters.rc.order', default=2) == 1:  # noqa

--- a/geojson_modelica_translator/model_connectors/teaser.py
+++ b/geojson_modelica_translator/model_connectors/teaser.py
@@ -202,7 +202,7 @@ class TeaserConnector(model_connector_base):
                 # All existing weaDat.weaBus connections need to be updated to simply weaBus
                 mofile.replace_connect_string('weaDat.weaBus', None, 'weaBus', None, True)
                 # Now remove the redundant weaBus -> weaBus connection
-                mofile.remove_connect_string('weaDat.weaBus', 'weaBus')
+                mofile.remove_connect_string('weaBus', 'weaBus')
 
 
                 # add new port connections

--- a/geojson_modelica_translator/modelica/input_parser.py
+++ b/geojson_modelica_translator/modelica/input_parser.py
@@ -346,6 +346,18 @@ class InputParser(object):
             else:
                 index, c = self.find_connect(a, b)
 
+    def remove_connect_string(self, a, b):
+        """
+        Remove a connection string that matches the a, b.
+
+        :param a: string, existing port a
+        :param b: string, existing port b
+        """
+        # find the connection that matches a, b
+        index, c = self.find_connect(a, b)
+        if index:
+            del self.connections[index]
+
     def serialize(self):
         """
         Serialize the modelica object to a string with line feeds

--- a/tests/modelica/test_input_parser.py
+++ b/tests/modelica/test_input_parser.py
@@ -93,7 +93,8 @@ class InputParserTest(unittest.TestCase):
         f1.replace_model_string(
             'Modelica.Blocks.Sources.CombiTimeTable',
             'internalGains',
-            'modelica://Project/B5a6b99ec37f4de7f94020090/B5a6b99ec37f4de7f94020090_Models/InternalGains_B5a6b99ec37f4de7f94020090Floor.mat',  # noqa
+            'modelica://Project/B5a6b99ec37f4de7f94020090/B5a6b99ec37f4de7f94020090_Models/InternalGains_B5a6b99ec37f4de7f94020090Floor.mat',
+            # noqa
             'modelica://a/new/path.mat'
         )
         f1.save_as(new_filename)
@@ -109,7 +110,8 @@ class InputParserTest(unittest.TestCase):
         new_filename = os.path.abspath('tests/modelica/output/test_1_output_5.mo')
         f1 = InputParser(filename)
         data = [
-            'annotation (Placement(transformation(extent={{-10,90},{10,110}}), iconTransformation(extent={{-10,90},{10,110}})));'  # noqa
+            'annotation (Placement(transformation(extent={{-10,90},{10,110}}), iconTransformation(extent={{-10,90},{10,110}})));'
+            # noqa
         ]
         f1.add_model_object('Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a', 'port_a', data)
         f1.save_as(new_filename)
@@ -142,6 +144,29 @@ class InputParserTest(unittest.TestCase):
         f1.replace_connect_string('eqAirTemp.TEqAir', 'prescribedTemperature.T', 'NothingOfImportance', None)
         f1.replace_connect_string('weaDat.weaBus', None, 'weaBus', None, True)
         f1.save_as(new_filename)
+
+        f2 = InputParser(new_filename)
+        self.assertFalse(filecmp.cmp(filename, new_filename))
+        index, c = f2.find_connect('weaBus', 'weaBus')
+        # there should exist the new connection
+        self.assertGreaterEqual(index, 0)
+
+        # the old one should not exist
+        index, c = f2.find_connect('weaDat.weaBus', 'weaBus')
+        self.assertIsNone(index)
+
+    def test_remove_connection(self):
+        filename = os.path.abspath('tests/modelica/data/test_1.mo')
+        new_filename = os.path.abspath('tests/modelica/output/test_1_output_8.mo')
+        f1 = InputParser(filename)
+        f1.remove_connect_string('weaDat.weaBus', 'weaBus')
+        f1.save_as(new_filename)
+
+        f2 = InputParser(new_filename)
+        self.assertFalse(filecmp.cmp(filename, new_filename))
+        index, c = f2.find_connect('weaDat.weaBus', 'weaBus')
+        # the connection should no longer exist
+        self.assertIsNone(index)
 
 
 def update_connection(self):

--- a/tests/modelica/test_input_parser.py
+++ b/tests/modelica/test_input_parser.py
@@ -93,7 +93,7 @@ class InputParserTest(unittest.TestCase):
         f1.replace_model_string(
             'Modelica.Blocks.Sources.CombiTimeTable',
             'internalGains',
-            'modelica://Project/B5a6b99ec37f4de7f94020090/B5a6b99ec37f4de7f94020090_Models/InternalGains_B5a6b99ec37f4de7f94020090Floor.mat',
+            'modelica://Project/B5a6b99ec37f4de7f94020090/B5a6b99ec37f4de7f94020090_Models/InternalGains_B5a6b99ec37f4de7f94020090Floor.mat', # noqa
             # noqa
             'modelica://a/new/path.mat'
         )
@@ -110,7 +110,7 @@ class InputParserTest(unittest.TestCase):
         new_filename = os.path.abspath('tests/modelica/output/test_1_output_5.mo')
         f1 = InputParser(filename)
         data = [
-            'annotation (Placement(transformation(extent={{-10,90},{10,110}}), iconTransformation(extent={{-10,90},{10,110}})));'
+            'annotation (Placement(transformation(extent={{-10,90},{10,110}}), iconTransformation(extent={{-10,90},{10,110}})));' # noqa
             # noqa
         ]
         f1.add_model_object('Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a', 'port_a', data)


### PR DESCRIPTION
#### Any background context you want to provide?
There was an unneeded weather bus in the TEASER outputs

#### What does this PR accomplish?
* Add method to remove connections to input parser
* Remove weaBus, weaBus from TEASER outputs

#### How should this be manually tested?

* `pip install -r requirements.txt` 
* Run `py.test`
* Inspect results of `output/rc_order_4/Loads/B*/*.mo`

#### What are the relevant tickets?

Fixes #28 

#### Screenshots (if appropriate)
N/A
