### PR TITLE
Clean up results of JModelica docker simulations

### DIFF
--- a/geojson_modelica_translator/modelica/modelica_runner.py
+++ b/geojson_modelica_translator/modelica/modelica_runner.py
@@ -125,11 +125,11 @@ class ModelicaRunner(object):
             os.chdir(curdir)
             stdout_log.close()
 
+        # Cleanup all of the temporary files that get created
         self.cleanup_path(run_path)
 
-        # get the filename
+        # get the location of the results path
         results_path = os.path.join(run_path, f'{project_name}_results')
-
         self.move_result_files(run_path, results_path)
         return exitcode
 

--- a/geojson_modelica_translator/modelica/modelica_runner.py
+++ b/geojson_modelica_translator/modelica/modelica_runner.py
@@ -28,6 +28,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ****************************************************************************************************
 """
 
+import glob
 import os
 import shutil
 import subprocess
@@ -63,7 +64,7 @@ class ModelicaRunner(object):
         r = subprocess.call(['docker', 'ps'], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         self.docker_configured = r == 0
 
-    def run_in_docker(self, file_to_run, run_path=None):
+    def run_in_docker(self, file_to_run, run_path=None, project_name=None):
         """
         Run the Modelica project in a docker-based environment. Results are saved into the path of the
         file that was selected to run.
@@ -71,6 +72,9 @@ class ModelicaRunner(object):
         stdout.log will store both stdout and stderr of the simulations
 
         :param file_to_run: string, name of the file (could be directory?) to simulate
+        :param run_path: string, location where the Modelica simulation where start
+        :param project_name: string, name of the project being simulated. Will be used to determine name of results
+                                     directory
         """
         if not self.docker_configured:
             raise Exception('Docker not configured on host computer, unable to run')
@@ -82,12 +86,21 @@ class ModelicaRunner(object):
             raise Exception(f'Expecting to run a file, not a folder in {file_to_run}')
 
         if not run_path:
+            # if there is no run_path, then run it in the same directory as the file being run. This works fine for
+            # simple Modelica projects but typically the run_path needs to be a few levels higher in order
+            # to include other project dependencies (e.g., multiple mo files).
             run_path = os.path.dirname(file_to_run)
 
+        if not project_name:
+            project_name = os.path.splitext(os.path.basename(file_to_run))[0]
+
+        # Copy over ipython and jmodelica needed to run the simulation
         new_jm_ipython = os.path.join(run_path, os.path.basename(self.jm_ipython_path))
         shutil.copyfile(self.jm_ipython_path, new_jm_ipython)
         os.chmod(new_jm_ipython, 0o775)
         shutil.copyfile(self.jmodelica_py_path, os.path.join(run_path, os.path.basename(self.jmodelica_py_path)))
+
+        # Set up the run content
         curdir = os.getcwd()
         os.chdir(run_path)
         stdout_log = open('stdout.log', 'w')
@@ -95,9 +108,11 @@ class ModelicaRunner(object):
             # get the relative difference between the file to run and the path which everything is running in.
             # make sure to simulate at a directory above the project directory!
 
-            # Use slashes for now, but can make these periods `.replace(os.sep, '.')` but must strip off
-            # the .mo extension on the model to run
+            # Use slashes for the location of the model to run. We can make these periods `.replace(os.sep, '.')`
+            # but must strip off the .mo extension on the model to run
             run_model = os.path.relpath(file_to_run, run_path)
+            print(f"Running Modelica file {run_model} in {run_path}")
+
             # TODO: Create a logger to show more information such as the actual run command being executed.
             p = subprocess.Popen(
                 ['./jm_ipython.sh', 'jmodelica.py', run_model],
@@ -110,7 +125,31 @@ class ModelicaRunner(object):
             os.chdir(curdir)
             stdout_log.close()
 
+        self.cleanup_path(run_path)
+
+        # get the filename
+        results_path = os.path.join(run_path, f'{project_name}_results')
+
+        self.move_result_files(run_path, results_path)
         return exitcode
+
+    def move_result_files(self, from_path, to_path):
+        """This method aggressively moves the results of the simulation. It is aggressive, because it move any
+        file in the folder `from_path`; therefore, use with caution. This will only move files.
+
+        :param from_path: string, where the files will move from
+        :param to_path: string, where the files will be saved. Will be created if does not exist.
+        :return:
+        """
+        # if there are results, they will simply be overwritten (for now).
+        if not os.path.exists(to_path):
+            os.makedirs(to_path)
+
+        # print(f"Moving simulation results from {from_path} to {to_path}")
+        for f in os.listdir(from_path):
+            to_move = os.path.join(from_path, f)
+            if os.path.isfile(to_move):
+                shutil.move(to_move, os.path.join(to_path, f))
 
     def cleanup_path(self, path):
         """
