### PR TITLE
Use previous version of MBL and report logs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,24 @@ env:
     - TOX_ENV=flake8
     - TOX_ENV=docs
 before_script:
-  - git clone --single-branch --branch issue1437_district_heating_cooling https://github.com/lbl-srg/modelica-buildings.git
   # Use a specific SHA of MBL as the E+ FMU seems to be causing issues in more recent commits
-  - cd modelica-buildings && git checkout 2eb417f9ca2a9dce188988f1937bf79253daa9ff
-  - export MODELICAPATH=$(pwd)/modelica-buildings
+  - |
+    git clone --single-branch --branch issue1437_district_heating_cooling https://github.com/lbl-srg/modelica-buildings.git
+    cd modelica-buildings && git checkout 2eb417f9ca2a9dce188988f1937bf79253daa9ff && cd ..
+    export MODELICAPATH=$(pwd)/modelica-buildings
+    cd $MODELICAPATH
+    echo $(git branch)
 script:
   - tox -e $TOX_ENV
 after_success:
   - coveralls
+after_failure:
+  - echo "Job Failed... Maybe these logs will help?"
+  - free -tm
+  - ls -alt /home/travis/build/urbanopt/geojson-modelica-translator
+  - echo "============================================ stdout.log ========================================="
+  - |
+    find /home/travis/build/urbanopt/geojson-modelica-translator -type f -name 'stdout.log' -print | while read filename; do
+      echo "$filename"
+      cat "$filename"
+    done

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,9 @@ if os.path.exists(save_path):
     shutil.rmtree(save_path)
 if os.path.exists(tmp_save_path):
     shutil.rmtree(tmp_save_path)
-mbl_archive_name = "issue1437_district_heating_cooling"
+# mbl_archive_name = "issue1437_district_heating_cooling"
+# Do not use the head of the issue1437 branch as Spawn E+ version doesn't work.
+mbl_archive_name = "2eb417f9ca2a9dce188988f1937bf79253daa9ff"
 r = get(f"https://github.com/lbl-srg/{repo_name}/archive/{mbl_archive_name}.zip")
 with ZipFile(BytesIO(r.content)) as zip:
     files = zip.namelist()


### PR DESCRIPTION
#### Any background context you want to provide?

Somewhere along the way, the version of MBL is breaking the GMT. New ticket is here (#105).

#### What does this PR accomplish?
* Lock MBL to version 2eb417f9ca2a9dce188988f1937bf79253daa9ff
* if the simulations fail, then print out the `stdout.log` to the screen

#### How should this be manually tested?
* Travis tests

#### What are the relevant tickets?
#104 

#### Screenshots (if appropriate)
