### PR TITLE
TEASER Parameter Names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ src/teaser
 src/modelica-builder
 sdist/
 var/
+src/teaser
 *.egg-info/
 .installed.cfg
 *.egg

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ lib/
 !geojson_modelica_translator/modelica/lib
 lib64/
 parts/
+src/teaser
+src/modelica-builder
 sdist/
 var/
 *.egg-info/

--- a/geojson_modelica_translator/geojson_modelica_translator.py
+++ b/geojson_modelica_translator/geojson_modelica_translator.py
@@ -34,7 +34,6 @@ import os
 from geojson_modelica_translator.geojson.urbanopt_geojson import (
     UrbanOptGeoJson
 )
-from geojson_modelica_translator.modelica.input_parser import PackageParser
 from geojson_modelica_translator.scaffold import Scaffold
 
 _log = logging.getLogger(__name__)
@@ -133,8 +132,9 @@ class GeoJsonModelicaTranslator(object):
         # add in Plants
 
         # now add in the top level package.
-        pp = PackageParser.new_from_template(self.scaffold.project_path, project_name, ["Loads"])
-        pp.save()
+        # Need to decide how to create the top level packages when running this as part of the model_connectors.
+        # pp = PackageParser.new_from_template(self.scaffold.project_path, project_name, ["Loads"])
+        # pp.save()
 
         # TODO: BuildingModelClass
         # TODO: mapper class

--- a/geojson_modelica_translator/model_connectors/spawn.py
+++ b/geojson_modelica_translator/model_connectors/spawn.py
@@ -167,12 +167,12 @@ class SpawnConnector(model_connector_base):
                     f"Missing MOS weather file for Spawn: {template_data['mos_weather']['mos_weather_filename']}")
 
             self.run_template(
-                    spawn_building_template,
-                    os.path.join(b_modelica_path.files_dir, "building.mo"),
-                    project_name=scaffold.project_name,
-                    model_name=f"B{building['building_id']}",
-                    data=template_data
-                )
+                spawn_building_template,
+                os.path.join(b_modelica_path.files_dir, "building.mo"),
+                project_name=scaffold.project_name,
+                model_name=f"B{building['building_id']}",
+                data=template_data
+            )
 
             full_model_name = os.path.join(
                 scaffold.project_name,
@@ -185,12 +185,12 @@ class SpawnConnector(model_connector_base):
                 f.write(file_data)
 
             self.run_template(
-                    spawn_coupling_template,
-                    os.path.join(b_modelica_path.files_dir, "coupling.mo"),
-                    project_name=scaffold.project_name,
-                    model_name=f"B{building['building_id']}",
-                    data=template_data
-                )
+                spawn_coupling_template,
+                os.path.join(b_modelica_path.files_dir, "coupling.mo"),
+                project_name=scaffold.project_name,
+                model_name=f"B{building['building_id']}",
+                data=template_data
+            )
 
         # run post process to create the remaining project files for this building
         self.post_process(scaffold, building_names)

--- a/geojson_modelica_translator/model_connectors/teaser.py
+++ b/geojson_modelica_translator/model_connectors/teaser.py
@@ -201,7 +201,7 @@ class TeaserConnector(model_connector_base):
                 string_replace_list.append(
                     (
                         f"Project/B{b}/B{b}_Models/{os.path.basename(f)}",
-                        f"Loads/{b_modelica_path.resources_relative_dir}/{new_file_name}",
+                        f"{scaffold.project_name}/Loads/{b_modelica_path.resources_relative_dir}/{new_file_name}",
                     )
                 )
 