@@ -124,3 +163,12 @@ class ModelicaRunner(object):
         for f in remove_files:
             if os.path.exists(os.path.join(path, f)):
                 os.remove(os.path.join(path, f))
+
+        for g in glob.glob(os.path.join(path, 'tmp-simulation-*')):
+            # print(f"Removing tmp-simulation files {g}")
+            # This is a complete hack but the name of the other folder that gets created is the
+            # globbed directory without the tmp-simulation
+            eplus_path = os.path.join(path, os.path.basename(g).replace('tmp-simulation-', ''))
+            if os.path.exists(eplus_path):
+                shutil.rmtree(eplus_path)
+            shutil.rmtree(g)

--- a/tests/model_connectors/test_spawn.py
+++ b/tests/model_connectors/test_spawn.py
@@ -97,47 +97,48 @@ class SpawnModelConnectorSingleBuildingTest(unittest.TestCase):
         )
 
 
-class SpawnModelConnectorTwoBuildingTest(unittest.TestCase):
-    def setUp(self):
-        self.data_dir = os.path.join(os.path.dirname(__file__), 'data')
-        self.output_dir = os.path.join(os.path.dirname(__file__), 'output')
-        if not os.path.exists(self.output_dir):
-            os.makedirs(self.output_dir)
-
-        project_name = "spawn_two_building"
-        if os.path.exists(os.path.join(self.output_dir, project_name)):
-            shutil.rmtree(os.path.join(self.output_dir, project_name))
-
-        # load in the example geojson with a single offie building
-        filename = os.path.join(self.data_dir, "spawn_geojson_ex2.json")
-        self.gj = GeoJsonModelicaTranslator.from_geojson(filename)
-        # use the GeoJson translator to scaffold out the directory
-        self.gj.scaffold_directory(self.output_dir, project_name)
-
-        # load system parameter data
-        filename = os.path.join(self.data_dir, "spawn_system_params_ex2.json")
-        sys_params = SystemParameters(filename)
-
-        # now test the spawn connector (independent of the larger geojson translator
-        self.spawn = SpawnConnector(sys_params)
-
-        for b in self.gj.buildings:
-            self.spawn.add_building(b)
-
-    def test_spawn_to_modelica_and_run(self):
-        self.spawn.to_modelica(self.gj.scaffold)
-
-        # make sure the model can run using the ModelicaRunner class
-        mr = ModelicaRunner()
-        file_to_run = os.path.abspath(
-            os.path.join(self.gj.scaffold.loads_path.files_dir, 'B5a6b99ec37f4de7f94021950', 'coupling.mo')
-        )
-        run_path = Path(os.path.abspath(self.gj.scaffold.project_path)).parent
-        exitcode = mr.run_in_docker(file_to_run, run_path=run_path)
-        self.assertEqual(0, exitcode)
-
-        exitcode = mr.run_in_docker(file_to_run, run_path=run_path, project_name=self.gj.scaffold.project_name)
-        self.assertEqual(0, exitcode)
-
-        results_path = os.path.join(run_path, f"{self.gj.scaffold.project_name}_results")
-        self.assertTrue(os.path.join(results_path, 'stdout.log'))
+# Do not run this case as it takes too long on travis.
+# class SpawnModelConnectorTwoBuildingTest(unittest.TestCase):
+#     def setUp(self):
+#         self.data_dir = os.path.join(os.path.dirname(__file__), 'data')
+#         self.output_dir = os.path.join(os.path.dirname(__file__), 'output')
+#         if not os.path.exists(self.output_dir):
+#             os.makedirs(self.output_dir)
+#
+#         project_name = "spawn_two_building"
+#         if os.path.exists(os.path.join(self.output_dir, project_name)):
+#             shutil.rmtree(os.path.join(self.output_dir, project_name))
+#
+#         # load in the example geojson with a single offie building
+#         filename = os.path.join(self.data_dir, "spawn_geojson_ex2.json")
+#         self.gj = GeoJsonModelicaTranslator.from_geojson(filename)
+#         # use the GeoJson translator to scaffold out the directory
+#         self.gj.scaffold_directory(self.output_dir, project_name)
+#
+#         # load system parameter data
+#         filename = os.path.join(self.data_dir, "spawn_system_params_ex2.json")
+#         sys_params = SystemParameters(filename)
+#
+#         # now test the spawn connector (independent of the larger geojson translator
+#         self.spawn = SpawnConnector(sys_params)
+#
+#         for b in self.gj.buildings:
+#             self.spawn.add_building(b)
+#
+#     def test_spawn_to_modelica_and_run(self):
+#         self.spawn.to_modelica(self.gj.scaffold)
+#
+#         # make sure the model can run using the ModelicaRunner class
+#         mr = ModelicaRunner()
+#         file_to_run = os.path.abspath(
+#             os.path.join(self.gj.scaffold.loads_path.files_dir, 'B5a6b99ec37f4de7f94021950', 'coupling.mo')
+#         )
+#         run_path = Path(os.path.abspath(self.gj.scaffold.project_path)).parent
+#         exitcode = mr.run_in_docker(file_to_run, run_path=run_path)
+#         self.assertEqual(0, exitcode)
+#
+#         exitcode = mr.run_in_docker(file_to_run, run_path=run_path, project_name=self.gj.scaffold.project_name)
+#         self.assertEqual(0, exitcode)
+#
+#         results_path = os.path.join(run_path, f"{self.gj.scaffold.project_name}_results")
+#         self.assertTrue(os.path.join(results_path, 'stdout.log'))

