### PR TITLE
Update to use component-modifications based on TEASER fix/update

### DIFF
--- a/geojson_modelica_translator/model_connectors/teaser.py
+++ b/geojson_modelica_translator/model_connectors/teaser.py
@@ -269,6 +269,7 @@ class TeaserConnector(model_connector_base):
                 # add heat port convective heat flow.
                 mofile.insert_component(
                     "Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a", "port_a",
+                    string_comment='Heat port for convective heat flow.',
                     annotations=[
                         "Placement(transformation(extent={{-10,90},{10,110}}), "
                         "iconTransformation(extent={{-10,90},{10,110}}))"
@@ -326,7 +327,7 @@ class TeaserConnector(model_connector_base):
                 mofile.add_parameter(
                     'Integer', 'nPorts',
                     assigned_value=n_ports,
-                    string_comment='Number of fluid ports.',
+                    string_comment='Number of air ports.',
                     annotations=['connectorSizing=true']
                 )
                 # Set the fraction latent person in the template by simply replacing the value
@@ -417,13 +418,12 @@ class TeaserConnector(model_connector_base):
                     )
                     mofile.add_connect(
                         f'{thermal_zone_name}.QLat_flow', 'perLatLoa.y',
-                        annotations=['Line(points={{93,28},{98,28},{98,-20},{110,-20}}, color={0,0,127})']
+                        annotations=['Line(points={{43,4},{42,4},{42,-28},{-8,-28},{-8,-50},{-59,-50}}, color={0,0,127})']
                     )
 
                     mofile.add_connect(
                         f'{thermal_zone_name}.intGainsRad', 'port_b',
-                        annotations=[
-                            'Line(points={{43,4},{40,4},{40,-28},{-40,-28},{-40,-50},{-59,-50}}, color={0, 0,127})'
+                        annotations=['Line(points={{92,24},{98,24},{98,-100},{40,-100}}, color={191,0,0}))'
                         ]
                     )
 

--- a/geojson_modelica_translator/model_connectors/teaser.py
+++ b/geojson_modelica_translator/model_connectors/teaser.py
@@ -389,18 +389,16 @@ class TeaserConnector(model_connector_base):
                     thermal_zone_name = 'thermalZoneFourElements'
 
                 if thermal_zone_name is not None and thermal_zone_type is not None:
-                    mofile.update_component_modification(
+                    mofile.update_component_modifications(
                         f"Buildings.ThermalZones.ReducedOrder.RC.{thermal_zone_type}",
                         thermal_zone_name,
-                        "use_moisture_balance",
-                        "use_moisture_balance"
+                        {"use_moisture_balance": "use_moisture_balance"}
                     )
 
-                    mofile.update_component_modification(
+                    mofile.update_component_modifications(
                         f"Buildings.ThermalZones.ReducedOrder.RC.{thermal_zone_type}",
                         thermal_zone_name,
-                        "nPorts",
-                        "nPorts",
+                        {"nPorts": "nPorts"}
                     )
 
                     mofile.add_connect(

--- a/geojson_modelica_translator/model_connectors/teaser.py
+++ b/geojson_modelica_translator/model_connectors/teaser.py
@@ -307,7 +307,7 @@ class TeaserConnector(model_connector_base):
                 )
 
                 n_ports = self.system_parameters.get_param(
-                    "buildings.default.load_model_parameters.rc.nPorts", default=0
+                    "buildings.default.load_model_parameters.rc.nPorts", default=2
                 )
 
                 # create a new parameter for fraction latent person
@@ -419,7 +419,7 @@ class TeaserConnector(model_connector_base):
                     mofile.add_connect(
                         f'{thermal_zone_name}.QLat_flow', 'perLatLoa.y',
                         annotations=['Line(points={{43,4},{42,4},{42,-28},{-8,-28},{-8,-50},{-59,-50}},'
-                                        'color={0,0,127})'
+                                     'color={0,0,127})'
                                      ]
                     )
 
@@ -429,24 +429,17 @@ class TeaserConnector(model_connector_base):
                                      ]
                     )
 
-                    # Need to figure out how to add equations to ModBuild. For now put this in for each port
-                    # defined in the system parameters file. Would ideally like to add the following to an
-                    # existing mo file:
-                    #       for i in 1:nPorts loop
-                    #           connect(ports[i], thermalZoneFourElements.ports[i]) annotation (Line(
-                    #           points={{-18,-102},{-18,-84},{83,-84},{83,-1.95}},
-                    #           color={0,127,255},
-                    #           smooth=Smooth.None));
-                    #       end for;
-                    for i in range(n_ports):
-                        mofile.add_connect(
-                            f'ports[{i + 1}]', f'thermalZone{thermal_zone_type}.ports[{i + 1}]',
-                            annotations=[
-                                'Line(points={{-18,-102},{-18,-84},{83,-84},{83,-1.95}}, '
-                                'color={0, 127, 255}, '
-                                'smooth=Smooth.None)'
-                            ]
-                        )
+                    mofile.insert_equation_for_loop(
+                        index_identifier="i",
+                        expression_raw="1:nPorts",
+                        loop_body_raw_list=[
+                            "connect(ports[i], thermalZoneFourElements.ports[i])",
+                            "\tannotation (Line(",
+                            "\tpoints={{-18,-102},{-18,-84},{83,-84},{83,-1.95}},",
+                            "\tcolor={0,127,255},",
+                            "\tsmooth=Smooth.None));",
+                        ],
+                    )
 
                 # change the name of the modelica model to remove the building id, update in package too!
                 original_model_name = mofile.get_name()

--- a/geojson_modelica_translator/model_connectors/teaser_ets_coupling.py
+++ b/geojson_modelica_translator/model_connectors/teaser_ets_coupling.py
@@ -390,18 +390,16 @@ class TeaserConnectorETS(model_connector_base):
                     thermal_zone_name = 'thermalZoneFourElements'
 
                 if thermal_zone_name is not None and thermal_zone_type is not None:
-                    mofile.update_component_modification(
+                    mofile.update_component_modifications(
                         f"Buildings.ThermalZones.ReducedOrder.RC.{thermal_zone_type}",
                         thermal_zone_name,
-                        "use_moisture_balance",
-                        "use_moisture_balance"
+                        {"use_moisture_balance": "use_moisture_balance"}
                     )
 
-                    mofile.update_component_modification(
+                    mofile.update_component_modifications(
                         f"Buildings.ThermalZones.ReducedOrder.RC.{thermal_zone_type}",
                         thermal_zone_name,
-                        "nPorts",
-                        "nPorts",
+                        {"nPorts": "nPorts"}
                     )
 
                     mofile.add_connect(

--- a/geojson_modelica_translator/model_connectors/teaser_ets_coupling.py
+++ b/geojson_modelica_translator/model_connectors/teaser_ets_coupling.py
@@ -433,24 +433,17 @@ class TeaserConnectorETS(model_connector_base):
                             'Line(points={{92, 24}, {98, 24}, {98, -100}, {40, -100}}, color={191, 0, 0})'
                         ]
                     )
-                    # Need to figure out how to add equations to ModBuild. For now put this in for each port
-                    # defined in the system parameters file. Would ideally like to add the following to an
-                    # existing mo file:
-                    #       for i in 1:nPorts loop
-                    #           connect(ports[i], thermalZoneFourElements.ports[i]) annotation (Line(
-                    #           points={{-18,-102},{-18,-84},{83,-84},{83,-1.95}},
-                    #           color={0,127,255},
-                    #           smooth=Smooth.None));
-                    #       end for;
-                    for i in range(n_ports):
-                        mofile.add_connect(
-                            f'ports[{i + 1}]', f'thermalZone{thermal_zone_type}.ports[{i + 1}]',
-                            annotations=[
-                                'Line(points={{-18,-102},{-18,-84},{83,-84},{83,-1.95}}, '
-                                'color={0, 127, 255}, '
-                                'smooth=Smooth.None)'
-                            ]
-                        )
+                    mofile.insert_equation_for_loop(
+                        index_identifier="i",
+                        expression_raw="1:nPorts",
+                        loop_body_raw_list=[
+                            "connect(ports[i], thermalZoneFourElements.ports[i])",
+                            "\tannotation (Line(",
+                            "\tpoints={{-18,-102},{-18,-84},{83,-84},{83,-1.95}},",
+                            "\tcolor={0,127,255},",
+                            "\tsmooth=Smooth.None));",
+                        ],
+                    )
 
                 # change the name of the modelica model to remove the building id, update in package too!
                 original_model_name = mofile.get_name()

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ BuildingsPy==2.0.0
 -e git+https://github.com/urbanopt/modelica-builder.git@develop#egg=modelica_builder
 #-e file:../modelica-builder#egg=modelica-builder
 
-# Use the core teaser library. Note: if using the github checkout, then it will be saved in the ./src directory if python is system python.
+# Use the core teaser library.
 #teaser==0.7.2
 -e git+https://github.com/urbanopt/TEASER.git@rc-argument-names#egg=teaser
 #-e git+https://github.com/RWTH-EBC/TEASER.git@0.7.2#egg=teaser


### PR DESCRIPTION
#### Any background context you want to provide?
We hacked in an nPorts and use_moisture_balance into TEASER which didn't belong.

#### What does this PR accomplish?
* Uses an updated modelica builder version that allows us to add an argument/parameter to a component model. nPorts and user_moisure_balance are now added programatically.

#### How should this be manually tested?
`py.test`

#### What are the relevant tickets?
n/a
#### Screenshots (if appropriate)
