### PR TITLE
Replace dot delimited strings with JsonPath

### DIFF
--- a/tests/system_parameters/test_system_parameters.py
+++ b/tests/system_parameters/test_system_parameters.py
@@ -105,7 +105,8 @@ class SystemParametersTest(unittest.TestCase):
             }
         }
         sp = SystemParameters.loadd(data)
-        value = sp.get_param("buildings.default.load_model_parameters.rc.order")
+        # $.buildings.*[?load_model=Spawn].load_model_parameters.spawn.idf_filename
+        value = sp.get_param("$.buildings.default.load_model_parameters.rc.order")
         self.assertEqual(value, 4)
 
         value = sp.get_param("buildings.default.load_model")
@@ -126,16 +127,18 @@ class SystemParametersTest(unittest.TestCase):
     def test_get_param_with_default(self):
         data = {"buildings": {"default": {"load_model": "Spawn"}}}
         sp = SystemParameters.loadd(data)
+        # this path doesn't exist, but there is a default
         value = sp.get_param(
             "buildings.default.load_model_parameters.rc.order", default=2
         )
-        self.assertEqual(value, 2)
+        self.assertEqual(2, value)
 
         value = sp.get_param("not.a.real.path", default=2)
-        self.assertEqual(value, 2)
+        self.assertEqual(2, value)
 
     def test_get_param_with_building_id_defaults(self):
         filename = os.path.join(self.data_dir, 'system_params_1.json')
+        print(filename)
         sdp = SystemParameters(filename)
 
         # ensure the defaults are respected. abcd1234 has NO metamodel defined
@@ -169,15 +172,15 @@ class SystemParametersTest(unittest.TestCase):
         self.assertEqual("Indirect Cooling", value)
         value = sdp.get_param_by_building_id(None, "ets_model_parameters", "Not None")
         self.assertEqual({'indirect_cooling':
-                         {"q_flow_nominal": 8000,
-                          "eta_efficiency": 0.666,
-                          "nominal_flow_district": 0.666,
-                          "nominal_flow_building": 0.666,
-                          "pressure_drop_valve": 888,
-                          "pressure_drop_hx_secondary": 999,
-                          "pressure_drop_hx_primary": 999,
-                          "supply_water_temperature_district": 5,
-                          "supply_water_temperature_building": 7}
+                          {"q_flow_nominal": 8000,
+                           "eta_efficiency": 0.666,
+                           "nominal_flow_district": 0.666,
+                           "nominal_flow_building": 0.666,
+                           "pressure_drop_valve": 888,
+                           "pressure_drop_hx_secondary": 999,
+                           "pressure_drop_hx_primary": 999,
+                           "supply_water_temperature_district": 5,
+                           "supply_water_temperature_building": 7}
                           }, value)
 
     # def test_get_param_with_building_id_merge_defaults(self):


### PR DESCRIPTION
#### Any background context you want to provide?

The original `get_param` method was a custom method to navigate a dictionary by delimiting on periods in a string.

#### What does this PR accomplish?
* Use JsonPath as the mechanism to navigate a python dictionary (loaded from a JSON file)

#### How should this be manually tested?
* `py.test` should cover all the cases.

#### What are the relevant tickets?
#63 

#### Screenshots (if appropriate)