--- a/tests/model_connectors/test_spawn.py
+++ b/tests/model_connectors/test_spawn.py
@@ -87,8 +87,14 @@ class SpawnModelConnectorSingleBuildingTest(unittest.TestCase):
             os.path.join(self.gj.scaffold.loads_path.files_dir, 'B5a6b99ec37f4de7f94020090', 'coupling.mo'),
         )
         run_path = Path(os.path.abspath(self.gj.scaffold.project_path)).parent
-        exitcode = mr.run_in_docker(file_to_run, run_path=run_path)
+        exitcode = mr.run_in_docker(file_to_run, run_path=run_path, project_name=self.gj.scaffold.project_name)
         self.assertEqual(0, exitcode)
+
+        results_path = os.path.join(run_path, f"{self.gj.scaffold.project_name}_results")
+        self.assertTrue(os.path.join(results_path, 'stdout.log'))
+        self.assertTrue(
+            os.path.join(results_path, 'spawn_single_Loads_B5a6b99ec37f4de7f94020090_CouplingETS_SpawnBuilding.fmu')
+        )
 
 
 class SpawnModelConnectorTwoBuildingTest(unittest.TestCase):
@@ -127,5 +133,11 @@ class SpawnModelConnectorTwoBuildingTest(unittest.TestCase):
             os.path.join(self.gj.scaffold.loads_path.files_dir, 'B5a6b99ec37f4de7f94021950', 'coupling.mo')
         )
         run_path = Path(os.path.abspath(self.gj.scaffold.project_path)).parent
-        exitcode = mr.run_in_docker(file_to_run,  run_path=run_path)
+        exitcode = mr.run_in_docker(file_to_run, run_path=run_path)
         self.assertEqual(0, exitcode)
+
+        exitcode = mr.run_in_docker(file_to_run, run_path=run_path, project_name=self.gj.scaffold.project_name)
+        self.assertEqual(0, exitcode)
+
+        results_path = os.path.join(run_path, f"{self.gj.scaffold.project_name}_results")
+        self.assertTrue(os.path.join(results_path, 'stdout.log'))

--- a/tests/model_connectors/test_spawn_ets.py
+++ b/tests/model_connectors/test_spawn_ets.py
@@ -45,7 +45,7 @@ from geojson_modelica_translator.system_parameters.system_parameters import (
 )
 
 
-class SpawnModelConnectorSingleBuildingTest(unittest.TestCase):
+class SpawnModelConnectorSingleBuildingETSTest(unittest.TestCase):
     def setUp(self):
         self.data_dir = os.path.join(os.path.dirname(__file__), 'data')
         self.output_dir = os.path.join(os.path.dirname(__file__), 'output')
@@ -92,44 +92,45 @@ class SpawnModelConnectorSingleBuildingTest(unittest.TestCase):
         self.assertTrue(os.path.join(results_path, 'stdout.log'))
 
 