--- a/geojson_modelica_translator/model_connectors/teaser.py
+++ b/geojson_modelica_translator/model_connectors/teaser.py
@@ -362,15 +362,15 @@ class TeaserConnector(model_connector_base):
                     mofile.update_component_argument(
                         f"Buildings.ThermalZones.ReducedOrder.RC.{thermal_zone_type}",
                         thermal_zone_name,
-                        "use_moisture_balance=0",
-                        "use_moisture_balance=use_moisture_balance"
+                        "use_moisture_balance",
+                        "use_moisture_balance"
                     )
 
                     mofile.update_component_argument(
                         f"Buildings.ThermalZones.ReducedOrder.RC.{thermal_zone_type}",
                         thermal_zone_name,
-                        "nPorts=0",
-                        "nPorts=nPorts"
+                        "nPorts",
+                        "nPorts"
                     )
 
                     mofile.add_connect(

--- a/geojson_modelica_translator/model_connectors/teaser.py
+++ b/geojson_modelica_translator/model_connectors/teaser.py
@@ -370,7 +370,7 @@ class TeaserConnector(model_connector_base):
                         f"Buildings.ThermalZones.ReducedOrder.RC.{thermal_zone_type}",
                         thermal_zone_name,
                         "nPorts",
-                        "nPorts"
+                        "nPorts=nPorts"
                     )
 
                     mofile.add_connect(

--- a/geojson_modelica_translator/model_connectors/teaser.py
+++ b/geojson_modelica_translator/model_connectors/teaser.py
@@ -370,7 +370,7 @@ class TeaserConnector(model_connector_base):
                         f"Buildings.ThermalZones.ReducedOrder.RC.{thermal_zone_type}",
                         thermal_zone_name,
                         "nPorts",
-                        "nPorts=nPorts"
+                        "nPorts",
                     )
 
                     mofile.add_connect(

--- a/geojson_modelica_translator/model_connectors/templates/CouplingETS_TimeSeriesBuilding.mot
+++ b/geojson_modelica_translator/model_connectors/templates/CouplingETS_TimeSeriesBuilding.mot
@@ -133,12 +133,12 @@ connect(coo.TSet, TChiWatSet.y) annotation (Line(points={{-2,-50},{-48,-50},{-48
  connect(pumBui.port_b, bui.secCooSup[1]) annotation (Line(points={{-60,-72},{-88,
          -72},{-88,67.0667},{0,67.0667}}, color={0,127,255}));
  connect(coo.port_a2, bui.secCooRet[1]) annotation (Line(points={{20,-56},{92,-56},{92,67},{20,67}}, color={0,127,255}));
-{% endraw %}
-{% raw %}
+
 annotation (Icon(coordinateSystem(preserveAspectRatio=false),
                            extent={{-100,-100},{100,100}}),
             Diagram(coordinateSystem(preserveAspectRatio=false),
                            extent={{-100,-100},{100,100}}),
+{% endraw %}
  __Dymola_Commands(file="modelica://{{project_name}}/Loads/Resources/Scripts/{{model_name}}/Dymola/RunCouplingETS_TimeSeriesBuilding.mos"
         "Simulate and plot"),
         experiment(StopTime=31532400,
@@ -158,5 +158,4 @@ First implementation.
 </li>
 </ul>
 </html>"));
-{% endraw %}
 end CouplingETS_TimeSeriesBuilding;

--- a/geojson_modelica_translator/model_connectors/templates/RunCouplingETS_TEASERBuilding.most
+++ b/geojson_modelica_translator/model_connectors/templates/RunCouplingETS_TEASERBuilding.most
@@ -1,0 +1,52 @@
+simulateModel("{{full_model_name}}",
+    method="cvode",
+    tolerance=1e-6,
+    numberOfIntervals=500,
+    stopTime=604800.0,
+    resultFile="{{model_name}}");
+
+    createPlot(
+        id=1,
+        position={10, 20, 670, 900},
+        y={"bui.maxTSet[1].y", "bui.minTSet[1].y", "bui.office.TAir", "bui.floor.TAir", "bui.storage.TAir", "bui.meeting.TAir", "bui.restroom.TAir", "bui.iCT.TAir"},
+        autoscale=true,
+        grid=true
+    );
+    createPlot(
+        id=1,
+        y={"bui.terUni[1].QActHea_flow", "bui.terUni[2].QActHea_flow", "bui.terUni[3].QActHea_flow", "bui.terUni[4].QActHea_flow", "bui.terUni[5].QActHea_flow", "bui.terUni[6].QActHea_flow"},
+        grid=true,
+        subPlot=2
+    );
+    createPlot(
+        id=1,
+        y={"bui.terUni[1].QActCoo_flow", "bui.terUni[2].QActCoo_flow", "bui.terUni[3].QActCoo_flow", "bui.terUni[4].QActCoo_flow", "bui.terUni[5].QActCoo_flow", "bui.terUni[6].QActCoo_flow"},
+        grid=true,
+        subPlot=3
+    );
+    createPlot(
+        id=2,
+        position={700, 20, 670, 900},
+        y={"supHeaWat.T_in", "bui.terUni[1].T_aHeaWat_nominal", "bui.terUni[2].T_aHeaWat_nominal", "bui.terUni[3].T_aHeaWat_nominal", "bui.terUni[4].T_aHeaWat_nominal", "bui.terUni[5].T_aHeaWat_nominal","bui.terUni[6].T_aHeaWat_nominal"},
+        autoscale=true,
+        grid=true
+    );
+    createPlot(
+        id=2,
+        y={"bui.disFloHea.mAct_flow[1].y", "bui.disFloHea.mAct_flow[2].y", "bui.disFloHea.mAct_flow[3].y", "bui.disFloHea.mAct_flow[4].y", "bui.disFloHea.mAct_flow[5].y", "bui.disFloHea.mAct_flow[6].y"},
+        grid=true,
+        subPlot=2
+    );
+    createPlot(
+        id=3,
+        position={1400, 20, 670, 900},
+        y={"supChiWat.T_in", "bui.terUni[1].T_aChiWat_nominal", "bui.terUni[2].T_aChiWat_nominal", "bui.terUni[3].T_aChiWat_nominal", "bui.terUni[4].T_aChiWat_nominal", "bui.terUni[5].T_aChiWat_nominal","bui.terUni[6].T_aChiWat_nominal"},
+        autoscale=true,
+        grid=true
+    );
+    createPlot(
+        id=3,
+        y={"bui.disFloCoo.mAct_flow[1].y", "bui.disFloCoo.mAct_flow[2].y", "bui.disFloCoo.mAct_flow[3].y", "bui.disFloCoo.mAct_flow[4].y", "bui.disFloCoo.mAct_flow[5].y", "bui.disFloCoo.mAct_flow[6].y"},
+        grid=true,
+        subPlot=2
+    );

--- a/geojson_modelica_translator/model_connectors/templates/RunTeaserBuilding.most
+++ b/geojson_modelica_translator/model_connectors/templates/RunTeaserBuilding.most
@@ -1,0 +1,40 @@
+simulateModel("{{full_model_name}}",
+    method="cvode",
+    tolerance=1e-6,
+    numberOfIntervals=500,
+    stopTime=604800.0,
+    resultFile="{{model_name}}");
+
+createPlot(
+        id=1,
+        position={10, 20, 670, 900},
+        y={"bui.maxTSet[1].y", "bui.minTSet[1].y", "bui.office.TAir", "bui.floor.TAir", "bui.storage.TAir", "bui.meeting.TAir", "bui.restroom.TAir", "bui.iCT.TAir"},
+        autoscale=true,
+        grid=true
+    );
+    createPlot(
+        id=1,
+        y={"bui.terUni[1].QActHea_flow", "bui.terUni[2].QActHea_flow", "bui.terUni[3].QActHea_flow", "bui.terUni[4].QActHea_flow", "bui.terUni[5].QActHea_flow", "bui.terUni[6].QActHea_flow"},
+        grid=true,
+        subPlot=2
+    );
+    createPlot(
+        id=1,
+        y={"bui.terUni[1].QActCoo_flow", "bui.terUni[2].QActCoo_flow", "bui.terUni[3].QActCoo_flow", "bui.terUni[4].QActCoo_flow", "bui.terUni[5].QActCoo_flow", "bui.terUni[6].QActCoo_flow"},
+        grid=true,
+        subPlot=3
+    );
+    createPlot(
+        id=2,
+        position={700, 20, 670, 900},
+        y={"supHeaWat.T_in", "bui.terUni[1].T_aHeaWat_nominal", "bui.terUni[2].T_aHeaWat_nominal", "bui.terUni[3].T_aHeaWat_nominal", "bui.terUni[4].T_aHeaWat_nominal", "bui.terUni[5].T_aHeaWat_nominal","bui.terUni[6].T_aHeaWat_nominal"},
+        autoscale=true,
+        grid=true
+    );
+    createPlot(
+        id=2,
+        y={"bui.disFloHea.mAct_flow[1].y", "bui.disFloHea.mAct_flow[2].y", "bui.disFloHea.mAct_flow[3].y", "bui.disFloHea.mAct_flow[4].y", "bui.disFloHea.mAct_flow[5].y", "bui.disFloHea.mAct_flow[6].y"},
+        grid=true,
+        subPlot=2
+    );
+  

--- a/geojson_modelica_translator/model_connectors/templates/RuntimeSeriesBuilding.most
+++ b/geojson_modelica_translator/model_connectors/templates/RuntimeSeriesBuilding.most
@@ -1,3 +1,5 @@
+old_hidden_avoid_double_computation=Hidden.AvoidDoubleComputation;
+Hidden.AvoidDoubleComputation=true;
 simulateModel("{{full_model_name}}",
 method="cvode",
     tolerance=1e-6,

--- a/geojson_modelica_translator/model_connectors/templates/teaser_building.mot
+++ b/geojson_modelica_translator/model_connectors/templates/teaser_building.mot
@@ -1,0 +1,164 @@
+within {{project_name}}.Loads.{{model_name}};
+model building
+  "n-zone RC building model based on URBANopt's use of TEASER export, with distribution pumps"
+  extends PartialBuilding(
+        redeclare package Medium = MediumW,
+        have_fan=false,
+        have_eleHea=false,
+        have_eleCoo=false);
+
+  package MediumW = Buildings.Media.Water
+       "Source side medium";
+  package MediumA = Buildings.Media.Air
+       "Load side medium";
+  parameter Integer nZon = {{data['thermal_zones'] | count}}
+    "Number of thermal zones";
+  parameter Integer facSca = 3
+    "Scaling factor to be applied to on each extensive quantity";
+  parameter Modelica.SIunits.TemperatureDifference delTBuiCoo=5
+     "Nominal building supply and return chilled water temperature difference";
+
+  Buildings.Controls.OBC.CDL.Continuous.Sources.Constant minTSet[nZon](
+    k=fill(293.15, nZon),
+    y(each final unit="K", each displayUnit="degC"))
+    "Minimum temperature set point"
+    {% raw %}
+    annotation (Placement(transformation(extent={{-290,230},{-270,250}})));
+    {% endraw %}
+  Buildings.Controls.OBC.CDL.Continuous.Sources.Constant maxTSet[nZon](
+    k=fill(297.15, nZon),
+    y(each final unit="K",each displayUnit="degC"))
+    "Maximum temperature set point"
+    {% raw %}
+    annotation (Placement(transformation(extent={{-290,190},{-270,210}})));
+    {% endraw %}
+  {% for zone in data['thermal_zones'] %}
+  {{zone['model_name']}} {{zone['instance_name']}}
+    annotation (Placement(transformation(extent={{zone['placement']}})));
+  {% endfor %}
+  Buildings.Controls.OBC.CDL.Continuous.MultiSum mulSum(nin=2) if have_pum
+    {% raw %}
+    annotation (Placement(transformation(extent={{260,70},{280,90}})));
+    {% endraw %}
+  Buildings.Applications.DHC.Loads.Examples.BaseClasses.FanCoil4PipeHeatPorts
+    terUni[nZon](
+    redeclare each package Medium1 = MediumW,
+    redeclare each package Medium2 = MediumA,
+    each facSca=facSca,
+    QHea_flow_nominal={10000,10000,10000,10000,10000,10000},
+    QCoo_flow_nominal={-10000,-10000,-10000,-10000,-10000,-50000},
+    each T_aLoaHea_nominal=293.15,
+    each T_aLoaCoo_nominal=297.15,
+    each T_bHeaWat_nominal=35 + 273.15,
+    each T_bChiWat_nominal=12 + 273.15,
+    each T_aHeaWat_nominal=40 + 273.15,
+    each T_aChiWat_nominal=7 + 273.15,
+    each mLoaHea_flow_nominal=5,
+    each mLoaCoo_flow_nominal=5) "Terminal unit"
+    {% raw %}
+    annotation (Placement(transformation(extent={{-200,-60},{-180,-40}})));
+    {% endraw %}
+  Buildings.Applications.DHC.Loads.BaseClasses.FlowDistribution disFloHea(
+    redeclare package Medium = MediumW,
+    m_flow_nominal=sum(terUni.mHeaWat_flow_nominal .* terUni.facSca),
+    dp_nominal(displayUnit="Pa")=100000,
+    have_pum=have_pum, 
+    nPorts_a1=nZon,
+    nPorts_b1=nZon)
+    "Heating water distribution system"
+    {% raw %}
+    annotation (Placement(transformation(extent={{-140, -100},{-120,-80}})));
+    {% endraw %}
+  Buildings.Applications.DHC.Loads.BaseClasses.FlowDistribution disFloCoo(
+    redeclare package Medium = MediumW,
+    m_flow_nominal=sum(terUni.mChiWat_flow_nominal .* terUni.facSca),
+    typDis=Buildings.Applications.DHC.Loads.Types.DistributionType.ChilledWater,
+    dp_nominal(displayUnit="Pa")=100000,
+    have_pum=have_pum,
+    nPorts_a1=nZon,
+    nPorts_b1=nZon)
+    "Chilled water distribution system"
+    {% raw %}
+    annotation (Placement(transformation(extent={{-140, -160},{-120,-140}})));
+    {% endraw %}
+equation
+  {% raw %}
+  connect(disFloHea.port_b, secHeaRet[1])
+      annotation (Line(points={{140,-70},{240,-70},{240,32},{300,32}}, color={0,127,255}));
+  connect(disFloHea.port_a, secHeaSup[1])
+      annotation (Line(points={{120,-70},{-242,-70},{-242,32},{-300,32}}, color={0,127,255}));
+  connect(disFloCoo.port_b, secCooRet[1])
+      annotation (Line(points={{140,-110},{252,-110},{252,-30},{300,-30}}, color={0,127,255}));
+  connect(disFloCoo.port_a, secCooSup[1])
+      annotation (Line(points={{120,-110},{-280,-110},{-280,-30},{-300,-30}}, color={0,127,255}));
+  connect(disFloHea.ports_a1, terUni.port_bHeaWat) annotation (Line(points={{-120,
+          -80.6667},{-104,-80.6667},{-104,-58.3333},{-180,-58.3333}},
+          color={0,127,255}));
+  connect(disFloHea.ports_b1, terUni.port_aHeaWat) annotation (Line(points={{-140,
+          -80.6667},{-216,-80.6667},{-216,-58.3333},{-200,-58.3333}},
+         color={0,127,255}));
+  connect(disFloCoo.ports_a1, terUni.port_bChiWat) annotation (Line(points={{-120,
+          -144},{-94,-144},{-94,-56},{-180,-56},{-180,-56.6667}}, color={0,127,255}));
+  connect(disFloCoo.ports_b1, terUni.port_aChiWat) annotation (Line(points={{-140,
+          -144},{-226,-144},{-226,-56.6667},{-200,-56.6667}},
+          color={0,127,255}));
+  {% endraw %}
+
+  {% for zone in data['thermal_zones'] %}
+  connect(weaBus, {{zone['instance_name']}}.weaBus)
+      annotation (
+        {% raw %}Line(points={{1,300},{0,300},{0,20},{-66,20},{-66,-10.2},{-96,-10.2}}, color={255,204,51},thickness=0.5),
+        Text(string="%first",index=-1,extent={{6,3},{6,3}},horizontalAlignment=TextAlignment.Left));{% endraw %}
+   connect(terUni[{{zone['index']}}+1].heaPorCon, {{zone['instance_name']}}.port_a)
+    {% raw %}annotation (Line(points={{-193.333,-50},{-192,-50},{-192,0},{-90,0}}, color={191,0,0}));{% endraw %}
+   connect(terUni[{{zone['index']}}+1].heaPorRad, {{zone['instance_name']}}.port_a)
+      {% raw %}annotation (Line(points={{-186.667,-50},{-90,-50},{-90,0}}, color={191,0,0}));{% endraw %}
+  {% endfor %}
+  {% raw %}
+
+  connect(terUni.mReqHeaWat_flow, disFloHea.mReq_flow)
+    annotation (Line(points={{-179.167,-53.3333},{-179.167,-54},{-170,-54},{-170,-94},{-141,-94}}, color={0,0,127}));
+  connect(terUni.mReqChiWat_flow, disFloCoo.mReq_flow)
+    annotation (Line(points={{-179.167,-55},{-179.167,-56},{-172,-56},{-172,-154},{-141,-154}}, color={0,0,127}));
+  connect(mulSum.y, PPum)
+    annotation (Line(points={{282,80},{320,80}}, color={0,0,127}));
+  connect(disFloHea.PPum, mulSum.u[1])
+    annotation (Line(points={{-119,-98},{240,-98},{240,81},{258,81}}, color={0,0,127}));
+  connect(disFloCoo.PPum, mulSum.u[2])
+    annotation (Line(points={{-119,-158},{240,-158},{240,79},{258,79}}, color={0,0,127}));
+  connect(disFloHea.QActTot_flow, QHea_flow)
+    annotation (Line(points={{-119,-96},{223.5,-96},{223.5,280},{320,280}}, color={0,0,127}));
+  connect(disFloCoo.QActTot_flow, QCoo_flow)
+    annotation (Line(points={{-119,-156},{230,-156},{230,240},{320,240}}, color={0,0,127}));
+  connect(maxTSet.y, terUni.TSetCoo)
+    annotation (Line(points={{-268,200},{-240,200},{-240,-46.6667},{-200.833,-46.6667}}, color={0,0,127}));
+  connect(minTSet.y, terUni.TSetHea)
+    annotation (Line(points={{-268,240},{-220,240},{-220,-45},{-200.833,-45}}, color={0,0,127}));
+  {% endraw %}
+  annotation (
+  Documentation(info="
+<html>
+<p>
+Building wrapper for running n-zone thermal zone models generated by TEASER.
+
+The heating and cooling loads are computed with a four-pipe
+fan coil unit model derived from
+<a href=\"modelica://Buildings.Applications.DHC.Loads.BaseClasses.PartialTerminalUnit\">
+Buildings.Applications.DHC.Loads.BaseClasses.PartialTerminalUnit</a>
+and connected to the room model by means of heat ports.
+</p>
+</html>",
+revisions=
+"<html>
+<ul>
+<li>
+May 29, 2020, by Nicholas Long:<br/>
+Template model for use in GeoJSON to Modelica Translator.
+</li>
+<li>
+February 21, 2020, by Antoine Gautier:<br/>
+First implementation.
+</li>
+</ul>
+</html>"));
+end building;

--- a/geojson_modelica_translator/model_connectors/templates/teaser_coupling.mot
+++ b/geojson_modelica_translator/model_connectors/templates/teaser_coupling.mot
@@ -1,0 +1,135 @@
+within {{project_name}}.Loads.{{model_name}};
+model coupling
+"Example illustrating the coupling of a teaser building loads to heating and chilled water loops"
+extends Modelica.Icons.Example;
+package MediumW = Buildings.Media.Water
+  "Source side medium";
+
+ building bui(
+{% raw %}
+   nPorts_bCoo=1,
+   nPorts_bHea=1,
+   nPorts_aHea=1,
+   nPorts_aCoo=1)
+   "Building with thermal loads as TEASER zones"
+   annotation (Placement(transformation(extent={{20,40},{40,60}})));
+ Buildings.Fluid.Sources.Boundary_pT sinHeaWat(
+   redeclare package Medium = MediumW,
+   p=300000,
+   nPorts=1)
+   "Sink for heating water"
+   annotation (Placement(transformation(
+       extent={{10,-10},{-10,10}},
+       rotation=0,
+       origin={130,80})));
+ Buildings.Fluid.Sources.Boundary_pT sinChiWat(
+   redeclare package Medium = MediumW,
+   p=300000,
+   nPorts=1)
+   "Sink for chilled water"
+   annotation (Placement(transformation(
+       extent={{10,-10},{-10,10}},
+       rotation=0,
+       origin={130,20})));
+ Modelica.Blocks.Sources.RealExpression THeaWatSup(
+   y=max(bui.terUni.T_aHeaWat_nominal))
+   "Heating water supply temperature"
+   annotation (Placement(transformation(extent={{-120,70},{-100,90}})));
+ Modelica.Blocks.Sources.RealExpression TChiWatSup(
+   y=max(bui.terUni.T_aChiWat_nominal))
+   "Chilled water supply temperature"
+   annotation (Placement(transformation(extent={{-120,10},{-100,30}})));
+ Buildings.Fluid.Sources.Boundary_pT supHeaWat(
+   redeclare package Medium = MediumW,
+   use_T_in=true,
+   nPorts=1) "Heating water supply"
+   annotation (Placement(transformation(
+       extent={{-10,-10},{10,10}},
+       rotation=0,
+       origin={-50,80})));
+ Buildings.Fluid.Sources.Boundary_pT supChiWat(
+   redeclare package Medium = MediumW,
+   use_T_in=true,
+   nPorts=1) "Chilled water supply"
+   annotation (Placement(transformation(
+       extent={{-10,-10},{10,10}},
+       rotation=0,
+       origin={-50,20})));
+ Buildings.BoundaryConditions.WeatherData.ReaderTMY3 weaDat(
+  calTSky=Buildings.BoundaryConditions.Types.SkyTemperatureCalculation.HorizontalRadiation,
+  pAtm(displayUnit="Pa") = 101339,
+  filNam=ModelicaServices.ExternalReferences.loadResource("modelica://Buildings/Resources/weatherdata/USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.mos"),
+  computeWetBulbTemperature=true)
+  "Weather data reader"
+  annotation (Placement(transformation(extent={{10,-10},{-10,10}},
+      rotation=90,
+      origin={56,96})));
+{% endraw %}
+equation
+  {% raw %}
+  connect(supHeaWat.T_in,THeaWatSup. y) annotation (Line(points={{-62,84},{-80,84},
+           {-80,80},{-99,80}},color={0,0,127}));
+  connect(TChiWatSup.y,supChiWat. T_in) annotation (Line(points={{-99,20},{-80,20},
+           {-80,24},{-62,24}},     color={0,0,127}));
+  connect(sinChiWat.ports[1], bui.secCooRet[1]) annotation (Line(points={{120,20},
+           {80,20},{80,47},{40,47}}, color={0,127,255}));
+  connect(sinHeaWat.ports[1], bui.secHeaRet[1]) annotation (Line(points={{120,80},
+           {80,80},{80,44},{40,44}}, color={0,127,255}));
+  connect(supHeaWat.ports[1], bui.secHeaSup[1]) annotation (Line(points={{-40,80},
+           {-10,80},{-10,44},{20,44}}, color={0,127,255}));
+  connect(bui.secCooSup[1], supChiWat.ports[1]) annotation (Line(points={{20,47.0667},
+           {-10,47.0667},{-10,20},{-40,20}}, color={0,127,255}));
+  connect(weaDat.weaBus, bui.weaBus) annotation (Line(
+                   points={{56,86},{36,86},{36,55.1333},{38.0333,55.1333}},
+                   color={255,204,51}));
+{% endraw %}
+
+  // TODO: determine how to handle the "lines"
+{% raw %}
+annotation (Diagram(
+      coordinateSystem(preserveAspectRatio=false,
+                       extent={{-140,-40},{160,140}})),
+{% endraw %}
+        __Dymola_Commands(file="modelica://{{project_name}}/Loads/Resources/Scripts/{{model_name}}/Dymola/RunTeaserBuilding.mos"
+{% raw %}
+         "Simulate and plot"),
+        experiment(
+            StopTime=604800,
+            Tolerance=1e-06),
+Documentation(info=
+"<html>
+<p>
+This example illustrates the use of
+<a href=\"modelica://Buildings.Applications.DHC.Loads.BaseClasses.PartialBuilding\">
+Buildings.Applications.DHC.Loads.BaseClasses.PartialBuilding</a>,
+<a href=\"modelica://Buildings.Applications.DHC.Loads.BaseClasses.PartialTerminalUnit\">
+Buildings.Applications.DHC.Loads.BaseClasses.PartialTerminalUnit</a>
+and
+<a href=\"modelica://Buildings.Applications.DHC.Loads.BaseClasses.FlowDistribution\">
+Buildings.Applications.DHC.Loads.BaseClasses.FlowDistribution</a>
+in a configuration with:
+</p>
+<ul>
+<li>
+building thermal loads integrating teaser zones.
+</li>
+<li>
+secondary pumps.
+</li>
+</ul>
+</html>",
+revisions=
+"<html>
+<ul>
+<li>
+April 8, 2020, by Nicholas Long:<br/>
+GeoJson-Modelica translator template first implementation.
+</li>
+<li>
+February 21, 2020, by Antoine Gautier:<br/>
+Model first implementation.
+</li>
+</ul>
+</html>"));
+{% endraw %}
+end coupling;

--- a/geojson_modelica_translator/model_connectors/templates/teaser_coupling_ets.mot
+++ b/geojson_modelica_translator/model_connectors/templates/teaser_coupling_ets.mot
@@ -1,0 +1,199 @@
+within {{project_name}}.Loads.{{model_name}};
+model teaser_coupling_ets
+    "TEASER building connected to indirect cooling ETS"
+  extends Modelica.Icons.Example;
+  package MediumW = Buildings.Media.Water
+    "Source side medium";
+  package MediumA = Buildings.Media.Air
+    "Load side medium";
+{% raw %}
+  parameter Modelica.SIunits.MassFlowRate m1_flow_nominal=
+   (bui.disFloCoo.m_flow_nominal.*(bui.delTBuiCoo/delTDisCoo))
+    "Nominal mass flow rate of primary (district) district cooling side";
+  parameter Modelica.SIunits.MassFlowRate m2_flow_nominal= bui.disFloCoo.m_flow_nominal
+    "Nominal mass flow rate of secondary (building) district cooling side";
+  parameter Modelica.SIunits.TemperatureDifference delTDisCoo=10
+    "Nominal district supply and return water temperature difference";
+
+  CoolingIndirect coo(
+   redeclare package Medium = MediumW,
+    m1_flow_nominal=m1_flow_nominal,
+    m2_flow_nominal=m2_flow_nominal,
+    dp1_nominal=500,
+    dp2_nominal=500,
+    dpValve_nominal=7000,
+    use_Q_flow_nominal=true,
+    Q_flow_nominal=-1*(sum(bui.terUni.QCoo_flow_nominal)),
+    T_a1_nominal=273.15 + 8,
+    T_a2_nominal=273.15 + 19)
+    "Indirect cooling energy transfer station ETS."
+      annotation (Placement(transformation(extent={{-4,-60},{20,-40}})));
+  building bui(
+    have_pum=false,
+    have_heaLoa=true,
+    have_cooLoa=true,
+    have_weaBus=true,
+    nPorts_bCoo=1,
+    nPorts_bHea=1,
+    nPorts_aHea=1,
+    nPorts_aCoo=1)
+    "Building model integrating multiple time series thermal zones."
+    annotation (Placement(transformation(extent={{0,60},{20,80}})));
+
+  Buildings.Fluid.Sources.MassFlowSource_T supChiWat(
+    redeclare package Medium = MediumW,
+    use_m_flow_in=true,
+    use_T_in=false,
+    T=281.15,
+    nPorts=1) "Chilled water supply (district side)."
+     annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=0,
+        origin={-30,-30})));
+
+  Buildings.Fluid.Sources.Boundary_pT sinChiWat(
+    redeclare package Medium = MediumW, nPorts=1)
+   "Sink for chilled water"
+     annotation (Placement(transformation(
+        extent={{10,-10},{-10,10}},
+        rotation=0,
+        origin={70,-30})));
+  Modelica.Blocks.Sources.RealExpression TChiWatSet(y=14 + 273.15)
+    "Primary loop (district side) chilled water setpoint temperature."
+     annotation (Placement(transformation(extent={{-80,-20},{-60,0}})));
+  Modelica.Blocks.Sources.RealExpression THeaWatSup(
+    y=max(bui.terUni.T_aHeaWat_nominal))
+    "Heating water supply temperature"
+     annotation (Placement(transformation(extent={{-80,20},{-60,40}})));
+
+  Buildings.Fluid.Sources.MassFlowSource_T supHeaWat(
+      redeclare package Medium = MediumW,
+      use_m_flow_in=true,
+      use_T_in=true,
+      nPorts=1) "Heating water supply" annotation (Placement(transformation(
+          extent={{-10,-10},{10,10}},
+          rotation=0,
+          origin={-30,40})));
+  Buildings.Fluid.Sources.Boundary_pT sinHeaWat(redeclare package Medium =
+          MediumW, nPorts=1)
+       "Sink for heating water" annotation (Placement(transformation(
+            extent={{10,-10},{-10,10}},
+            rotation=0,
+            origin={50,40})));
+  Modelica.Blocks.Sources.RealExpression mHeaWatSup(y=bui.disFloHea.mReqTot_flow)
+      "Heating water supply mass flow rate."
+      annotation (Placement(transformation(extent={{-80,40},{-60,60}})));
+
+  Modelica.Blocks.Sources.RealExpression secMasFloRat(
+    y=bui.disFloCoo.mReqTot_flow) "Secondary loop chilled water flow rate."
+     annotation (Placement(transformation(extent={{-80,-40},{-60,-20}})));
+  Modelica.Blocks.Sources.RealExpression priMasFloRat(
+    y=bui.disFloCoo.mReqTot_flow.* (bui.delTBuiCoo/delTDisCoo))
+    "Primary loop chilled water flow rate."
+     annotation (Placement(transformation(extent={{-80,0},{-60,20}})));
+  Buildings.Fluid.Movers.FlowControlled_m_flow pumBui(
+    redeclare package Medium = MediumW,
+    energyDynamics=Modelica.Fluid.Types.Dynamics.FixedInitial,
+    m_flow_nominal=sum(bui.terUni.mChiWat_flow_nominal .* bui.terUni.facSca),
+    inputType=Buildings.Fluid.Types.InputType.Continuous,
+    nominalValuesDefineDefaultPressureCurve=true,
+    use_inputFilter=false,
+    dp_nominal=6000)
+     "Building-side (secondary) pump."
+     annotation (Placement(transformation(extent={{-40,-82},{-60,-62}})));
+  Modelica.Fluid.Sources.FixedBoundary pre(
+    redeclare package Medium = MediumW,
+    p=300000,
+    use_T=false,
+    nPorts=1)
+    "Pressure source"
+     annotation (Placement(transformation(
+        extent={{10,-10},{-10,10}},
+        rotation=0,
+        origin={70,-72})));
+  Buildings.BoundaryConditions.WeatherData.ReaderTMY3 weaDat(
+    calTSky=Buildings.BoundaryConditions.Types.SkyTemperatureCalculation.HorizontalRadiation,
+    pAtm(displayUnit="Pa") = 101339,
+    filNam=ModelicaServices.ExternalReferences.loadResource("modelica://Buildings/Resources/weatherdata/USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.mos"),
+    computeWetBulbTemperature=true)
+    "Weather data reader"
+    annotation (Placement(transformation(extent={{10,-10},{-10,10}},
+        rotation=90,
+        origin={50,90})));
+
+{% endraw %}
+equation
+{% raw %}
+      connect(weaDat.weaBus, bui.weaBus) annotation (Line(
+        points={{40,30},{30,30},{30,-22.8667},{50.0333,-22.8667}},
+        color={255,204,51},
+        thickness=0.5));
+      connect(coo.TSet, TChiWatSet.y)
+        annotation (Line(points={{-2,-50},{-48,-50},{-48,
+               -10},{-59,-10}}, color={0,0,127}));
+       connect(supHeaWat.T_in, THeaWatSup.y)
+        annotation (Line(points={{-42,34},{-46,34},{-46,30},{-59,30}}, color={0,0,127}));
+       connect(secMasFloRat.y, pumBui.m_flow_in)
+        annotation (Line(points={{-59,-30},{-50,-30},{-50,-60}}, color={0,0,127}));
+       connect(coo.port_a1, supChiWat.ports[1])
+        annotation (Line(points={{0,-44},{-14,-44},{-14,-30},{-20,-30}}, color={0,127,255}));
+       connect(coo.port_b2, pumBui.port_a)
+        annotation (Line(points={{0,-56},{0,-72},{-40,-72}},color={0,127,255}));
+       connect(coo.port_b2, pre.ports[1])
+        annotation (Line(points={{0,-56},{0,-72},{60,-72}},color={0,127,255}));
+       connect(supChiWat.m_flow_in, priMasFloRat.y)
+        annotation (Line(points={{-42,-22},{-46,-22},{-46,10},{-59,10}}, color={0,0,127}));
+       connect(sinChiWat.ports[1], coo.port_b1)
+        annotation (Line(points={{60,-30},{40,-30},{40,-44},{20,-44}}, color={0,127,255}));
+       connect(supHeaWat.ports[1], bui.secHeaSup[1])
+        annotation (Line(points={{-20,30},{-8,30},{-8,64},{0,64}}, color={0,127,255}));
+       connect(sinHeaWat.ports[1], bui.secHeaRet[1])
+        annotation (Line(points={{60,30},{28,30},{28,64},{20,64}}, color={0,127,255}));
+       connect(pumBui.port_b, bui.secCooSup[1])
+        annotation (Line(points={{-60,-72},{-88,-72},{-88,67.0667},{0,67.0667}}, color={0,127,255}));
+       connect(coo.port_a2, bui.secCooRet[1])
+        annotation (Line(points={{20,-56},{92,-56},{92,67},{20,67}}, color={0,127,255}));
+       connect(mHeaWatSup.y, supHeaWat.m_flow_in)
+        annotation (Line(points={{-59,48},{-42,48}}, color={0,0,127}));
+  annotation (
+{% endraw %}
+   __Dymola_Commands(file="modelica://{{project_name}}/Loads/Resources/Scripts/{{model_name}}/Dymola/RunCouplingETS_TEASERBuilding.mos"
+          "Simulate and plot"),
+          experiment(StopTime=86400,
+                     Tolerance=1e-06),
+  Documentation(info="<html>
+<p>
+This example illustrates the use of
+<a href=\"modelica://Buildings.Applications.DHC.Loads.BaseClasses.PartialBuilding\">
+Buildings.Applications.DHC.Loads.BaseClasses.PartialBuilding</a>,
+<a href=\"modelica://Buildings.Applications.DHC.Loads.BaseClasses.PartialTerminalUnit\">
+Buildings.Applications.DHC.Loads.BaseClasses.PartialTerminalUnit</a>
+and
+<a href=\"modelica://Buildings.Applications.DHC.Loads.BaseClasses.FlowDistribution\">
+Buildings.Applications.DHC.Loads.BaseClasses.FlowDistribution</a>
+in a configuration with
+</p>
+<ul>
+<li>
+an n-zone building model based on a two-element reduced order model (from
+GeoJSON export), and
+</li>
+<li>
+secondary pumps.
+</li>
+</ul>
+</html>",
+revisions=
+"<html>
+<ul>
+<li>
+May 29, 2020, by Nicholas Long:<br/>
+ETS Templating for TEASER.
+</li>
+<li>
+February 21, 2020, by Antoine Gautier:<br/>
+First implementation.
+</li>
+</ul>
+</html>"));
+end teaser_coupling_ets;

--- a/geojson_modelica_translator/model_connectors/templates/time_series_building.mot
+++ b/geojson_modelica_translator/model_connectors/templates/time_series_building.mot
@@ -1,7 +1,7 @@
 within {{project_name}}.Loads.{{model_name}};
 model building
   "Building model with heating and cooling loads provided as time series"
-extends PartialBuilding(
+  extends PartialBuilding(
     redeclare package Medium = MediumW,
     have_fan=false,
     have_eleHea=false,
@@ -130,22 +130,22 @@ extends PartialBuilding(
 {% endraw %}
 {% raw %}
 equation
- if have_heaLoa then
-  connect(disFloHea.port_b, secHeaRet[1]) annotation (Line(points={{140,-70},{240,
+  if have_heaLoa then
+    connect(disFloHea.port_b, secHeaRet[1]) annotation (Line(points={{140,-70},{240,
           -70},{240,32},{300,32}}, color={0,127,255}));
-  connect(disFloHea.port_a, secHeaSup[1]) annotation (Line(points={{120,-70},{-242,
+    connect(disFloHea.port_a, secHeaSup[1]) annotation (Line(points={{120,-70},{-242,
           -70},{-242,32},{-300,32}}, color={0,127,255}));
- end if;
-if have_cooLoa then
-  connect(disFloCoo.port_b, secCooRet[1]) annotation (Line(points={{140,-110},{252,
+  end if;
+  if have_cooLoa then
+    connect(disFloCoo.port_b, secCooRet[1]) annotation (Line(points={{140,-110},{252,
           -110},{252,-30},{300,-30}}, color={0,127,255}));
-  connect(disFloCoo.port_a, secCooSup[1]) annotation (Line(points={{120,-110},{-280,
+    connect(disFloCoo.port_a, secCooSup[1]) annotation (Line(points={{120,-110},{-280,
           -110},{-280,-30},{-300,-30}}, color={0,127,255}));
- end if;
+  end if;
   connect(terUniHea.port_bHeaWat, disFloHea.ports_a1[1]) annotation (Line(
         points={{90,-32.3333},{90,-32},{146,-32},{146,-64},{140,-64}}, color={0,
           127,255}));
-  connect(disFloHea.ports_b1[1],terUniHea. port_aHeaWat) annotation (Line(
+  connect(disFloHea.ports_b1[1],terUniHea.port_aHeaWat) annotation (Line(
         points={{120,-64},{64,-64},{64,-32.3333},{70,-32.3333}}, color={0,127,255}));
   connect(terUniHea.mReqHeaWat_flow, disFloHea.mReq_flow[1]) annotation (Line(
         points={{90.8333,-27.3333},{92,-27.3333},{92,-28},{100,-28},{100,-74},{119,
@@ -198,8 +198,8 @@ if have_cooLoa then
     </p>
    </html>", revisions="<html>
    <ul><li>
-   Aoril 8, 2020: Nicholas Long<br/>
-   Updated implemention and modified the documentation to handle template needed for GeoJSON to Modelica.
+   April 8, 2020: Nicholas Long<br/>
+   Updated implementation and modified the documentation to handle template needed for GeoJSON to Modelica.
    </li>
    <li>
    February 21, 2020, by Antoine Gautier:<br/>

--- a/geojson_modelica_translator/model_connectors/time_series.py
+++ b/geojson_modelica_translator/model_connectors/time_series.py
@@ -81,14 +81,10 @@ class TimeSeriesConnector(model_connector_base):
 
         time_series_coupling_template = self.template_env.get_template("time_series_coupling.mot")
         time_series_building_template = self.template_env.get_template("time_series_building.mot")
-        time_series_mos_template = self.template_env.get_template("RuntimeSeriesBuilding.mos")
+        time_series_mos_template = self.template_env.get_template("RuntimeSeriesBuilding.most")
         building_names = []
         try:
             for building in self.buildings:
-                # create each timeSeries building and save to the correct directory
-                print(f"Creating time series coupling for building: {building['building_id']}")
-
-                # Path for building data
                 building_names.append(f"B{building['building_id']}")
                 b_modelica_path = ModelicaPath(
                     f"B{building['building_id']}", scaffold.loads_path.files_dir, True
@@ -140,7 +136,7 @@ class TimeSeriesConnector(model_connector_base):
 
                 self.run_template(
                     time_series_mos_template,
-                    os.path.join(b_modelica_path.scripts_dir, "RuntimeSeriesBuilding.mos"),
+                    os.path.join(b_modelica_path.scripts_dir, "RuntimeSeriesBuilding.most"),
                     full_model_name=os.path.join(
                         scaffold.project_name,
                         scaffold.loads_path.files_relative_dir,
@@ -169,7 +165,7 @@ class TimeSeriesConnector(model_connector_base):
         for b in building_names:
             b_modelica_path = os.path.join(scaffold.loads_path.files_dir, b)
             new_package = PackageParser.new_from_template(
-                b_modelica_path, b, ["building", "coupling"],
+                b_modelica_path, b, ["PartialBuilding", "building", "coupling"],
                 within=f"{scaffold.project_name}.Loads"
             )
             new_package.save()

--- a/geojson_modelica_translator/model_connectors/time_series_ets_coupling.py
+++ b/geojson_modelica_translator/model_connectors/time_series_ets_coupling.py
@@ -86,10 +86,6 @@ class TimeSeriesConnectorETS(model_connector_base):
         building_names = []
         try:
             for building in self.buildings:
-                # create timeSeries building and save to the correct directory
-                print(f"Creating timeSeries for building: {building['building_id']}")
-
-                # Path for building data
                 building_names.append(f"B{building['building_id']}")
                 b_modelica_path = ModelicaPath(
                     f"B{building['building_id']}", scaffold.loads_path.files_dir, True
@@ -110,16 +106,15 @@ class TimeSeriesConnectorETS(model_connector_base):
                     }
                 }
 
-        # copy over the resource files for this building
                 if os.path.exists(template_data["time_series"]["filepath"]):
-
                     new_file = os.path.join(b_modelica_path.resources_dir, template_data["time_series"]["filename"])
                     os.makedirs(os.path.dirname(new_file), exist_ok=True)
                     shutil.copy(template_data["time_series"]["filepath"], new_file)
                 else:
                     raise Exception(f"Missing MOS file for time series: {template_data['time_series']['filepath']}")
-                    # write a file name building.mo, CoolingIndirect.mo and CouplingETS_TimeSeriesBuilding.mo
-                    # Run the templating
+
+                # write a file name building.mo, CoolingIndirect.mo and CouplingETS_TimeSeriesBuilding.mo
+                # Run the templating
                 file_data = timeSeries_building_template.render(
                     project_name=scaffold.project_name,
                     model_name=f"B{building['building_id']}",
@@ -172,6 +167,7 @@ class TimeSeriesConnectorETS(model_connector_base):
                 with open(os.path.join(os.path.join(b_modelica_path.files_dir, "CouplingETS_TimeSeriesBuilding.mo")),
                           "w") as f:
                     f.write(file_data)
+
                 # Copy the required modelica files
                 for f in self.required_mo_files:
                     shutil.copy(f, os.path.join(b_modelica_path.files_dir, os.path.basename(f)))
@@ -189,6 +185,7 @@ class TimeSeriesConnectorETS(model_connector_base):
 
             * Add a Loads project
             * Add a project level project
+            * Add the PartialBuilding to the package order (this is temporary until PartialBuilding is updated in MBL)
 
         :param scaffold: Scaffold object, Scaffold of the entire directory of the project.
         :param building_names: list, names of the buildings that need to be cleaned up after export
@@ -198,7 +195,7 @@ class TimeSeriesConnectorETS(model_connector_base):
             b_modelica_path = os.path.join(scaffold.loads_path.files_dir, b)
             new_package = PackageParser.new_from_template(
                 b_modelica_path, b,
-                ["building", "CoolingIndirect", "CouplingETS_TimeSeriesBuilding"],
+                ["PartialBuilding", "building", "CoolingIndirect", "CouplingETS_TimeSeriesBuilding"],
                 within=f"{scaffold.project_name}.Loads"
             )
             new_package.save()

--- a/geojson_modelica_translator/modelica/input_parser.py
+++ b/geojson_modelica_translator/modelica/input_parser.py
@@ -47,7 +47,7 @@ class PackageParser(object):
         :param path: string, path to where the package.mo and package.order reside.
         """
         self.path = path
-        self.order_data = None
+        self.order_data = None  # This is stored as a string for now.
         self.package_data = None
         self.load()
 
@@ -78,7 +78,6 @@ class PackageParser(object):
 
         klass.package_data = template.render(within=within, name=name, order=order)
         klass.order_data = "\n".join(order)
-        klass.order_data += "\n"  # trailing line
         return klass
 
     def load(self):
@@ -104,6 +103,7 @@ class PackageParser(object):
 
         with open(os.path.join(os.path.join(self.path, "package.order")), "w") as f:
             f.write(self.order_data)
+            f.write("\n")
 
     @property
     def order(self):
@@ -112,7 +112,10 @@ class PackageParser(object):
 
         :return: list, list of the loaded models in the package.order file
         """
-        return self.order_data.split("\n")
+        data = self.order_data.split("\n")
+        if "" in data:
+            data.remove("")
+        return data
 
     def rename_model(self, old_model, new_model):
         """
@@ -122,6 +125,20 @@ class PackageParser(object):
         :param new_model: string, new name
         """
         self.order_data = self.order_data.replace(old_model, new_model)
+
+    def add_model(self, new_model_name, insert_at=-1):
+        """Insert a new model into the package> Note that the order_data is stored as a string right now,
+        so there is a bit of a hack to get this to work correctly.
+
+        :param new_model_name: string, name of the new model to add to the package order.
+        :param insert_at: int, location to insert package, if 0 at beginning, -1 at end
+        """
+        data = self.order_data.split("\n")
+        if insert_at == -1:
+            data.append(new_model_name)
+        else:
+            data.insert(insert_at, new_model_name)
+        self.order_data = "\n".join(data)
 
 
 class InputParser(object):

--- a/geojson_modelica_translator/modelica/templates/package_base.mot
+++ b/geojson_modelica_translator/modelica/templates/package_base.mot
@@ -2,5 +2,5 @@ package {{name}}
   extends Modelica.Icons.Package;
 
   annotation (uses(
-    Modelica(version="3.2.2"), Buildings(version="7.0.0")), version="1");
+    Modelica(version="3.2.3"), Buildings(version="7.0.0")), version="1");
 end {{name}};

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,13 +11,14 @@ jsonpath-ng==1.5.1
 BuildingsPy==2.0.0
 
 # Modelica Builder package (use the local [file:] version if needed for debugging)
--e git+https://github.com/urbanopt/modelica-builder.git@develop#egg=modelica_builder
+-e git+https://github.com/urbanopt/modelica-builder.git@add-conditional-component#egg=modelica_builder
 #-e file:../modelica-builder#egg=modelica-builder
 
 # Use the core teaser library. Note: if using the github checkout, then it will be saved in the ./src directory if python is system python.
-teaser==0.7.2
+#teaser==0.7.2
+-e git+https://github.com/urbanopt/TEASER.git@rc-argument-names#egg=teaser
 #-e git+https://github.com/RWTH-EBC/TEASER.git@0.7.2#egg=teaser
-#-e file:../TEASER-urbanopt#egg=teaser
+#-e file:../TEASER-UO#egg=teaser
 
 # Test and documentation
 nose==1.3.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ jsonpath-ng==1.5.1
 BuildingsPy==2.0.0
 
 # Modelica Builder package (use the local [file:] version if needed for debugging)
--e git+https://github.com/urbanopt/modelica-builder.git@add-conditional-component#egg=modelica_builder
+-e git+https://github.com/urbanopt/modelica-builder.git@develop#egg=modelica_builder
 #-e file:../modelica-builder#egg=modelica-builder
 
 # Use the core teaser library. Note: if using the github checkout, then it will be saved in the ./src directory if python is system python.

--- a/tests/model_connectors/test_teaser.py
+++ b/tests/model_connectors/test_teaser.py
@@ -30,11 +30,13 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import itertools
 import os
+from pathlib import Path
 
 from geojson_modelica_translator.geojson_modelica_translator import (
     GeoJsonModelicaTranslator
 )
 from geojson_modelica_translator.model_connectors.teaser import TeaserConnector
+from geojson_modelica_translator.modelica.modelica_runner import ModelicaRunner
 from geojson_modelica_translator.system_parameters.system_parameters import (
     SystemParameters
 )
@@ -91,6 +93,16 @@ class TeaserModelConnectorSingleBuildingTest(TestCaseBase):
         with open(check_file) as f:
             self.assertTrue('Buildings.ThermalZones.ReducedOrder.RC.TwoElements' in f.read())
 
+        # make sure the model can run using the ModelicaRunner class - this is broke for some reason
+        mr = ModelicaRunner()
+
+        file_to_run = os.path.abspath(
+            os.path.join(self.gj.scaffold.loads_path.files_dir, 'B5a6b99ec37f4de7f94020090', 'coupling.mo'),
+        )
+        run_path = Path(os.path.abspath(self.gj.scaffold.project_path)).parent
+        exitcode = mr.run_in_docker(file_to_run, run_path=run_path, project_name=self.gj.scaffold.project_name)
+        self.assertEqual(0, exitcode)
+
     def test_teaser_rc_4(self):
         """Models should be 4 element RC models"""
         project_name = 'teaser_rc_4'
@@ -125,17 +137,11 @@ class TeaserModelConnectorSingleBuildingTest(TestCaseBase):
                 self.assertTrue(os.path.exists(path), f"Path not found: {path}")
 
         # make sure the model can run using the ModelicaRunner class - this is broke for some reason
-        # mr = ModelicaRunner()
-        #
-        # file_to_run = os.path.abspath(
-        #     os.path.join(self.gj.scaffold.loads_path.files_dir, 'B5a6b99ec37f4de7f94020090', 'Office.mo'),
-        # )
-        # run_path = Path(os.path.abspath(self.gj.scaffold.project_path)).parent
-        # exitcode = mr.run_in_docker(file_to_run, run_path=run_path, project_name=self.gj.scaffold.project_name)
-        # self.assertEqual(0, exitcode)
+        mr = ModelicaRunner()
 
-        # results_path = os.path.join(run_path, f"{self.gj.scaffold.project_name}_results")
-        # self.assertTrue(os.path.join(results_path, 'stdout.log'))
-        # self.assertTrue(
-        #     os.path.join(results_path, 'spawn_single_Loads_B5a6b99ec37f4de7f94020090_CouplingETS_SpawnBuilding.fmu')
-        # )
+        file_to_run = os.path.abspath(
+            os.path.join(self.gj.scaffold.loads_path.files_dir, 'B5a6b99ec37f4de7f94020090', 'Office.mo'),
+        )
+        run_path = Path(os.path.abspath(self.gj.scaffold.project_path)).parent
+        exitcode = mr.run_in_docker(file_to_run, run_path=run_path, project_name=self.gj.scaffold.project_name)
+        self.assertEqual(0, exitcode)

--- a/tests/model_connectors/test_teaser.py
+++ b/tests/model_connectors/test_teaser.py
@@ -30,18 +30,19 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import itertools
 import os
-from pathlib import Path
 
 from geojson_modelica_translator.geojson_modelica_translator import (
     GeoJsonModelicaTranslator
 )
 from geojson_modelica_translator.model_connectors.teaser import TeaserConnector
-from geojson_modelica_translator.modelica.modelica_runner import ModelicaRunner
+# from geojson_modelica_translator.modelica.modelica_runner import ModelicaRunner
 from geojson_modelica_translator.system_parameters.system_parameters import (
     SystemParameters
 )
 
 from ..base_test_case import TestCaseBase
+
+# from pathlib import Path
 
 
 class TeaserModelConnectorSingleBuildingTest(TestCaseBase):
@@ -93,15 +94,15 @@ class TeaserModelConnectorSingleBuildingTest(TestCaseBase):
         with open(check_file) as f:
             self.assertTrue('Buildings.ThermalZones.ReducedOrder.RC.TwoElements' in f.read())
 
-        # make sure the model can run using the ModelicaRunner class - this is broke for some reason
-        mr = ModelicaRunner()
-
-        file_to_run = os.path.abspath(
-            os.path.join(self.gj.scaffold.loads_path.files_dir, 'B5a6b99ec37f4de7f94020090', 'coupling.mo'),
-        )
-        run_path = Path(os.path.abspath(self.gj.scaffold.project_path)).parent
-        exitcode = mr.run_in_docker(file_to_run, run_path=run_path, project_name=self.gj.scaffold.project_name)
-        self.assertEqual(0, exitcode)
+        # # make sure the model can run using the ModelicaRunner class - this is broke for some reason
+        # mr = ModelicaRunner()
+        #
+        # file_to_run = os.path.abspath(
+        #     os.path.join(self.gj.scaffold.loads_path.files_dir, 'B5a6b99ec37f4de7f94020090', 'coupling.mo'),
+        # )
+        # run_path = Path(os.path.abspath(self.gj.scaffold.project_path)).parent
+        # exitcode = mr.run_in_docker(file_to_run, run_path=run_path, project_name=self.gj.scaffold.project_name)
+        # self.assertEqual(0, exitcode)
 
     def test_teaser_rc_4(self):
         """Models should be 4 element RC models"""
@@ -137,11 +138,11 @@ class TeaserModelConnectorSingleBuildingTest(TestCaseBase):
                 self.assertTrue(os.path.exists(path), f"Path not found: {path}")
 
         # make sure the model can run using the ModelicaRunner class - this is broke for some reason
-        mr = ModelicaRunner()
-
-        file_to_run = os.path.abspath(
-            os.path.join(self.gj.scaffold.loads_path.files_dir, 'B5a6b99ec37f4de7f94020090', 'Office.mo'),
-        )
-        run_path = Path(os.path.abspath(self.gj.scaffold.project_path)).parent
-        exitcode = mr.run_in_docker(file_to_run, run_path=run_path, project_name=self.gj.scaffold.project_name)
-        self.assertEqual(0, exitcode)
+        # mr = ModelicaRunner()
+        #
+        # file_to_run = os.path.abspath(
+        #     os.path.join(self.gj.scaffold.loads_path.files_dir, 'B5a6b99ec37f4de7f94020090', 'Office.mo'),
+        # )
+        # run_path = Path(os.path.abspath(self.gj.scaffold.project_path)).parent
+        # exitcode = mr.run_in_docker(file_to_run, run_path=run_path, project_name=self.gj.scaffold.project_name)
+        # self.assertEqual(0, exitcode)

--- a/tests/model_connectors/test_teaser_ets.py
+++ b/tests/model_connectors/test_teaser_ets.py
@@ -28,14 +28,15 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ****************************************************************************************************
 """
 
-import itertools
 import os
 from pathlib import Path
 
 from geojson_modelica_translator.geojson_modelica_translator import (
     GeoJsonModelicaTranslator
 )
-from geojson_modelica_translator.model_connectors.teaser import TeaserConnector
+from geojson_modelica_translator.model_connectors.teaser_ets_coupling import (
+    TeaserConnectorETS
+)
 from geojson_modelica_translator.modelica.modelica_runner import ModelicaRunner
 from geojson_modelica_translator.system_parameters.system_parameters import (
     SystemParameters
@@ -60,30 +61,14 @@ class TeaserModelConnectorSingleBuildingTest(TestCaseBase):
         else:
             sys_params = SystemParameters()
 
-        self.teaser = TeaserConnector(sys_params)
+        self.teaser = TeaserConnectorETS(sys_params)
         for b in self.gj.buildings:
             self.teaser.add_building(b)
 
-    def test_building_types(self):
-        sys_params = SystemParameters()
-        tc = TeaserConnector(sys_params)
-        self.assertEqual('institute8', tc.lookup_building_type('Laboratory'))
-        self.assertEqual('institute', tc.lookup_building_type('Education'))
-        self.assertEqual('office', tc.lookup_building_type('Office'))
-
-    def test_undefined_building_type(self):
-        sys_params = SystemParameters()
-        tc = TeaserConnector(sys_params)
-
-        with self.assertRaises(Exception) as exc:
-            tc.lookup_building_type('Undefined Building Type')
-        self.assertEqual("Building type of Undefined Building Type not defined in GeoJSON to TEASER mappings",
-                         str(exc.exception))
-
-    def test_teaser_rc_default(self):
+    def test_teaser_rc_ets(self):
         """Should result in TEASER models with two element RC models"""
-        project_name = 'teaser_rc_default'
-        self.load_project(project_name, "teaser_geojson_ex1.json", None)
+        project_name = 'teaser_rc_ets_default'
+        self.load_project(project_name, "teaser_geojson_ex1.json", "teaser_system_params_ex1.json")
         self.teaser.to_modelica(self.gj.scaffold)
 
         # Check that the created file is two element
@@ -91,46 +76,13 @@ class TeaserModelConnectorSingleBuildingTest(TestCaseBase):
         self.assertTrue(os.path.exists(check_file))
 
         with open(check_file) as f:
-            self.assertTrue('Buildings.ThermalZones.ReducedOrder.RC.TwoElements' in f.read())
+            self.assertTrue('Buildings.ThermalZones.ReducedOrder.RC.FourElements' in f.read())
 
         mr = ModelicaRunner()
 
         file_to_run = os.path.abspath(
-            os.path.join(self.gj.scaffold.loads_path.files_dir, 'B5a6b99ec37f4de7f94020090', 'coupling.mo'),
+            os.path.join(self.gj.scaffold.loads_path.files_dir, 'B5a6b99ec37f4de7f94020090', 'teaser_coupling_ets.mo'),
         )
         run_path = Path(os.path.abspath(self.gj.scaffold.project_path)).parent
         exitcode = mr.run_in_docker(file_to_run, run_path=run_path, project_name=self.gj.scaffold.project_name)
         self.assertEqual(0, exitcode)
-
-    def test_teaser_rc_4(self):
-        """Models should be 4 element RC models"""
-        project_name = 'teaser_rc_4'
-
-        self.load_project(project_name, "teaser_geojson_ex1.json", "teaser_system_params_ex1.json")
-        self.teaser.to_modelica(self.gj.scaffold)
-
-        # setup what wze are going to check
-        model_names = ["Floor", "ICT", "Meeting", "Office", "package", "Restroom", "Storage", ]
-        building_paths = [
-            os.path.join(self.gj.scaffold.loads_path.files_dir, b.dirname) for b in self.gj.buildings
-        ]
-        path_checks = [f"{os.path.sep.join(r)}.mo" for r in itertools.product(building_paths, model_names)]
-
-        for p in path_checks:
-            self.assertTrue(os.path.exists(p), f"Path not found {p}")
-            if os.path.basename(p) == 'package.mo':
-                continue
-
-            with open(p) as f:
-                self.assertTrue('Buildings.ThermalZones.ReducedOrder.RC.FourElements' in f.read(),
-                                "Could not find the correct RC Model Order")
-
-        # go through the generated buildings and ensure that the resources are created
-        resource_names = ["InternalGains_Floor", "InternalGains_ICT", "InternalGains_Meeting",
-                          "InternalGains_Office", "InternalGains_Restroom", "InternalGains_Storage", ]
-        for b in self.gj.buildings:
-            for resource_name in resource_names:
-                # TEASER 0.7.2 used .txt for schedule files
-                path = os.path.join(self.gj.scaffold.loads_path.files_dir, "Resources", "Data",
-                                    b.dirname, f"{resource_name}.txt")
-                self.assertTrue(os.path.exists(path), f"Path not found: {path}")

--- a/tests/model_connectors/test_time_series_ets.py
+++ b/tests/model_connectors/test_time_series_ets.py
@@ -50,7 +50,7 @@ class TimeSeriesModelConnectorSingleBuildingETSTest(unittest.TestCase):
         self.data_dir = os.path.join(os.path.dirname(__file__), 'data')
         self.output_dir = os.path.join(os.path.dirname(__file__), 'output')
 
-        project_name = "time_series_ex1"
+        project_name = "time_series_ets_ex1"
         if os.path.exists(os.path.join(self.output_dir, project_name)):
             shutil.rmtree(os.path.join(self.output_dir, project_name))
 

--- a/tests/modelica/data/test_1.mo
+++ b/tests/modelica/data/test_1.mo
@@ -27,8 +27,8 @@ model B5a6b99ec37f4de7f94020090_Floor
   thermalZoneTwoElements(
     redeclare package Medium = Buildings.Media.Air,
     VAir=3261.7921338576007,
-    alphaExt=2.0490178828959134,
-    alphaWin=2.7000000000000006,
+    hConExt=2.0490178828959134,
+    hConWin=2.7000000000000006,
     gWin=0.6699999999999999,
     ratioWinConRad=0.029999999999999995,
     nExt=1,

--- a/tests/modelica/data/test_1.mo
+++ b/tests/modelica/data/test_1.mo
@@ -25,7 +25,7 @@ model B5a6b99ec37f4de7f94020090_Floor
     annotation (Placement(transformation(extent={{6,54},{26,74}})));
   Buildings.ThermalZones.ReducedOrder.RC.TwoElements
   thermalZoneTwoElements(
-    redeclare package Medium = Modelica.Media.Air.DryAirNasa,
+    redeclare package Medium = Buildings.Media.Air,
     VAir=3261.7921338576007,
     alphaExt=2.0490178828959134,
     alphaWin=2.7000000000000006,
@@ -85,7 +85,7 @@ model B5a6b99ec37f4de7f94020090_Floor
     annotation (Placement(
     transformation(extent={{-100,-10},{-66,22}}),iconTransformation(
     extent={{-70,-12},{-50,8}})));
-  Modelica.Blocks.Sources.Constant alphaWall(k=25.0*1400.34914915219)
+  Modelica.Blocks.Sources.Constant hConWall(k=25.0*1400.34914915219)
     "Outdoor coefficient of heat transfer for walls"
     annotation (Placement(
     transformation(
@@ -245,7 +245,7 @@ equation
     color={191,0,0}));
   connect(thermalConductorWall.fluid, prescribedTemperature.port)
     annotation (Line(points={{26,1},{24,1},{24,0},{20,0}}, color={191,0,0}));
-  connect(alphaWall.y, thermalConductorWall.Gc)
+  connect(hConWall.y, thermalConductorWall.Gc)
     annotation (Line(points={{30,-11.6},{30,-4},{31,-4}}, color={0,0,127}));
   connect(alphaWin.y, thermalConductorWin.Gc)
     annotation (Line(points={{32,33.6},{32,26},{33,26}}, color={0,0,127}));

--- a/tests/modelica/test_package_parser.py
+++ b/tests/modelica/test_package_parser.py
@@ -1,0 +1,92 @@
+"""
+****************************************************************************************************
+:copyright (c) 2019-2020 URBANopt, Alliance for Sustainable Energy, LLC, and other contributors.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted
+provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions
+and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions
+and the following disclaimer in the documentation and/or other materials provided with the
+distribution.
+
+Neither the name of the copyright holder nor the names of its contributors may be used to endorse
+or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+****************************************************************************************************
+"""
+
+import os
+import unittest
+
+from geojson_modelica_translator.modelica.input_parser import PackageParser
+
+
+class PackageParserTest(unittest.TestCase):
+    def setUp(self):
+        self.data_dir = os.path.join(os.path.dirname(__file__), 'data')
+        self.output_dir = os.path.join(os.path.dirname(__file__), 'output')
+        if not os.path.exists(self.output_dir):
+            os.makedirs(self.output_dir)
+
+    def test_new_from_template(self):
+        package = PackageParser.new_from_template(
+            self.output_dir, 'new_model_name', ["model_a", "model_b"], within="SomeWithin"
+        )
+        package.save()
+
+        self.assertTrue(os.path.exists(os.path.join(self.output_dir, 'package.mo')))
+        self.assertTrue(os.path.exists(os.path.join(self.output_dir, 'package.order')))
+
+        # check for strings in files
+        with open(os.path.join(self.output_dir, 'package.mo')) as f:
+            file_data = f.read()
+            self.assertTrue('within SomeWithin;' in file_data, 'Incorrect within clause')
+            self.assertTrue('package new_model_name' in file_data, 'Incorrect package definition')
+            self.assertTrue('end new_model_name;' in file_data, 'Incorrect package ending')
+
+        with open(os.path.join(self.output_dir, 'package.order')) as f:
+            self.assertTrue('model_a\nmodel_b' in f.read(), 'Incorrect package order')
+
+    def test_round_trip(self):
+        package = PackageParser.new_from_template(
+            self.output_dir, 'another_model', ["model_x", "model_y"], within="DifferentWithin"
+        )
+        package.save()
+
+        # Read in the package
+        package = PackageParser(self.output_dir)
+        self.assertListEqual(package.order, ["model_x", "model_y"])
+
+    def test_rename_model(self):
+        package = PackageParser.new_from_template(
+            self.output_dir, 'rename_model', ["model_1", "model_2"], within="RenameWithin"
+        )
+        package.save()
+
+        package.rename_model('model_1', 'my_super_new_model')
+        self.assertEqual(len(package.order), 2)
+        self.assertIn('my_super_new_model', package.order)
+
+    def test_add_model(self):
+        package = PackageParser.new_from_template(
+            self.output_dir, 'so_many_models', ["model_beta", "model_gamma"], within="SoMany"
+        )
+        package.save()
+
+        package.add_model('model_delta')
+        package.add_model('model_alpha', 0)
+        self.assertEqual(len(package.order), 4)
+        self.assertListEqual(['model_alpha', 'model_beta', 'model_gamma', 'model_delta'], package.order)


### PR DESCRIPTION
#### Any background context you want to provide?
TEASER was using older versions of the parameters for the IBPSA/MBL RC models. 

#### What does this PR accomplish?
* Requires a forked version of TEASER (https://github.com/urbanopt/TEASER/tree/rc-argument-names). This PR has yet to be submitted to TEASER.
* Move `use_moisture_balance` to forked teaser (this is temporary)
* Move `nports` to forked teaser (this is temporary)

#### How should this be manually tested?
* py.test should test the required functionality.

#### What are the relevant tickets?
#51 #52
#### Screenshots (if appropriate)