-class SpawnModelConnectorTwoBuildingTest(unittest.TestCase):
-    def setUp(self):
-        self.data_dir = os.path.join(os.path.dirname(__file__), 'data')
-        self.output_dir = os.path.join(os.path.dirname(__file__), 'output')
-
-        project_name = "spawn_two_building"
-
-        if os.path.exists(os.path.join(self.output_dir, project_name)):
-            shutil.rmtree(os.path.join(self.output_dir, project_name))
-
-        # load in the example geojson with a single offie building
-        filename = os.path.join(self.data_dir, "spawn_geojson_ex2.json")
-        self.gj = GeoJsonModelicaTranslator.from_geojson(filename)
-        # use the GeoJson translator to scaffold out the directory
-        self.gj.scaffold_directory(self.output_dir, project_name)
-
-        # load system parameter data
-        filename = os.path.join(self.data_dir, "spawn_system_params_ex2.json")
-        sys_params = SystemParameters(filename)
-
-        # now test the spawn connector (independent of the larger geojson translator
-        self.spawn = SpawnConnectorETS(sys_params)
-        for b in self.gj.buildings:
-            self.spawn.add_building(b)
-
-    def test_spawn_to_modelica_and_run(self):
-        self.spawn.to_modelica(self.gj.scaffold)
-
-        # make sure the model can run using the ModelicaRunner class
-        mr = ModelicaRunner()
-        file_to_run = os.path.abspath(
-            os.path.join(
-                self.gj.scaffold.loads_path.files_dir, 'B5a6b99ec37f4de7f94021950', 'CouplingETS_SpawnBuilding.mo'
-            )
-        )
-        run_path = Path(os.path.abspath(self.gj.scaffold.project_path)).parent
-        exitcode = mr.run_in_docker(file_to_run, run_path=run_path, project_name=self.gj.scaffold.project_name)
-        self.assertEqual(0, exitcode)
-
-        results_path = os.path.join(run_path, f"{self.gj.scaffold.project_name}_results")
-        self.assertTrue(os.path.join(results_path, 'stdout.log'))
+# Do not run this case as it takes too long on travis.
+# class SpawnModelConnectorTwoBuildingETSTest(unittest.TestCase):
+#     def setUp(self):
+#         self.data_dir = os.path.join(os.path.dirname(__file__), 'data')
+#         self.output_dir = os.path.join(os.path.dirname(__file__), 'output')
+#
+#         project_name = "spawn_two_building"
+#
+#         if os.path.exists(os.path.join(self.output_dir, project_name)):
+#             shutil.rmtree(os.path.join(self.output_dir, project_name))
+#
+#         # load in the example geojson with a single offie building
+#         filename = os.path.join(self.data_dir, "spawn_geojson_ex2.json")
+#         self.gj = GeoJsonModelicaTranslator.from_geojson(filename)
+#         # use the GeoJson translator to scaffold out the directory
+#         self.gj.scaffold_directory(self.output_dir, project_name)
+#
+#         # load system parameter data
+#         filename = os.path.join(self.data_dir, "spawn_system_params_ex2.json")
+#         sys_params = SystemParameters(filename)
+#
+#         # now test the spawn connector (independent of the larger geojson translator
+#         self.spawn = SpawnConnectorETS(sys_params)
+#         for b in self.gj.buildings:
+#             self.spawn.add_building(b)
+#
+#     def test_spawn_to_modelica_and_run(self):
+#         self.spawn.to_modelica(self.gj.scaffold)
+#
+#         # make sure the model can run using the ModelicaRunner class
+#         mr = ModelicaRunner()
+#         file_to_run = os.path.abspath(
+#             os.path.join(
+#                 self.gj.scaffold.loads_path.files_dir, 'B5a6b99ec37f4de7f94021950', 'CouplingETS_SpawnBuilding.mo'
+#             )
+#         )
+#         run_path = Path(os.path.abspath(self.gj.scaffold.project_path)).parent
+#         exitcode = mr.run_in_docker(file_to_run, run_path=run_path, project_name=self.gj.scaffold.project_name)
+#         self.assertEqual(0, exitcode)
+#
+#         results_path = os.path.join(run_path, f"{self.gj.scaffold.project_name}_results")
+#         self.assertTrue(os.path.join(results_path, 'stdout.log'))

--- a/tests/model_connectors/test_spawn_ets.py
+++ b/tests/model_connectors/test_spawn_ets.py
@@ -85,8 +85,11 @@ class SpawnModelConnectorSingleBuildingTest(unittest.TestCase):
             )
         )
         run_path = Path(os.path.abspath(self.gj.scaffold.project_path)).parent
-        exitcode = mr.run_in_docker(file_to_run, run_path=run_path)
+        exitcode = mr.run_in_docker(file_to_run, run_path=run_path, project_name=self.gj.scaffold.project_name)
         self.assertEqual(0, exitcode)
+
+        results_path = os.path.join(run_path, f"{self.gj.scaffold.project_name}_results")
+        self.assertTrue(os.path.join(results_path, 'stdout.log'))
 
 
 class SpawnModelConnectorTwoBuildingTest(unittest.TestCase):
@@ -125,5 +128,8 @@ class SpawnModelConnectorTwoBuildingTest(unittest.TestCase):
             )
         )
         run_path = Path(os.path.abspath(self.gj.scaffold.project_path)).parent
-        exitcode = mr.run_in_docker(file_to_run,  run_path=run_path)
+        exitcode = mr.run_in_docker(file_to_run, run_path=run_path, project_name=self.gj.scaffold.project_name)
         self.assertEqual(0, exitcode)
+
+        results_path = os.path.join(run_path, f"{self.gj.scaffold.project_name}_results")
+        self.assertTrue(os.path.join(results_path, 'stdout.log'))

--- a/tests/model_connectors/test_time_series.py
+++ b/tests/model_connectors/test_time_series.py
@@ -87,5 +87,8 @@ class SpawnModelConnectorSingleBuildingTest(unittest.TestCase):
             os.path.join(self.gj.scaffold.loads_path.files_dir, 'B5a6b99ec37f4de7f94020090', 'coupling.mo'),
         )
         run_path = Path(os.path.abspath(self.gj.scaffold.project_path)).parent
-        exitcode = mr.run_in_docker(file_to_run, run_path=run_path)
+        exitcode = mr.run_in_docker(file_to_run, run_path=run_path, project_name=self.gj.scaffold.project_name)
         self.assertEqual(0, exitcode)
+
+        results_path = os.path.join(run_path, f"{self.gj.scaffold.project_name}_results")
+        self.assertTrue(os.path.join(results_path, 'stdout.log'))

--- a/tests/model_connectors/test_time_series.py
+++ b/tests/model_connectors/test_time_series.py
@@ -45,7 +45,7 @@ from geojson_modelica_translator.system_parameters.system_parameters import (
 )
 
 
-class SpawnModelConnectorSingleBuildingTest(unittest.TestCase):
+class SpawnModelConnectorSingleBuildingTimeSeriesTest(unittest.TestCase):
     def setUp(self):
         self.data_dir = os.path.join(os.path.dirname(__file__), 'data')
         self.output_dir = os.path.join(os.path.dirname(__file__), 'output')

--- a/tests/modelica/test_modelica_runner.py
+++ b/tests/modelica/test_modelica_runner.py
@@ -82,6 +82,7 @@ class ModelicaRunnerTest(unittest.TestCase):
     def test_run_in_docker(self):
         mr = ModelicaRunner()
         mr.run_in_docker(os.path.join(self.run_path, 'BouncingBall.mo'))
-        mr.cleanup_path(self.run_path)
         self.assertTrue(os.path.exists(os.path.join(self.run_path, 'stdout.log')))
         self.assertTrue(os.path.exists(os.path.join(self.run_path, 'BouncingBall_result.mat')))
+        self.assertFalse(os.path.exists(os.path.join(self.run_path, 'jm_ipython.sh')))
+        self.assertFalse(os.path.exists(os.path.join(self.run_path, 'jmodelica.py')))

--- a/tests/modelica/test_modelica_runner.py
+++ b/tests/modelica/test_modelica_runner.py
@@ -82,7 +82,9 @@ class ModelicaRunnerTest(unittest.TestCase):
     def test_run_in_docker(self):
         mr = ModelicaRunner()
         mr.run_in_docker(os.path.join(self.run_path, 'BouncingBall.mo'))
-        self.assertTrue(os.path.exists(os.path.join(self.run_path, 'stdout.log')))
-        self.assertTrue(os.path.exists(os.path.join(self.run_path, 'BouncingBall_result.mat')))
-        self.assertFalse(os.path.exists(os.path.join(self.run_path, 'jm_ipython.sh')))
-        self.assertFalse(os.path.exists(os.path.join(self.run_path, 'jmodelica.py')))
+
+        results_path = os.path.join(self.run_path, 'BouncingBall_results')
+        self.assertTrue(os.path.exists(os.path.join(results_path, 'stdout.log')))
+        self.assertTrue(os.path.exists(os.path.join(results_path, 'BouncingBall_result.mat')))
+        self.assertFalse(os.path.exists(os.path.join(results_path, 'jm_ipython.sh')))
+        self.assertFalse(os.path.exists(os.path.join(results_path, 'jmodelica.py')))


### PR DESCRIPTION
#### Any background context you want to provide?
Running multiple simulations in the same directory causes the results to be overridden.

#### What does this PR accomplish?
* Move the results of the docker simulations into a results directory that has the project name prepended.

#### How should this be manually tested?
* Run `py.test`

#### What are the relevant tickets?
#91 

#### Screenshots (if appropriate)

