### PR TITLE
Refactor/format template mo files

### DIFF
--- a/geojson_modelica_translator/model_connectors/templates/BuildingSpawnZ6WithCoolingIndirectETS.mo
+++ b/geojson_modelica_translator/model_connectors/templates/BuildingSpawnZ6WithCoolingIndirectETS.mo
@@ -1,54 +1,51 @@
 //within geojson_modelica_translator.model_connectors.templates;
 model BuildingSpawnZ6WithCoolingIndirectETS
-package MediumW = Buildings.Media.Water;
+  package MediumW=Buildings.Media.Water;
   extends PartialBuildingWithCoolingIndirectETS(
     final m1_flow_nominal=mBuiHea_flow_nominal,
     final m2_flow_nominal=mDis_flow_nominal,
-    redeclare final package Medium1 =MediumW,
-    redeclare final package Medium2 =MediumW,
+    redeclare final package Medium1=MediumW,
+    redeclare final package Medium2=MediumW,
     preSou(
-     redeclare package Medium = MediumW),
+      redeclare package Medium=MediumW),
     val(
-     redeclare package Medium = MediumW,
-     m_flow_nominal=mDis_flow_nominal,
-     dpValve_nominal=7000),
-   redeclare building bui(
-     final idfName=idfName,
-     final weaName=weaName,
-     T_aChiWat_nominal=280.15,
-     T_bChiWat_nominal=285.15,
-     nPorts_aHeaWat=1,
-     nPorts_bHeaWat=1,
-     nPorts_bChiWat=1,
-     nPorts_aChiWat=1),
-   redeclare CoolingIndirect ets(
-     redeclare package Medium =MediumW,
-     final mDis_flow_nominal=mDis_flow_nominal,
-     final mBui_flow_nominal=mBui_flow_nominal,
-     dp1_nominal=500,
-     dp2_nominal=500,
-     use_Q_flow_nominal=true,
-     Q_flow_nominal=-1*(sum(bui.terUni.QCoo_flow_nominal)),
-     T_a1_nominal=273.15 + 5,
-     T_a2_nominal=273.15 + 12,
-     eta=0.8)
-  "Spawn building connected to the indirect cooling ETS model");
-
-  parameter String idfName=
-    "modelica://Buildings/Resources/Data/ThermalZones/EnergyPlus/Validation/RefBldgSmallOffice/RefBldgSmallOfficeNew2004_Chicago.idf"
+      redeclare package Medium=MediumW,
+      m_flow_nominal=mDis_flow_nominal,
+      dpValve_nominal=7000),
+    redeclare building bui(
+      final idfName=idfName,
+      final weaName=weaName,
+      T_aChiWat_nominal=280.15,
+      T_bChiWat_nominal=285.15,
+      nPorts_aHeaWat=1,
+      nPorts_bHeaWat=1,
+      nPorts_bChiWat=1,
+      nPorts_aChiWat=1),
+    redeclare CoolingIndirect ets(
+      redeclare package Medium=MediumW,
+      final mDis_flow_nominal=mDis_flow_nominal,
+      final mBui_flow_nominal=mBui_flow_nominal,
+      dp1_nominal=500,
+      dp2_nominal=500,
+      use_Q_flow_nominal=true,
+      Q_flow_nominal=-1*(sum(
+        bui.terUni.QCoo_flow_nominal)),
+      T_a1_nominal=273.15 + 5,
+      T_a2_nominal=273.15 + 12,
+      eta=0.8)
+      "Spawn building connected to the indirect cooling ETS model");
+  parameter String idfName="modelica://Buildings/Resources/Data/ThermalZones/EnergyPlus/Validation/RefBldgSmallOffice/RefBldgSmallOfficeNew2004_Chicago.idf"
     "Name of the IDF file"
-    annotation(Dialog(group="Building model parameters"));
-  parameter String weaName=
-    "modelica://Buildings/Resources/weatherdata/USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.mos"
+    annotation (Dialog(group="Building model parameters"));
+  parameter String weaName="modelica://Buildings/Resources/weatherdata/USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.mos"
     "Name of the weather file"
-    annotation(Dialog(group="Building model parameters"));
+    annotation (Dialog(group="Building model parameters"));
   parameter Modelica.SIunits.MassFlowRate mDis_flow_nominal=bui.disFloCoo.m_flow_nominal*(bui.delTBuiCoo/bui.delTDisCoo)
-   "Nominal mass flow rate of primary (district) district cooling side";
-  parameter Modelica.SIunits.MassFlowRate mBuiHea_flow_nominal= bui.disFloHea.m_flow_nominal
+    "Nominal mass flow rate of primary (district) district cooling side";
+  parameter Modelica.SIunits.MassFlowRate mBuiHea_flow_nominal=bui.disFloHea.m_flow_nominal
     "Nominal mass flow rate of secondary (building) district heating side";
-  parameter Modelica.SIunits.MassFlowRate mBui_flow_nominal= bui.disFloCoo.m_flow_nominal
+  parameter Modelica.SIunits.MassFlowRate mBui_flow_nominal=bui.disFloCoo.m_flow_nominal
     "Nominal mass flow rate of secondary (building) district cooling side";
-
   Buildings.Controls.Continuous.LimPID con(
     final controllerType=Modelica.Blocks.Types.SimpleController.PI,
     final k=1,
@@ -59,23 +56,19 @@ package MediumW = Buildings.Media.Water;
     final y_start=1,
     final reverseActing=true)
     "Controller"
-    annotation (Placement(transformation(extent={{-12,-124},{8,-104}})));
-  Modelica.Blocks.Sources.RealExpression mDis_flowSet(y=0.6)
-    annotation (Placement(transformation(extent={{-44,-124},{-24,-104}})));
-  Modelica.Blocks.Sources.RealExpression mDis_mea(y=port_a2.m_flow)
-    annotation (Placement(transformation(extent={{-44,-144},{-24,-124}})));
-
+    annotation (Placement(transformation(extent={{-12,-124}, {8,-104}})));
+  Modelica.Blocks.Sources.RealExpression mDis_flowSet(
+    y=0.6)
+    annotation (Placement(transformation(extent={{-44,-124}, {-24,-104}})));
+  Modelica.Blocks.Sources.RealExpression mDis_mea(
+    y=port_a2.m_flow)
+    annotation (Placement(transformation(extent={{-44,-144}, {-24,-124}})));
 equation
-  connect(con.y, val.y) annotation(Line(points={{9,-114},{50,-114},{50,-108}},
-                color={0,0,127}));
-  connect(con.u_s, mDis_flowSet.y) annotation (Line(points={{-14,-114},{-23,-114}},
-                color={0,0,127}));
-  connect(mDis_mea.y, con.u_m) annotation (Line(points={{-23,-134},{-2,-134},{-2,-126}},
-                color={0,0,127}));
-
-  annotation (Icon(graphics={
-                      Bitmap(extent={{-72,-62},{62,74}},
-                      fileName="modelica://Buildings/Resources/Images/ThermalZones/EnergyPlus/EnergyPlusLogo.png")}),
-                  Diagram(coordinateSystem(extent={{-100,-140},{100,100}})));
-
+  connect(con.y, val.y)
+    annotation (Line(points={{9,-114}, {50,-114}, {50,-108}}, color={0, 0, 127}));
+  connect(con.u_s, mDis_flowSet.y)
+    annotation (Line(points={{-14,-114}, {-23,-114}}, color={0, 0, 127}));
+  connect(mDis_mea.y, con.u_m)
+    annotation (Line(points={{-23,-134}, {-2,-134}, {-2,-126}}, color={0, 0, 127}));
+  annotation (Icon(graphics={Bitmap(extent={{-72,-62}, {62, 74}}, fileName="modelica://Buildings/Resources/Images/ThermalZones/EnergyPlus/EnergyPlusLogo.png")}), Diagram(coordinateSystem(extent={{-100,-140}, {100, 100}})));
 end BuildingSpawnZ6WithCoolingIndirectETS;

--- a/geojson_modelica_translator/model_connectors/templates/CentralCoolingPlant.mo
+++ b/geojson_modelica_translator/model_connectors/templates/CentralCoolingPlant.mo
@@ -1,20 +1,19 @@
 // within geojson_modelica_translator.model_connectors.templates;
 model CentralCoolingPlant
-   "Cooling plant model with two chillers"
-
-  package Medium = Buildings.Media.Water "Medium model";
-
-  parameter Integer numChi(min=1, max=2)=2 "Number of chillers, maximum is 2";
-
-  parameter Boolean show_T = true
+  "Cooling plant model with two chillers"
+  package Medium=Buildings.Media.Water
+    "Medium model";
+  parameter Integer numChi(
+    min=1,
+    max=2)=2
+    "Number of chillers, maximum is 2";
+  parameter Boolean show_T=true
     "= true, if actual temperature at port is computed"
-    annotation(Dialog(tab="Advanced",group="Diagnostics"));
-
+    annotation (Dialog(tab="Advanced", group="Diagnostics"));
   // chiller parameters
   replaceable parameter Buildings.Fluid.Chillers.Data.ElectricEIR.Generic perChi
     "Performance data of chiller"
-    annotation (Dialog(group="Chiller"), choicesAllMatching = true,
-    Placement(transformation(extent={{98,82},{112,96}})));
+    annotation (Dialog(group="Chiller"), choicesAllMatching=true, Placement(transformation(extent={{98, 82}, {112, 96}})));
   parameter Modelica.SIunits.MassFlowRate mCHW_flow_nominal
     "Nominal chilled water mass flow rate"
     annotation (Dialog(group="Chiller"));
@@ -27,7 +26,6 @@ model CentralCoolingPlant
   parameter Modelica.SIunits.MassFlowRate mMin_flow
     "Minimum mass flow rate of single chiller"
     annotation (Dialog(group="Chiller"));
-
   // cooling tower parameters
   parameter Modelica.SIunits.MassFlowRate mCW_flow_nominal
     "Nominal condenser water mass flow rate"
@@ -43,106 +41,101 @@ model CentralCoolingPlant
     annotation (Dialog(group="Cooling Tower"));
   parameter Modelica.SIunits.TemperatureDifference dT_nominal
     "Temperature difference between inlet and outlet of the tower"
-     annotation (Dialog(group="Cooling Tower"));
+    annotation (Dialog(group="Cooling Tower"));
   parameter Modelica.SIunits.Temperature TMin
     "Minimum allowed water temperature entering chiller"
     annotation (Dialog(group="Cooling Tower"));
   parameter Modelica.SIunits.Power PFan_nominal
     "Fan power"
     annotation (Dialog(group="Cooling Tower"));
-
   // pump parameters
   replaceable parameter Buildings.Fluid.Movers.Data.Generic perCHWPum
     constrainedby Buildings.Fluid.Movers.Data.Generic
     "Performance data of chilled water pump"
-    annotation (Dialog(group="Pump"),choicesAllMatching=true,
-      Placement(transformation(extent={{120,82},{134,96}})));
+    annotation (Dialog(group="Pump"), choicesAllMatching=true, Placement(transformation(extent={{120, 82}, {134, 96}})));
   replaceable parameter Buildings.Fluid.Movers.Data.Generic perCWPum
     constrainedby Buildings.Fluid.Movers.Data.Generic
     "Performance data of condenser water pump"
-    annotation (Dialog(group="Pump"),choicesAllMatching=true,
-      Placement(transformation(extent={{142,82},{156,96}})));
+    annotation (Dialog(group="Pump"), choicesAllMatching=true, Placement(transformation(extent={{142, 82}, {156, 96}})));
   parameter Modelica.SIunits.Pressure dpCHWPum_nominal
     "Nominal pressure drop of chilled water pumps"
     annotation (Dialog(group="Pump"));
   parameter Modelica.SIunits.Pressure dpCWPum_nominal
     "Nominal pressure drop of condenser water pumps"
     annotation (Dialog(group="Pump"));
-
   // control settings
-  parameter Modelica.SIunits.Time tWai "Waiting time"
+  parameter Modelica.SIunits.Time tWai
+    "Waiting time"
     annotation (Dialog(group="Control Settings"));
-  parameter Modelica.SIunits.PressureDifference dpSetPoi(displayUnit="Pa")
-   "Demand side pressure difference setpoint"
+  parameter Modelica.SIunits.PressureDifference dpSetPoi(
+    displayUnit="Pa")
+    "Demand side pressure difference setpoint"
     annotation (Dialog(group="Control Settings"));
-
   // dynamics
   parameter Modelica.Fluid.Types.Dynamics energyDynamics=Modelica.Fluid.Types.Dynamics.DynamicFreeInitial
     "Type of energy balance: dynamic (3 initialization options) or steady state"
-    annotation(Evaluate=true, Dialog(tab = "Dynamics", group="Equations"));
+    annotation (Evaluate=true, Dialog(tab="Dynamics", group="Equations"));
   parameter Modelica.Fluid.Types.Dynamics massDynamics=energyDynamics
     "Type of mass balance: dynamic (3 initialization options) or steady state"
-    annotation(Evaluate=true, Dialog(tab = "Dynamics", group="Equations"));
-
-  Medium.ThermodynamicState sta_a=
-      Medium.setState_phX(port_a.p,
-                          noEvent(actualStream(port_a.h_outflow)),
-                          noEvent(actualStream(port_a.Xi_outflow))) if
-         show_T "Medium properties in port_a";
-
-  Medium.ThermodynamicState sta_b=
-      Medium.setState_phX(port_b.p,
-                          noEvent(actualStream(port_b.h_outflow)),
-                          noEvent(actualStream(port_b.Xi_outflow))) if
-          show_T "Medium properties in port_b";
-
-  Modelica.Fluid.Interfaces.FluidPort_a port_a(redeclare package Medium = Medium)
+    annotation (Evaluate=true, Dialog(tab="Dynamics", group="Equations"));
+  Medium.ThermodynamicState sta_a=Medium.setState_phX(
+    port_a.p,
+    noEvent(
+      actualStream(
+        port_a.h_outflow)),
+    noEvent(
+      actualStream(
+        port_a.Xi_outflow))) if show_T
+    "Medium properties in port_a";
+  Medium.ThermodynamicState sta_b=Medium.setState_phX(
+    port_b.p,
+    noEvent(
+      actualStream(
+        port_b.h_outflow)),
+    noEvent(
+      actualStream(
+        port_b.Xi_outflow))) if show_T
+    "Medium properties in port_b";
+  Modelica.Fluid.Interfaces.FluidPort_a port_a(
+    redeclare package Medium=Medium)
     "Fluid connector a (positive design flow direction is from port_a to port_b)"
-    annotation (Placement(transformation(extent={{150,40},{170,60}}),
-        iconTransformation(extent={{90,40},{110,60}})));
-
-  Modelica.Fluid.Interfaces.FluidPort_b port_b(redeclare package Medium = Medium)
+    annotation (Placement(transformation(extent={{150, 40}, {170, 60}}), iconTransformation(extent={{90, 40}, {110, 60}})));
+  Modelica.Fluid.Interfaces.FluidPort_b port_b(
+    redeclare package Medium=Medium)
     "Fluid connector b (positive design flow direction is from port_a to port_b)"
-    annotation (Placement(transformation(extent={{150,-60},{170,-40}}),
-        iconTransformation(extent={{90,-60},{110,-40}})));
-
-  Modelica.Blocks.Interfaces.BooleanInput on "On signal of the plant"
-    annotation (Placement(transformation(extent={{-180,40},{-140,80}}),
-        iconTransformation(extent={{-140,60},{-100,100}})));
-
+    annotation (Placement(transformation(extent={{150,-60}, {170,-40}}), iconTransformation(extent={{90,-60}, {110,-40}})));
+  Modelica.Blocks.Interfaces.BooleanInput on
+    "On signal of the plant"
+    annotation (Placement(transformation(extent={{-180, 40}, {-140, 80}}), iconTransformation(extent={{-140, 60}, {-100, 100}})));
   Modelica.Blocks.Interfaces.RealInput TCHWSupSet(
     final unit="K",
     displayUnit="degC")
     "Set point for chilled water supply temperature"
-    annotation (Placement(transformation(extent={{-180,0},{-140,40}}),
-        iconTransformation(extent={{-140,10},{-100,50}})));
-
+    annotation (Placement(transformation(extent={{-180, 0}, {-140, 40}}), iconTransformation(extent={{-140, 10}, {-100, 50}})));
   Modelica.Blocks.Interfaces.RealInput TWetBul(
     final unit="K",
     displayUnit="degC")
     "Entering air wetbulb temperature"
-    annotation (Placement(transformation(extent={{-180,-80},{-140,-40}}),
-        iconTransformation(extent={{-140,-100},{-100,-60}})));
-
+    annotation (Placement(transformation(extent={{-180,-80}, {-140,-40}}), iconTransformation(extent={{-140,-100}, {-100,-60}})));
   Modelica.Blocks.Interfaces.RealInput dpMea(
     final unit="Pa")
     "Measured pressure difference"
-    annotation (Placement(transformation(extent={{-180,-40},{-140,0}}),
-        iconTransformation(extent={{-140,-50},{-100,-10}})));
-
+    annotation (Placement(transformation(extent={{-180,-40}, {-140, 0}}), iconTransformation(extent={{-140,-50}, {-100,-10}})));
   Buildings.Applications.DataCenters.ChillerCooled.Equipment.ElectricChillerParallel mulChiSys(
-    per=fill(perChi, numChi),
+    per=fill(
+      perChi,
+      numChi),
     m1_flow_nominal=mCHW_flow_nominal,
     m2_flow_nominal=mCW_flow_nominal,
     dp1_nominal=dpCHW_nominal,
     dp2_nominal=dpCW_nominal,
     num=numChi,
     redeclare package Medium1=Medium,
-    redeclare package Medium2=Medium) "Chillers connected in parallel"
-    annotation (Placement(transformation(extent={{10,20},{-10,0}})));
-
+    redeclare package Medium2=Medium)
+    "Chillers connected in parallel"
+    annotation (Placement(transformation(extent={{10, 20}, {-10, 0}})));
   CoolingTowerWithBypass cooTowWitByp(
-    redeclare package Medium = Medium,
+    redeclare package Medium=Medium,
     num=numChi,
     m_flow_nominal=mCW_flow_nominal,
     dp_nominal=dpCW_nominal,
@@ -150,205 +143,196 @@ model CentralCoolingPlant
     TWatIn_nominal=TCW_nominal,
     dT_nominal=dT_nominal,
     PFan_nominal=PFan_nominal,
-    TMin=TMin) "Cooling towers with bypass valve"
-    annotation (Placement(transformation(extent={{-60,-60},{-40,-40}})));
-
+    TMin=TMin)
+    "Cooling towers with bypass valve"
+    annotation (Placement(transformation(extent={{-60,-60}, {-40,-40}})));
   Buildings.Applications.DataCenters.ChillerCooled.Equipment.FlowMachine_y pumCHW(
-    redeclare package Medium = Medium,
-    per=fill(perCHWPum, numChi),
+    redeclare package Medium=Medium,
+    per=fill(
+      perCHWPum,
+      numChi),
     energyDynamics=energyDynamics,
     m_flow_nominal=mCHW_flow_nominal,
     dpValve_nominal=dpCHWPum_nominal,
-    num=numChi) "Chilled water pumps"
-    annotation (Placement(transformation(extent={{10,40},{-10,60}})));
-
+    num=numChi)
+    "Chilled water pumps"
+    annotation (Placement(transformation(extent={{10, 40}, {-10, 60}})));
   Buildings.Applications.DataCenters.ChillerCooled.Equipment.FlowMachine_m pumCW(
-    redeclare package Medium = Medium,
-    per=fill(perCWPum, numChi),
+    redeclare package Medium=Medium,
+    per=fill(
+      perCWPum,
+      numChi),
     energyDynamics=energyDynamics,
     m_flow_nominal=mCW_flow_nominal,
     dpValve_nominal=dpCWPum_nominal,
-    num=numChi) "Condenser water pumps"
-    annotation (Placement(transformation(extent={{-10,-60},{10,-40}})));
-
+    num=numChi)
+    "Condenser water pumps"
+    annotation (Placement(transformation(extent={{-10,-60}, {10,-40}})));
   Buildings.Fluid.Actuators.Valves.TwoWayEqualPercentage valByp(
-    redeclare package Medium = Medium,
+    redeclare package Medium=Medium,
     allowFlowReversal=false,
     m_flow_nominal=mCHW_flow_nominal*0.05,
-    dpValve_nominal=dpCHW_nominal) "Chilled water bypass valve"
-    annotation (Placement(transformation(
-        extent={{-10,10},{10,-10}},
-        rotation=90,
-        origin={80,0})));
-
+    dpValve_nominal=dpCHW_nominal)
+    "Chilled water bypass valve"
+    annotation (Placement(transformation(extent={{-10, 10}, {10,-10}}, rotation=90, origin={80, 0})));
   Buildings.Fluid.Sensors.MassFlowRate senMasFloByp(
-    redeclare package Medium = Medium)
+    redeclare package Medium=Medium)
     "Chilled water bypass valve mass flow meter"
-    annotation (Placement(transformation(
-        extent={{10,-10},{-10,10}},
-        rotation=-90,
-        origin={80,-30})));
-
+    annotation (Placement(transformation(extent={{10,-10}, {-10, 10}}, rotation=-90, origin={80,-30})));
   Buildings.Fluid.Sensors.TemperatureTwoPort senTCHWSup(
-    redeclare package Medium = Medium,
-    m_flow_nominal=mCHW_flow_nominal) "Chilled water supply temperature"
-    annotation (Placement(transformation(
-        extent={{-10,-10},{10,10}},
-        rotation=0,
-        origin={130,-50})));
-
-  ChilledWaterPumpSpeed
-    CHWPumCon(
+    redeclare package Medium=Medium,
+    m_flow_nominal=mCHW_flow_nominal)
+    "Chilled water supply temperature"
+    annotation (Placement(transformation(extent={{-10,-10}, {10, 10}}, rotation=0, origin={130,-50})));
+  ChilledWaterPumpSpeed CHWPumCon(
     tWai=tWai,
     m_flow_nominal=mCHW_flow_nominal,
     dpSetPoi=dpSetPoi,
-    controllerType=Modelica.Blocks.Types.SimpleController.PI) "Chilled water pump controller"
-    annotation (Placement(transformation(extent={{-120,-26},{-100,-6}})));
-
+    controllerType=Modelica.Blocks.Types.SimpleController.PI)
+    "Chilled water pump controller"
+    annotation (Placement(transformation(extent={{-120,-26}, {-100,-6}})));
   ChillerStage chiStaCon(
     tWai=tWai,
-    QEva_nominal=QEva_nominal) "Chiller staging controller"
-    annotation (Placement(transformation(extent={{-120,46},{-100,66}})));
-
+    QEva_nominal=QEva_nominal)
+    "Chiller staging controller"
+    annotation (Placement(transformation(extent={{-120, 46}, {-100, 66}})));
   Modelica.Blocks.Math.RealToBoolean chiOn[numChi]
     "Real value to boolean value"
-    annotation (Placement(transformation(extent={{-80,50},{-60,70}})));
-
-  Modelica.Blocks.Sources.RealExpression mPum_flow(y=pumCHW.port_a.m_flow)
+    annotation (Placement(transformation(extent={{-80, 50}, {-60, 70}})));
+  Modelica.Blocks.Sources.RealExpression mPum_flow(
+    y=pumCHW.port_a.m_flow)
     "Total chilled water pump mass flow rate"
-    annotation (Placement(transformation(extent={{-100,-2},{-120,18}})));
-
-  Modelica.Blocks.Sources.RealExpression mValByp_flow(y=valByp.port_a.m_flow/(
-        if chiOn[numChi].y then numChi*mMin_flow else mMin_flow))
+    annotation (Placement(transformation(extent={{-100,-2}, {-120, 18}})));
+  Modelica.Blocks.Sources.RealExpression mValByp_flow(
+    y=valByp.port_a.m_flow/(
+      if chiOn[numChi].y then
+        numChi*mMin_flow
+      else
+        mMin_flow))
     "Chilled water bypass valve mass flow rate"
-    annotation (Placement(transformation(extent={{160,-40},{140,-20}})));
-
+    annotation (Placement(transformation(extent={{160,-40}, {140,-20}})));
   Buildings.Controls.Continuous.LimPID bypValCon(
     controllerType=Modelica.Blocks.Types.SimpleController.PI,
     k=1,
     Ti=60,
     reset=Buildings.Types.Reset.Parameter,
     y_reset=0)
-           "Chilled water bypass valve controller"
-    annotation (Placement(transformation(extent={{140,-10},{120,10}})));
-  Buildings.Fluid.Sensors.TemperatureTwoPort senTCHWRet(redeclare package Medium = Medium,
-      m_flow_nominal=mCHW_flow_nominal) "Chilled water return temperature"
-    annotation (Placement(transformation(
-        extent={{10,-10},{-10,10}},
-        rotation=0,
-        origin={130,50})));
-  Modelica.Blocks.Math.Add dT(final k1=-1, final k2=+1)
+    "Chilled water bypass valve controller"
+    annotation (Placement(transformation(extent={{140,-10}, {120, 10}})));
+  Buildings.Fluid.Sensors.TemperatureTwoPort senTCHWRet(
+    redeclare package Medium=Medium,
+    m_flow_nominal=mCHW_flow_nominal)
+    "Chilled water return temperature"
+    annotation (Placement(transformation(extent={{10,-10}, {-10, 10}}, rotation=0, origin={130, 50})));
+  Modelica.Blocks.Math.Add dT(
+    final k1=-1,
+    final k2=+ 1)
     "Temperature difference"
-    annotation (Placement(transformation(extent={{80,70},{60,90}})));
+    annotation (Placement(transformation(extent={{80, 70}, {60, 90}})));
   Modelica.Blocks.Math.Product pro
     "Product"
-    annotation (Placement(transformation(extent={{40,70},{20,90}})));
-  Modelica.Blocks.Math.Gain cp(final k=cp_default)
+    annotation (Placement(transformation(extent={{40, 70}, {20, 90}})));
+  Modelica.Blocks.Math.Gain cp(
+    final k=cp_default)
     "Specific heat multiplier to calculate heat flow rate"
-    annotation (Placement(transformation(extent={{0,70},{-20,90}})));
-
-  Buildings.Fluid.Sources.Boundary_pT expTanCW(redeclare package Medium = Medium,
-    nPorts=1) "Condenser water expansion tank"
-    annotation (Placement(transformation(extent={{-50,-30},{-30,-10}})));
-
-  Buildings.Fluid.Sources.Boundary_pT expTanCHW(redeclare package Medium = Medium,
-      nPorts=1) "Chilled water expansion tank"
-    annotation (Placement(transformation(extent={{50,20},{70,40}})));
-
-  Buildings.Fluid.Sensors.MassFlowRate senMasFlo(redeclare package Medium = Medium)
+    annotation (Placement(transformation(extent={{0, 70}, {-20, 90}})));
+  Buildings.Fluid.Sources.Boundary_pT expTanCW(
+    redeclare package Medium=Medium,
+    nPorts=1)
+    "Condenser water expansion tank"
+    annotation (Placement(transformation(extent={{-50,-30}, {-30,-10}})));
+  Buildings.Fluid.Sources.Boundary_pT expTanCHW(
+    redeclare package Medium=Medium,
+    nPorts=1)
+    "Chilled water expansion tank"
+    annotation (Placement(transformation(extent={{50, 20}, {70, 40}})));
+  Buildings.Fluid.Sensors.MassFlowRate senMasFlo(
+    redeclare package Medium=Medium)
     "Chilled water return mass flow"
-    annotation (Placement(transformation(extent={{50,40},{30,60}})));
-
-  Modelica.Blocks.Sources.Constant mSetSca_flow(k=1)
+    annotation (Placement(transformation(extent={{50, 40}, {30, 60}})));
+  Modelica.Blocks.Sources.Constant mSetSca_flow(
+    k=1)
     "Scaled bypass valve mass flow setpoint"
-    annotation (Placement(transformation(extent={{90,10},{110,30}})));
+    annotation (Placement(transformation(extent={{90, 10}, {110, 30}})));
 protected
-  final parameter Medium.ThermodynamicState sta_default = Medium.setState_pTX(
+  final parameter Medium.ThermodynamicState sta_default=Medium.setState_pTX(
     T=Medium.T_default,
     p=Medium.p_default,
-    X=Medium.X_default) "Medium state at default properties";
-  final parameter Modelica.SIunits.SpecificHeatCapacity cp_default=
-    Medium.specificHeatCapacityCp(sta_default)
+    X=Medium.X_default)
+    "Medium state at default properties";
+  final parameter Modelica.SIunits.SpecificHeatCapacity cp_default=Medium.specificHeatCapacityCp(
+    sta_default)
     "Specific heat capacity of the fluid";
-
 equation
-
-  connect(senTCHWSup.port_b, port_b) annotation (Line(
-      points={{140,-50},{160,-50}},
-      color={0,127,255}));
-  connect(senMasFloByp.port_b, valByp.port_a) annotation (Line(
-      points={{80,-20},{80,-10}},
-      color={0,127,255}));
-  connect(senMasFloByp.port_a, senTCHWSup.port_a) annotation (Line(points={{80,-40},
-          {80,-50},{120,-50}},                                                                           color={0,127,255}));
-  connect(cooTowWitByp.port_b, pumCW.port_a) annotation (Line(points={{-40,-50},{-10,-50}}, color={0,127,255}));
-  connect(on, chiStaCon.on) annotation (Line(points={{-160,60},{-122,60}},
-                      color={255,0,255}));
-  connect(chiStaCon.y, cooTowWitByp.on) annotation (Line(points={{-99,56},{-90,
-          56},{-90,-46},{-62,-46}},
-                                color={0,0,127}));
-  connect(chiStaCon.y, pumCW.u) annotation (Line(points={{-99,56},{-90,56},{-90,
-          -38},{-20,-38},{-20,-46},{-12,-46}}, color={0,0,127}));
-  connect(TWetBul, cooTowWitByp.TWetBul) annotation (Line(points={{-160,-60},{
-          -90,-60},{-90,-52},{-62,-52}},
-                                     color={0,0,127}));
-  connect(chiStaCon.y, chiOn.u) annotation (Line(points={{-99,56},{-90,56},{-90,60},{-82,60}},
-                                                 color={0,0,127}));
-  connect(CHWPumCon.dpMea, dpMea) annotation (Line(points={{-122,-20},{-160,-20}}, color={0,0,127}));
-  connect(mPum_flow.y, CHWPumCon.masFloPum) annotation (Line(points={{-121,8},
-          {-132,8},{-132,-12},{-122,-12}}, color={0,0,127}));
-  connect(CHWPumCon.y, pumCHW.u) annotation (Line(points={{-99,-16},{-80,-16},{-80,
-          8},{-40,8},{-40,60},{20,60},{20,54},{12,54}},      color={0,0,127}));
-  connect(bypValCon.y, valByp.y) annotation (Line(points={{119,0},{92,0}},color={0,0,127}));
-  connect(mValByp_flow.y, bypValCon.u_m) annotation (Line(points={{139,-30},{
-          130,-30},{130,-12}},                                                                    color={0,0,127}));
-  connect(port_a, senTCHWRet.port_a) annotation (Line(points={{160,50},{140,50}}, color={0,127,255}));
-  connect(senTCHWSup.T, dT.u2) annotation (Line(points={{130,-39},{130,-32},{116,
-          -32},{116,74},{82,74}},color={0,0,127}));
-  connect(senTCHWRet.T, dT.u1) annotation (Line(points={{130,61},{130,78},{88,78},
-          {88,86},{82,86}}, color={0,0,127}));
-  connect(dT.y, pro.u1) annotation (Line(points={{59,80},{54,80},{54,86},{42,86}},
-        color={0,0,127}));
-  connect(cp.u, pro.y) annotation (Line(points={{2,80},{19,80}}, color={0,0,127}));
-  connect(cp.y, chiStaCon.QLoa) annotation (Line(points={{-21,80},{-130,80},{-130,
-          52},{-122,52}}, color={0,0,127}));
-  connect(pumCHW.port_b, mulChiSys.port_a2) annotation (Line(points={{-10,50},{-20,
-          50},{-20,16},{-10,16}}, color={0,127,255}));
-  connect(mulChiSys.port_b2, senTCHWSup.port_a) annotation (Line(points={{10,16},
-          {32,16},{32,-50},{120,-50}}, color={0,127,255}));
-  connect(pumCW.port_b, mulChiSys.port_a1) annotation (Line(points={{10,-50},{20,
-          -50},{20,4},{10,4}}, color={0,127,255}));
-  connect(mulChiSys.port_b1, cooTowWitByp.port_a) annotation (Line(points={{-10,
-          4},{-70,4},{-70,-50},{-60,-50}}, color={0,127,255}));
-  connect(chiOn.y, mulChiSys.on) annotation (Line(points={{-59,60},{-48,60},{-48,
-          32},{22,32},{22,6},{12,6}}, color={255,0,255}));
-  connect(expTanCW.ports[1], pumCW.port_a) annotation (Line(points={{-30,-20},{-26,
-          -20},{-26,-50},{-10,-50}}, color={0,127,255}));
+  connect(senTCHWSup.port_b, port_b)
+    annotation (Line(points={{140,-50}, {160,-50}}, color={0, 127, 255}));
+  connect(senMasFloByp.port_b, valByp.port_a)
+    annotation (Line(points={{80,-20}, {80,-10}}, color={0, 127, 255}));
+  connect(senMasFloByp.port_a, senTCHWSup.port_a)
+    annotation (Line(points={{80,-40}, {80,-50}, {120,-50}}, color={0, 127, 255}));
+  connect(cooTowWitByp.port_b, pumCW.port_a)
+    annotation (Line(points={{-40,-50}, {-10,-50}}, color={0, 127, 255}));
+  connect(on, chiStaCon.on)
+    annotation (Line(points={{-160, 60}, {-122, 60}}, color={255, 0, 255}));
+  connect(chiStaCon.y, cooTowWitByp.on)
+    annotation (Line(points={{-99, 56}, {-90, 56}, {-90,-46}, {-62,-46}}, color={0, 0, 127}));
+  connect(chiStaCon.y, pumCW.u)
+    annotation (Line(points={{-99, 56}, {-90, 56}, {-90,-38}, {-20,-38}, {-20,-46}, {-12,-46}}, color={0, 0, 127}));
+  connect(TWetBul, cooTowWitByp.TWetBul)
+    annotation (Line(points={{-160,-60}, {-90,-60}, {-90,-52}, {-62,-52}}, color={0, 0, 127}));
+  connect(chiStaCon.y, chiOn.u)
+    annotation (Line(points={{-99, 56}, {-90, 56}, {-90, 60}, {-82, 60}}, color={0, 0, 127}));
+  connect(CHWPumCon.dpMea, dpMea)
+    annotation (Line(points={{-122,-20}, {-160,-20}}, color={0, 0, 127}));
+  connect(mPum_flow.y, CHWPumCon.masFloPum)
+    annotation (Line(points={{-121, 8}, {-132, 8}, {-132,-12}, {-122,-12}}, color={0, 0, 127}));
+  connect(CHWPumCon.y, pumCHW.u)
+    annotation (Line(points={{-99,-16}, {-80,-16}, {-80, 8}, {-40, 8}, {-40, 60}, {20, 60}, {20, 54}, {12, 54}}, color={0, 0, 127}));
+  connect(bypValCon.y, valByp.y)
+    annotation (Line(points={{119, 0}, {92, 0}}, color={0, 0, 127}));
+  connect(mValByp_flow.y, bypValCon.u_m)
+    annotation (Line(points={{139,-30}, {130,-30}, {130,-12}}, color={0, 0, 127}));
+  connect(port_a, senTCHWRet.port_a)
+    annotation (Line(points={{160, 50}, {140, 50}}, color={0, 127, 255}));
+  connect(senTCHWSup.T, dT.u2)
+    annotation (Line(points={{130,-39}, {130,-32}, {116,-32}, {116, 74}, {82, 74}}, color={0, 0, 127}));
+  connect(senTCHWRet.T, dT.u1)
+    annotation (Line(points={{130, 61}, {130, 78}, {88, 78}, {88, 86}, {82, 86}}, color={0, 0, 127}));
+  connect(dT.y, pro.u1)
+    annotation (Line(points={{59, 80}, {54, 80}, {54, 86}, {42, 86}}, color={0, 0, 127}));
+  connect(cp.u, pro.y)
+    annotation (Line(points={{2, 80}, {19, 80}}, color={0, 0, 127}));
+  connect(cp.y, chiStaCon.QLoa)
+    annotation (Line(points={{-21, 80}, {-130, 80}, {-130, 52}, {-122, 52}}, color={0, 0, 127}));
+  connect(pumCHW.port_b, mulChiSys.port_a2)
+    annotation (Line(points={{-10, 50}, {-20, 50}, {-20, 16}, {-10, 16}}, color={0, 127, 255}));
+  connect(mulChiSys.port_b2, senTCHWSup.port_a)
+    annotation (Line(points={{10, 16}, {32, 16}, {32,-50}, {120,-50}}, color={0, 127, 255}));
+  connect(pumCW.port_b, mulChiSys.port_a1)
+    annotation (Line(points={{10,-50}, {20,-50}, {20, 4}, {10, 4}}, color={0, 127, 255}));
+  connect(mulChiSys.port_b1, cooTowWitByp.port_a)
+    annotation (Line(points={{-10, 4}, {-70, 4}, {-70,-50}, {-60,-50}}, color={0, 127, 255}));
+  connect(chiOn.y, mulChiSys.on)
+    annotation (Line(points={{-59, 60}, {-48, 60}, {-48, 32}, {22, 32}, {22, 6}, {12, 6}}, color={255, 0, 255}));
+  connect(expTanCW.ports[1], pumCW.port_a)
+    annotation (Line(points={{-30,-20}, {-26,-20}, {-26,-50}, {-10,-50}}, color={0, 127, 255}));
   connect(senTCHWRet.port_b, senMasFlo.port_a)
-    annotation (Line(points={{120,50},{50,50}}, color={0,127,255}));
+    annotation (Line(points={{120, 50}, {50, 50}}, color={0, 127, 255}));
   connect(pumCHW.port_a, senMasFlo.port_b)
-    annotation (Line(points={{10,50},{30,50}}, color={0,127,255}));
-  connect(senMasFlo.m_flow, pro.u2) annotation (Line(points={{40,61},{40,66},{54,
-          66},{54,74},{42,74}}, color={0,0,127}));
-  connect(expTanCHW.ports[1], senMasFlo.port_a) annotation (Line(points={{70,30},
-          {80,30},{80,50},{50,50}}, color={0,127,255}));
+    annotation (Line(points={{10, 50}, {30, 50}}, color={0, 127, 255}));
+  connect(senMasFlo.m_flow, pro.u2)
+    annotation (Line(points={{40, 61}, {40, 66}, {54, 66}, {54, 74}, {42, 74}}, color={0, 0, 127}));
+  connect(expTanCHW.ports[1], senMasFlo.port_a)
+    annotation (Line(points={{70, 30}, {80, 30}, {80, 50}, {50, 50}}, color={0, 127, 255}));
   connect(valByp.port_b, senMasFlo.port_a)
-    annotation (Line(points={{80,10},{80,50},{50,50}}, color={0,127,255}));
-  connect(mulChiSys.TSet, TCHWSupSet) annotation (Line(points={{12,10},{20,10},
-          {20,20},{-160,20}},color={0,0,127}));
-  connect(chiOn[1].y, bypValCon.trigger) annotation (Line(points={{-59,60},{-48,
-          60},{-48,32},{40,32},{40,-16},{138,-16},{138,-12}}, color={255,0,255}));
-  connect(mSetSca_flow.y, bypValCon.u_s) annotation (Line(points={{111,20},{150,
-          20},{150,0},{142,0}}, color={0,0,127}));
-  annotation (__Dymola_Commands,
-  Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-140,-80},{160,100}})),
-    experiment(
-      StartTime=1.728e+007,
-      StopTime=1.73664e+007,
-      __Dymola_NumberOfIntervals=1440,
-      __Dymola_Algorithm="Dassl"),
-    __Dymola_experimentSetupOutput,
-    Documentation(info="<html>
+    annotation (Line(points={{80, 10}, {80, 50}, {50, 50}}, color={0, 127, 255}));
+  connect(mulChiSys.TSet, TCHWSupSet)
+    annotation (Line(points={{12, 10}, {20, 10}, {20, 20}, {-160, 20}}, color={0, 0, 127}));
+  connect(chiOn[1].y, bypValCon.trigger)
+    annotation (Line(points={{-59, 60}, {-48, 60}, {-48, 32}, {40, 32}, {40,-16}, {138,-16}, {138,-12}}, color={255, 0, 255}));
+  connect(mSetSca_flow.y, bypValCon.u_s)
+    annotation (Line(points={{111, 20}, {150, 20}, {150, 0}, {142, 0}}, color={0, 0, 127}));
+  annotation (__Dymola_Commands, Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-140,-80}, {160, 100}})), experiment(StartTime=1.728e+007, StopTime=1.73664e+007, __Dymola_NumberOfIntervals=1440, __Dymola_Algorithm="Dassl"), __Dymola_experimentSetupOutput, Documentation(info="<html>
 <p>The schematic drawing of the Lejeune plant is shown as folowing.</p>
 <p><img src=\"Resources/Images/lejeunePlant/lejeune_schematic_drawing.jpg\" alt=\"image\"/> </p>
 <p>In addition, the parameters are listed as below.</p>
@@ -361,86 +345,5 @@ equation
 <p><img src=\"Resources/Images/lejeunePlant/SecCHWPum2.png\" alt=\"image\"/> </p>
 <p>The parameters for the condenser water pump.</p>
 <p><img src=\"Resources/Images/lejeunePlant/CWPum.png\" alt=\"image\"/> </p>
-</html>"),
-    Icon(coordinateSystem(extent={{-100,-100},{100,100}}),    graphics={
-                                Rectangle(
-        extent={{-100,-100},{100,100}},
-        lineColor={0,0,127},
-        fillColor={255,255,255},
-        fillPattern=FillPattern.Solid),
-        Polygon(
-          points={{-62,-14},{-62,-14}},
-          lineColor={238,46,47},
-          fillColor={255,255,255},
-          fillPattern=FillPattern.Solid),
-        Polygon(
-          points={{80,-60},{-80,-60},{-80,60},{-60,60},{-60,0},{-40,0},{-40,20},
-              {0,0},{0,20},{40,0},{40,20},{80,0},{80,-60}},
-          lineColor={95,95,95},
-          fillColor={28,108,200},
-          fillPattern=FillPattern.Solid),
-      Rectangle(
-        extent={{46,-38},{58,-26}},
-        lineColor={255,255,255},
-        fillColor={255,255,255},
-        fillPattern=FillPattern.Solid),
-      Rectangle(
-        extent={{62,-38},{74,-26}},
-        lineColor={255,255,255},
-        fillColor={255,255,255},
-        fillPattern=FillPattern.Solid),
-      Rectangle(
-        extent={{62,-54},{74,-42}},
-        lineColor={255,255,255},
-        fillColor={255,255,255},
-        fillPattern=FillPattern.Solid),
-      Rectangle(
-        extent={{46,-54},{58,-42}},
-        lineColor={255,255,255},
-        fillColor={255,255,255},
-        fillPattern=FillPattern.Solid),
-      Rectangle(
-        extent={{22,-54},{34,-42}},
-        lineColor={255,255,255},
-        fillColor={255,255,255},
-        fillPattern=FillPattern.Solid),
-      Rectangle(
-        extent={{6,-54},{18,-42}},
-        lineColor={255,255,255},
-        fillColor={255,255,255},
-        fillPattern=FillPattern.Solid),
-      Rectangle(
-        extent={{6,-38},{18,-26}},
-        lineColor={255,255,255},
-        fillColor={255,255,255},
-        fillPattern=FillPattern.Solid),
-      Rectangle(
-        extent={{22,-38},{34,-26}},
-        lineColor={255,255,255},
-        fillColor={255,255,255},
-        fillPattern=FillPattern.Solid),
-      Rectangle(
-        extent={{-18,-54},{-6,-42}},
-        lineColor={255,255,255},
-        fillColor={255,255,255},
-        fillPattern=FillPattern.Solid),
-      Rectangle(
-        extent={{-34,-54},{-22,-42}},
-        lineColor={255,255,255},
-        fillColor={255,255,255},
-        fillPattern=FillPattern.Solid),
-      Rectangle(
-        extent={{-34,-38},{-22,-26}},
-        lineColor={255,255,255},
-        fillColor={255,255,255},
-        fillPattern=FillPattern.Solid),
-      Rectangle(
-        extent={{-18,-38},{-6,-26}},
-        lineColor={255,255,255},
-        fillColor={255,255,255},
-        fillPattern=FillPattern.Solid),
-        Text(
-          extent={{-149,-114},{151,-154}},
-          lineColor={0,0,255},
-          textString="%name")}));
+</html>"), Icon(coordinateSystem(extent={{-100,-100}, {100, 100}}), graphics={Rectangle(extent={{-100,-100}, {100, 100}}, lineColor={0, 0, 127}, fillColor={255, 255, 255}, fillPattern=FillPattern.Solid), Polygon(points={{-62,-14}, {-62,-14}}, lineColor={238, 46, 47}, fillColor={255, 255, 255}, fillPattern=FillPattern.Solid), Polygon(points={{80,-60}, {-80,-60}, {-80, 60}, {-60, 60}, {-60, 0}, {-40, 0}, {-40, 20}, {0, 0}, {0, 20}, {40, 0}, {40, 20}, {80, 0}, {80,-60}}, lineColor={95, 95, 95}, fillColor={28, 108, 200}, fillPattern=FillPattern.Solid), Rectangle(extent={{46,-38}, {58,-26}}, lineColor={255, 255, 255}, fillColor={255, 255, 255}, fillPattern=FillPattern.Solid), Rectangle(extent={{62,-38}, {74,-26}}, lineColor={255, 255, 255}, fillColor={255, 255, 255}, fillPattern=FillPattern.Solid), Rectangle(extent={{62,-54}, {74,-42}}, lineColor={255, 255, 255}, fillColor={255, 255, 255}, fillPattern=FillPattern.Solid), Rectangle(extent={{46,-54}, {58,-42}}, lineColor={255, 255, 255}, fillColor={255, 255, 255}, fillPattern=FillPattern.Solid), Rectangle(extent={{22,-54}, {34,-42}}, lineColor={255, 255, 255}, fillColor={255, 255, 255}, fillPattern=FillPattern.Solid), Rectangle(extent={{6,-54}, {18,-42}}, lineColor={255, 255, 255}, fillColor={255, 255, 255}, fillPattern=FillPattern.Solid), Rectangle(extent={{6,-38}, {18,-26}}, lineColor={255, 255, 255}, fillColor={255, 255, 255}, fillPattern=FillPattern.Solid), Rectangle(extent={{22,-38}, {34,-26}}, lineColor={255, 255, 255}, fillColor={255, 255, 255}, fillPattern=FillPattern.Solid), Rectangle(extent={{-18,-54}, {-6,-42}}, lineColor={255, 255, 255}, fillColor={255, 255, 255}, fillPattern=FillPattern.Solid), Rectangle(extent={{-34,-54}, {-22,-42}}, lineColor={255, 255, 255}, fillColor={255, 255, 255}, fillPattern=FillPattern.Solid), Rectangle(extent={{-34,-38}, {-22,-26}}, lineColor={255, 255, 255}, fillColor={255, 255, 255}, fillPattern=FillPattern.Solid), Rectangle(extent={{-18,-38}, {-6,-26}}, lineColor={255, 255, 255}, fillColor={255, 255, 255}, fillPattern=FillPattern.Solid), Text(extent={{-149,-114}, {151,-154}}, lineColor={0, 0, 255}, textString="%name")}));
 end CentralCoolingPlant;

--- a/geojson_modelica_translator/model_connectors/templates/ChilledWaterPumpSpeed.mo
+++ b/geojson_modelica_translator/model_connectors/templates/ChilledWaterPumpSpeed.mo
@@ -1,96 +1,92 @@
 //within geojson_modelica_translator.model_connectors.templates;
 model ChilledWaterPumpSpeed
-    "Controller for variable speed chilled water pumps"
-
-  parameter Integer numPum(min=1, max=2)=2 "Number of chilled water pumps, maximum is 2";
-
-  parameter Modelica.SIunits.PressureDifference dpSetPoi(displayUnit="Pa")
+  "Controller for variable speed chilled water pumps"
+  parameter Integer numPum(
+    min=1,
+    max=2)=2
+    "Number of chilled water pumps, maximum is 2";
+  parameter Modelica.SIunits.PressureDifference dpSetPoi(
+    displayUnit="Pa")
     "Pressure difference setpoint";
-
-  parameter Modelica.SIunits.Time tWai "Waiting time";
-
+  parameter Modelica.SIunits.Time tWai
+    "Waiting time";
   parameter Modelica.SIunits.MassFlowRate m_flow_nominal
     "Nominal mass flow rate of single chilled water pump";
-
-  parameter Real minSpe(unit="1",min=0,max=1) = 0.05
+  parameter Real minSpe(
+    unit="1",
+    min=0,
+    max=1)=0.05
     "Minimum speed ratio required by chilled water pumps";
-
-  parameter Modelica.Blocks.Types.SimpleController controllerType=
-    Modelica.Blocks.Types.SimpleController.PID
+  parameter Modelica.Blocks.Types.SimpleController controllerType=Modelica.Blocks.Types.SimpleController.PID
     "Type of pump speed controller";
-
-  parameter Real k(unit="1", min=0) = 1 "Gain of controller";
-
-  parameter Modelica.SIunits.Time Ti(min=Modelica.Constants.small)=60
-    "Time constant of Integrator block" annotation (Dialog(enable=
-          controllerType == Modelica.Blocks.Types.SimpleController.PI or
-          controllerType == Modelica.Blocks.Types.SimpleController.PID));
-  parameter Modelica.SIunits.Time Td(min=0)=0.1
-    "Time constant of Derivative block" annotation (Dialog(enable=
-          controllerType == Modelica.Blocks.Types.SimpleController.PD or
-          controllerType == Modelica.Blocks.Types.SimpleController.PID));
+  parameter Real k(
+    unit="1",
+    min=0)=1
+    "Gain of controller";
+  parameter Modelica.SIunits.Time Ti(
+    min=Modelica.Constants.small)=60
+    "Time constant of Integrator block"
+    annotation (Dialog(enable=controllerType == Modelica.Blocks.Types.SimpleController.PI or controllerType == Modelica.Blocks.Types.SimpleController.PID));
+  parameter Modelica.SIunits.Time Td(
+    min=0)=0.1
+    "Time constant of Derivative block"
+    annotation (Dialog(enable=controllerType == Modelica.Blocks.Types.SimpleController.PD or controllerType == Modelica.Blocks.Types.SimpleController.PID));
   Modelica.Blocks.Interfaces.RealInput masFloPum(
     final unit="kg/s")
     "Total mass flowrate of chilled water pumps"
-    annotation (Placement(transformation(extent={{-140,20},{-100,60}})));
-
+    annotation (Placement(transformation(extent={{-140, 20}, {-100, 60}})));
   Modelica.Blocks.Interfaces.RealInput dpMea(
     final unit="Pa")
     "Measured pressure difference"
-    annotation (Placement(transformation(extent={{-140,-60},{-100,-20}})));
-
+    annotation (Placement(transformation(extent={{-140,-60}, {-100,-20}})));
   Modelica.Blocks.Interfaces.RealOutput y[numPum](
-    unit="1",min=0,max=1) "Pump speed signal"
-    annotation (Placement(transformation(extent={{100,-10},{120,10}})));
-
-  Modelica.Blocks.Math.Product pumSpe[numPum] "Output pump speed"
-    annotation (Placement(transformation(extent={{40,-10},{60,10}})));
-
+    unit="1",
+    min=0,
+    max=1)
+    "Pump speed signal"
+    annotation (Placement(transformation(extent={{100,-10}, {120, 10}})));
+  Modelica.Blocks.Math.Product pumSpe[numPum]
+    "Output pump speed"
+    annotation (Placement(transformation(extent={{40,-10}, {60, 10}})));
   Buildings.Applications.DataCenters.ChillerCooled.Controls.VariableSpeedPumpStage pumStaCon(
     tWai=tWai,
     m_flow_nominal=m_flow_nominal,
     minSpe=minSpe)
     "Chilled water pump staging control"
-    annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
-
+    annotation (Placement(transformation(extent={{-10,-10}, {10, 10}})));
   Buildings.Controls.Continuous.LimPID conPID(
     controllerType=controllerType,
     Ti=Ti,
     k=k,
-    Td=Td) "PID controller of pump speed"
-    annotation (Placement(transformation(extent={{-60,-10},{-40,10}})));
-  Modelica.Blocks.Math.Gain gai(k=1/dpSetPoi)
+    Td=Td)
+    "PID controller of pump speed"
+    annotation (Placement(transformation(extent={{-60,-10}, {-40, 10}})));
+  Modelica.Blocks.Math.Gain gai(
+    k=1/dpSetPoi)
     "Multiplier gain for normalizing dp input"
-    annotation (Placement(transformation(extent={{-80,-50},{-60,-30}})));
-  Modelica.Blocks.Sources.Constant dpSetSca(k=1)
+    annotation (Placement(transformation(extent={{-80,-50}, {-60,-30}})));
+  Modelica.Blocks.Sources.Constant dpSetSca(
+    k=1)
     "Scaled differential pressure setpoint"
-    annotation (Placement(transformation(extent={{-100,-10},{-80,10}})));
+    annotation (Placement(transformation(extent={{-100,-10}, {-80, 10}})));
 equation
-  connect(pumStaCon.masFloPum, masFloPum) annotation (Line(points={{-12,8},{-20,
-          8},{-20,40},{-120,40}}, color={0,0,127}));
-  connect(conPID.y, pumStaCon.speSig) annotation (Line(points={{-39,0},{-20,0},{
-          -20,4},{-12,4}}, color={0,0,127}));
-  connect(pumStaCon.y, pumSpe.u1) annotation (Line(points={{11,0},{28,0},{28,6},{38,6}}, color={0,0,127}));
-  connect(conPID.y, pumSpe[1].u2) annotation (Line(points={{-39,0},{-30,0},{-30,
-          -20},{28,-20},{28,-6},{38,-6}}, color={0,0,127}));
-  connect(conPID.y, pumSpe[2].u2) annotation (Line(points={{-39,0},{-30,0},{-30,
-          -20},{28,-20},{28,-6},{38,-6}}, color={0,0,127}));
-  connect(pumSpe.y, y) annotation (Line(points={{61,0},{110,0}}, color={0,0,127}));
+  connect(pumStaCon.masFloPum, masFloPum)
+    annotation (Line(points={{-12, 8}, {-20, 8}, {-20, 40}, {-120, 40}}, color={0, 0, 127}));
+  connect(conPID.y, pumStaCon.speSig)
+    annotation (Line(points={{-39, 0}, {-20, 0}, {-20, 4}, {-12, 4}}, color={0, 0, 127}));
+  connect(pumStaCon.y, pumSpe.u1)
+    annotation (Line(points={{11, 0}, {28, 0}, {28, 6}, {38, 6}}, color={0, 0, 127}));
+  connect(conPID.y, pumSpe[1].u2)
+    annotation (Line(points={{-39, 0}, {-30, 0}, {-30,-20}, {28,-20}, {28,-6}, {38,-6}}, color={0, 0, 127}));
+  connect(conPID.y, pumSpe[2].u2)
+    annotation (Line(points={{-39, 0}, {-30, 0}, {-30,-20}, {28,-20}, {28,-6}, {38,-6}}, color={0, 0, 127}));
+  connect(pumSpe.y, y)
+    annotation (Line(points={{61, 0}, {110, 0}}, color={0, 0, 127}));
   connect(dpMea, gai.u)
-    annotation (Line(points={{-120,-40},{-82,-40}}, color={0,0,127}));
+    annotation (Line(points={{-120,-40}, {-82,-40}}, color={0, 0, 127}));
   connect(gai.y, conPID.u_m)
-    annotation (Line(points={{-59,-40},{-50,-40},{-50,-12}}, color={0,0,127}));
+    annotation (Line(points={{-59,-40}, {-50,-40}, {-50,-12}}, color={0, 0, 127}));
   connect(dpSetSca.y, conPID.u_s)
-    annotation (Line(points={{-79,0},{-62,0}}, color={0,0,127}));
-  annotation (Icon(coordinateSystem(preserveAspectRatio=false), graphics={
-          Rectangle(
-          extent={{-100,100},{100,-100}},
-          lineColor={0,0,127},
-          fillColor={255,255,255},
-          fillPattern=FillPattern.Solid),
-                                        Text(
-        extent={{-150,150},{150,110}},
-        textString="%name",
-        lineColor={0,0,255})}),             Diagram(coordinateSystem(
-          preserveAspectRatio=false)));
+    annotation (Line(points={{-79, 0}, {-62, 0}}, color={0, 0, 127}));
+  annotation (Icon(coordinateSystem(preserveAspectRatio=false), graphics={Rectangle(extent={{-100, 100}, {100,-100}}, lineColor={0, 0, 127}, fillColor={255, 255, 255}, fillPattern=FillPattern.Solid), Text(extent={{-150, 150}, {150, 110}}, textString="%name", lineColor={0, 0, 255})}), Diagram(coordinateSystem(preserveAspectRatio=false)));
 end ChilledWaterPumpSpeed;

--- a/geojson_modelica_translator/model_connectors/templates/ChillerStage.mo
+++ b/geojson_modelica_translator/model_connectors/templates/ChillerStage.mo
@@ -1,135 +1,112 @@
 //within geojson_modelica_translator.model_connectors.templates;
 model ChillerStage
-   "Stage controller for chillers"
-
-  parameter Modelica.SIunits.Time tWai "Waiting time";
-
+  "Stage controller for chillers"
+  parameter Modelica.SIunits.Time tWai
+    "Waiting time";
   parameter Modelica.SIunits.Power QEva_nominal
     "Nominal cooling capaciaty (negative means cooling)";
-
-  parameter Modelica.SIunits.Power  criPoiLoa = 0.55*QEva_nominal
+  parameter Modelica.SIunits.Power criPoiLoa=0.55*QEva_nominal
     "Critical point of cooling load for switching one chiller on or off";
-
-  parameter Modelica.SIunits.Power  dQ = 0.25*QEva_nominal
+  parameter Modelica.SIunits.Power dQ=0.25*QEva_nominal
     "Deadband for critical point of cooling load";
-
-  Modelica.Blocks.Interfaces.RealInput QLoa(unit="W") "Total cooling load, negative"
-    annotation (Placement(transformation(extent={{-140,-60},{-100,-20}})));
-  Modelica.Blocks.Interfaces.BooleanInput on "On signal of the chillers"
-    annotation (Placement(transformation(extent={{-140,20},{-100,60}})));
+  Modelica.Blocks.Interfaces.RealInput QLoa(
+    unit="W")
+    "Total cooling load, negative"
+    annotation (Placement(transformation(extent={{-140,-60}, {-100,-20}})));
+  Modelica.Blocks.Interfaces.BooleanInput on
+    "On signal of the chillers"
+    annotation (Placement(transformation(extent={{-140, 20}, {-100, 60}})));
   Modelica.Blocks.Interfaces.RealOutput y[2]
     "On/off signal for the chillers - 0: off; 1: on"
-    annotation (Placement(transformation(extent={{100,-10},{120,10}})));
-  Modelica.StateGraph.InitialStep off(nIn=1) "No cooling is demanded"
-    annotation (Placement(transformation(
-        extent={{-10,10},{10,-10}},
-        rotation=-90,
-        origin={-50,70})));
-  Modelica.StateGraph.StepWithSignal oneOn(nOut=2, nIn=2)
+    annotation (Placement(transformation(extent={{100,-10}, {120, 10}})));
+  Modelica.StateGraph.InitialStep off(
+    nIn=1)
+    "No cooling is demanded"
+    annotation (Placement(transformation(extent={{-10, 10}, {10,-10}}, rotation=-90, origin={-50, 70})));
+  Modelica.StateGraph.StepWithSignal oneOn(
+    nOut=2,
+    nIn=2)
     "One chiller is on"
-    annotation (Placement(
-        transformation(
-        extent={{10,-10},{-10,10}},
-        rotation=90,
-        origin={-50,0})));
-  Modelica.StateGraph.StepWithSignal twoOn "Two chillers are on"
-    annotation (Placement(
-        transformation(
-        extent={{10,-10},{-10,10}},
-        rotation=90,
-        origin={-50,-70})));
+    annotation (Placement(transformation(extent={{10,-10}, {-10, 10}}, rotation=90, origin={-50, 0})));
+  Modelica.StateGraph.StepWithSignal twoOn
+    "Two chillers are on"
+    annotation (Placement(transformation(extent={{10,-10}, {-10, 10}}, rotation=90, origin={-50,-70})));
   Modelica.StateGraph.Transition offToOne(
     condition=on == true,
     enableTimer=true,
-    waitTime=tWai) "Condition of transition from off to one chiller on"
-    annotation (Placement(transformation(
-        extent={{10,10},{-10,-10}},
-        rotation=90,
-        origin={-50,40})));
+    waitTime=tWai)
+    "Condition of transition from off to one chiller on"
+    annotation (Placement(transformation(extent={{10, 10}, {-10,-10}}, rotation=90, origin={-50, 40})));
   Modelica.StateGraph.Transition oneToTwo(
     enableTimer=true,
     waitTime=tWai,
-    condition=-QLoa >= -(criPoiLoa + dQ))
+    condition=-QLoa >=-(criPoiLoa + dQ))
     "Condition of transition from one chiller to two chillers"
-    annotation (
-      Placement(transformation(
-        extent={{10,10},{-10,-10}},
-        rotation=90,
-        origin={-50,-40})));
+    annotation (Placement(transformation(extent={{10, 10}, {-10,-10}}, rotation=90, origin={-50,-40})));
   Modelica.StateGraph.Transition twoToOne(
     enableTimer=true,
     waitTime=tWai,
-    condition=-QLoa < -(criPoiLoa - dQ))
+    condition=-QLoa <-(criPoiLoa-dQ))
     "Condition of transion from two chillers to one chiller"
-    annotation (
-      Placement(transformation(
-        extent={{-10,10},{10,-10}},
-        rotation=90,
-        origin={0,-40})));
+    annotation (Placement(transformation(extent={{-10, 10}, {10,-10}}, rotation=90, origin={0,-40})));
   Modelica.StateGraph.Transition oneToOff(
     condition=on == false,
     enableTimer=true,
-    waitTime=tWai) "Transition from one chiller to off"
-    annotation (Placement(
-        transformation(
-        extent={{-10,10},{10,-10}},
-        rotation=90,
-        origin={-20,40})));
+    waitTime=tWai)
+    "Transition from one chiller to off"
+    annotation (Placement(transformation(extent={{-10, 10}, {10,-10}}, rotation=90, origin={-20, 40})));
   inner Modelica.StateGraph.StateGraphRoot stateGraphRoot
-    annotation (Placement(transformation(extent={{60,60},{80,80}})));
-  Modelica.Blocks.Tables.CombiTable1Ds combiTable1Ds(table=[0,0,0; 1,1,0; 2,1,1])
-    annotation (Placement(transformation(extent={{70,-10},{90,10}})));
+    annotation (Placement(transformation(extent={{60, 60}, {80, 80}})));
+  Modelica.Blocks.Tables.CombiTable1Ds combiTable1Ds(
+    table=[
+      0, 0, 0;
+      1, 1, 0;
+      2, 1, 1])
+    annotation (Placement(transformation(extent={{70,-10}, {90, 10}})));
   Buildings.Controls.OBC.CDL.Conversions.BooleanToInteger booToInt(
-    final integerTrue=1, final integerFalse=0)
-    annotation (Placement(transformation(extent={{30,-40},{50,-20}})));
+    final integerTrue=1,
+    final integerFalse=0)
+    annotation (Placement(transformation(extent={{30,-40}, {50,-20}})));
   Buildings.Controls.OBC.CDL.Conversions.BooleanToInteger booToInt1(
-    final integerFalse=0, final integerTrue=2)
-    annotation (Placement(transformation(extent={{30,-80},{50,-60}})));
+    final integerFalse=0,
+    final integerTrue=2)
+    annotation (Placement(transformation(extent={{30,-80}, {50,-60}})));
   Buildings.Controls.OBC.CDL.Integers.Add addInt
-    annotation (Placement(transformation(extent={{70,-60},{90,-40}})));
+    annotation (Placement(transformation(extent={{70,-60}, {90,-40}})));
   Buildings.Controls.OBC.CDL.Conversions.IntegerToReal intToRea
-    annotation (Placement(transformation(extent={{40,-10},{60,10}})));
+    annotation (Placement(transformation(extent={{40,-10}, {60, 10}})));
 equation
-  connect(off.outPort[1], offToOne.inPort) annotation (Line(points={{-50,59.5},{
-          -50,44}},               color={0,0,0}));
-  connect(oneToOff.outPort, off.inPort[1]) annotation (Line(points={{-20,41.5},{
-          -20,88},{-50,88},{-50,81}},     color={0,0,0}));
-  connect(oneToTwo.outPort, twoOn.inPort[1]) annotation (Line(points={{-50,-41.5},{-50,-59}}, color={0,0,0}));
-  connect(twoOn.outPort[1], twoToOne.inPort) annotation (Line(points={{-50,-80.5},
-          {-50,-88},{-2.22045e-16,-88},{-2.22045e-16,-44}},
-                                          color={0,0,0}));
-  connect(twoToOne.outPort, oneOn.inPort[2]) annotation (Line(points={{0,-38.5},
-          {0,16},{-49.5,16},{-49.5,11}},   color={0,0,0}));
-  connect(offToOne.outPort, oneOn.inPort[1]) annotation (Line(points={{-50,38.5},
-          {-50,24},{-50,11},{-50.5,11}}, color={0,0,0}));
-  connect(oneOn.outPort[2], oneToOff.inPort) annotation (Line(points={{-49.75,-10.5},
-          {-49.75,-18},{-20,-18},{-20,36}}, color={0,0,0}));
-  connect(oneOn.outPort[1], oneToTwo.inPort) annotation (Line(points={{-50.25,-10.5},
-          {-50.25,-18},{-50,-18},{-50,-36}}, color={0,0,0}));
-  connect(combiTable1Ds.y, y) annotation (Line(points={{91,0},{110,0}}, color={0,0,127}));
-  connect(combiTable1Ds.u, intToRea.y) annotation (Line(points={{68,0},{62,0}}, color={0,0,127}));
-  connect(addInt.u2, booToInt1.y) annotation (Line(points={{68,-56},{60,-56},{
-          60,-70},{52,-70}},
-                          color={255,127,0}));
-  connect(oneOn.active, booToInt.u) annotation (Line(points={{-39,0},{20,0},{20,
-          -30},{28,-30}}, color={255,0,255}));
-  connect(twoOn.active, booToInt1.u) annotation (Line(points={{-39,-70},{28,-70}}, color={255,0,255}));
-  connect(booToInt.y, addInt.u1) annotation (Line(points={{52,-30},{60,-30},{60,
-          -44},{68,-44}}, color={255,127,0}));
-  connect(addInt.y, intToRea.u) annotation (Line(points={{92,-50},{94,-50},{94,-14},
-          {34,-14},{34,0},{38,0}}, color={255,127,0}));
-  annotation (Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,
-            -100},{100,100}})),           Icon(coordinateSystem(
-          preserveAspectRatio=false, extent={{-100,-100},{100,100}}), graphics={
-                                Rectangle(
-        extent={{-100,-100},{100,100}},
-        lineColor={0,0,127},
-        fillColor={255,255,255},
-        fillPattern=FillPattern.Solid), Text(
-        extent={{-150,150},{150,110}},
-        textString="%name",
-        lineColor={0,0,255})}),
-    Documentation(revisions="<html>
+  connect(off.outPort[1], offToOne.inPort)
+    annotation (Line(points={{-50, 59.5}, {-50, 44}}, color={0, 0, 0}));
+  connect(oneToOff.outPort, off.inPort[1])
+    annotation (Line(points={{-20, 41.5}, {-20, 88}, {-50, 88}, {-50, 81}}, color={0, 0, 0}));
+  connect(oneToTwo.outPort, twoOn.inPort[1])
+    annotation (Line(points={{-50,-41.5}, {-50,-59}}, color={0, 0, 0}));
+  connect(twoOn.outPort[1], twoToOne.inPort)
+    annotation (Line(points={{-50,-80.5}, {-50,-88}, {-2.22045e-16,-88}, {-2.22045e-16,-44}}, color={0, 0, 0}));
+  connect(twoToOne.outPort, oneOn.inPort[2])
+    annotation (Line(points={{0,-38.5}, {0, 16}, {-49.5, 16}, {-49.5, 11}}, color={0, 0, 0}));
+  connect(offToOne.outPort, oneOn.inPort[1])
+    annotation (Line(points={{-50, 38.5}, {-50, 24}, {-50, 11}, {-50.5, 11}}, color={0, 0, 0}));
+  connect(oneOn.outPort[2], oneToOff.inPort)
+    annotation (Line(points={{-49.75,-10.5}, {-49.75,-18}, {-20,-18}, {-20, 36}}, color={0, 0, 0}));
+  connect(oneOn.outPort[1], oneToTwo.inPort)
+    annotation (Line(points={{-50.25,-10.5}, {-50.25,-18}, {-50,-18}, {-50,-36}}, color={0, 0, 0}));
+  connect(combiTable1Ds.y, y)
+    annotation (Line(points={{91, 0}, {110, 0}}, color={0, 0, 127}));
+  connect(combiTable1Ds.u, intToRea.y)
+    annotation (Line(points={{68, 0}, {62, 0}}, color={0, 0, 127}));
+  connect(addInt.u2, booToInt1.y)
+    annotation (Line(points={{68,-56}, {60,-56}, {60,-70}, {52,-70}}, color={255, 127, 0}));
+  connect(oneOn.active, booToInt.u)
+    annotation (Line(points={{-39, 0}, {20, 0}, {20,-30}, {28,-30}}, color={255, 0, 255}));
+  connect(twoOn.active, booToInt1.u)
+    annotation (Line(points={{-39,-70}, {28,-70}}, color={255, 0, 255}));
+  connect(booToInt.y, addInt.u1)
+    annotation (Line(points={{52,-30}, {60,-30}, {60,-44}, {68,-44}}, color={255, 127, 0}));
+  connect(addInt.y, intToRea.u)
+    annotation (Line(points={{92,-50}, {94,-50}, {94,-14}, {34,-14}, {34, 0}, {38, 0}}, color={255, 127, 0}));
+  annotation (Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100}, {100, 100}})), Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100}, {100, 100}}), graphics={Rectangle(extent={{-100,-100}, {100, 100}}, lineColor={0, 0, 127}, fillColor={255, 255, 255}, fillPattern=FillPattern.Solid), Text(extent={{-150, 150}, {150, 110}}, textString="%name", lineColor={0, 0, 255})}), Documentation(revisions="<html>
 <ul>
 <li>
 March 19, 2014 by Sen Huang:<br/>

--- a/geojson_modelica_translator/model_connectors/templates/ConnectionParallel.mo
+++ b/geojson_modelica_translator/model_connectors/templates/ConnectionParallel.mo
@@ -1,13 +1,15 @@
 //within Buildings.Applications.DHC.Examples.Combined.Generation5.Unidirectional.Networks;
-model ConnectionParallel "Model for connecting an agent to the DHC system"
+model ConnectionParallel
+  "Model for connecting an agent to the DHC system"
   extends PartialConnection2Pipe(
-    redeclare model Model_pipDis = PipeDistribution (
-      final dh=dhDis, final length=lDis, final fac=1.1),
-    redeclare model Model_pipCon = PipeConnection (
+    redeclare model Model_pipDis=PipeDistribution(
+      final dh=dhDis,
+      final length=lDis,
+      final fac=1.1),
+    redeclare model Model_pipCon=PipeConnection(
       final fac=1.1,
       final length=2*lCon,
       final dh=dhCon));
-
   parameter Modelica.SIunits.Length lDis
     "Length of the distribution pipe before the connection";
   parameter Modelica.SIunits.Length lCon

--- a/geojson_modelica_translator/model_connectors/templates/CoolingTowerParellel.mo
+++ b/geojson_modelica_translator/model_connectors/templates/CoolingTowerParellel.mo
@@ -1,283 +1,142 @@
 //within geojson_modelica_translator.model_connectors.templates;
-
 model CoolingTowerParellel
   "Multiple identical cooling towers in parallel connection"
   extends Buildings.Applications.DataCenters.ChillerCooled.Equipment.BaseClasses.SignalFilter(
-     riseTimeValve=30,
-     use_inputFilter=true,
+    riseTimeValve=30,
+    use_inputFilter=true,
     final numFil=num);
-
-  parameter Integer num(min=1)=2 "Number of cooling towers";
-
+  parameter Integer num(
+    min=1)=2
+    "Number of cooling towers";
   replaceable package Medium=Buildings.Media.Water
     "Condenser water medium";
-
   parameter Modelica.Fluid.Types.Dynamics energyDynamics=Modelica.Fluid.Types.Dynamics.FixedInitial
     "Type of energy balance: dynamic (3 initialization options) or steady state"
-    annotation(Evaluate=true, Dialog(tab = "Dynamics", group="Equations"));
-
-  parameter Boolean show_T = true
+    annotation (Evaluate=true, Dialog(tab="Dynamics", group="Equations"));
+  parameter Boolean show_T=true
     "= true, if actual temperature at port is computed"
-    annotation(Dialog(tab="Advanced",group="Diagnostics"));
-
+    annotation (Dialog(tab="Advanced", group="Diagnostics"));
   parameter Modelica.SIunits.MassFlowRate m_flow_nominal
     "Nominal mass flow rate of condenser water in each tower"
     annotation (Dialog(group="Nominal condition"));
-
   parameter Modelica.SIunits.Pressure dp_nominal
     "Nominal pressure difference of the tower"
     annotation (Dialog(group="Nominal condition"));
-
-  parameter Real ratWatAir_nominal(min=0, unit="1")=0.625
+  parameter Real ratWatAir_nominal(
+    min=0,
+    unit="1")=0.625
     "Design water-to-air ratio"
     annotation (Dialog(group="Nominal condition"));
-
   parameter Modelica.SIunits.Temperature TAirInWB_nominal
     "Nominal outdoor (air inlet) wetbulb temperature"
     annotation (Dialog(group="Heat transfer"));
-
   parameter Modelica.SIunits.Temperature TWatIn_nominal
     "Nominal water inlet temperature"
     annotation (Dialog(group="Heat transfer"));
-
   parameter Modelica.SIunits.TemperatureDifference dT_nominal
     "Temperature difference between inlet and outlet of the tower"
-     annotation (Dialog(group="Heat transfer"));
-
+    annotation (Dialog(group="Heat transfer"));
   parameter Modelica.SIunits.Power PFan_nominal
     "Fan power"
     annotation (Dialog(group="Fan"));
-
-  Medium.ThermodynamicState sta_a=
-      Medium.setState_phX(port_a.p,
-                          noEvent(actualStream(port_a.h_outflow)),
-                          noEvent(actualStream(port_a.Xi_outflow))) if
-         show_T "Medium properties in port_a";
-
-  Medium.ThermodynamicState sta_b=
-      Medium.setState_phX(port_b.p,
-                          noEvent(actualStream(port_b.h_outflow)),
-                          noEvent(actualStream(port_b.Xi_outflow))) if
-          show_T "Medium properties in port_b";
-
-  Modelica.Fluid.Interfaces.FluidPort_a port_a(redeclare package Medium=Medium)
+  Medium.ThermodynamicState sta_a=Medium.setState_phX(
+    port_a.p,
+    noEvent(
+      actualStream(
+        port_a.h_outflow)),
+    noEvent(
+      actualStream(
+        port_a.Xi_outflow))) if show_T
+    "Medium properties in port_a";
+  Medium.ThermodynamicState sta_b=Medium.setState_phX(
+    port_b.p,
+    noEvent(
+      actualStream(
+        port_b.h_outflow)),
+    noEvent(
+      actualStream(
+        port_b.Xi_outflow))) if show_T
+    "Medium properties in port_b";
+  Modelica.Fluid.Interfaces.FluidPort_a port_a(
+    redeclare package Medium=Medium)
     "Fluid connector a (positive design flow direction is from port_a to port_b)"
-    annotation (Placement(transformation(extent={{-110,-10},{-90,10}})));
-
-  Modelica.Fluid.Interfaces.FluidPort_b port_b(redeclare package Medium=Medium)
+    annotation (Placement(transformation(extent={{-110,-10}, {-90, 10}})));
+  Modelica.Fluid.Interfaces.FluidPort_b port_b(
+    redeclare package Medium=Medium)
     "Fluid connector b (positive design flow direction is from port_a to port_b)"
-    annotation (Placement(transformation(extent={{90,-10},{110,10}})));
-
+    annotation (Placement(transformation(extent={{90,-10}, {110, 10}})));
   Modelica.Blocks.Interfaces.RealInput on[num](
-    min=0, max=1, unit="1")
+    min=0,
+    max=1,
+    unit="1")
     "On signal for cooling towers"
-    annotation (Placement(transformation(extent={{-140,40},{-100,80}})));
-
-  Modelica.Blocks.Interfaces.RealInput speFan(unit="1")
+    annotation (Placement(transformation(extent={{-140, 40}, {-100, 80}})));
+  Modelica.Blocks.Interfaces.RealInput speFan(
+    unit="1")
     "Fan speed control signal"
-    annotation (Placement(transformation(extent={{-140,0},{-100,40}})));
-
+    annotation (Placement(transformation(extent={{-140, 0}, {-100, 40}})));
   Modelica.Blocks.Interfaces.RealInput TWetBul(
     final unit="K",
     displayUnit="degC")
     "Entering air wetbulb temperature"
-    annotation (Placement(transformation(extent={{-140,-80},{-100,-40}})));
-
+    annotation (Placement(transformation(extent={{-140,-80}, {-100,-40}})));
   Modelica.Blocks.Interfaces.RealOutput PFan[num](
     final quantity="Power",
     final unit="W")
     "Electric power consumed by fan"
-    annotation (Placement(transformation(extent={{100,50},{120,70}})));
-
+    annotation (Placement(transformation(extent={{100, 50}, {120, 70}})));
   Modelica.Blocks.Interfaces.RealOutput TLvg[num](
     final unit="K",
     displayUnit="degC")
     "Leaving water temperature"
-    annotation (Placement(transformation(extent={{100,20},{120,40}})));
-
+    annotation (Placement(transformation(extent={{100, 20}, {120, 40}})));
   replaceable Buildings.Fluid.HeatExchangers.CoolingTowers.Merkel cooTow[num](
     each final ratWatAir_nominal=ratWatAir_nominal,
     each final TAirInWB_nominal=TAirInWB_nominal,
     each final TWatIn_nominal=TWatIn_nominal,
     each final TWatOut_nominal=TWatIn_nominal-dT_nominal,
-    each final PFan_nominal=PFan_nominal) constrainedby
-   Buildings.Fluid.HeatExchangers.CoolingTowers.BaseClasses.CoolingTower(
-    redeclare each final package Medium = Medium,
-    each show_T=show_T,
-    each final m_flow_nominal=m_flow_nominal,
-    each final dp_nominal=dp_nominal,
-    each final energyDynamics=energyDynamics)
-   "Cooling tower type"
-     annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
-
+    each final PFan_nominal=PFan_nominal)
+    constrainedby Buildings.Fluid.HeatExchangers.CoolingTowers.BaseClasses.CoolingTower(
+      redeclare each final package Medium=Medium,
+      each show_T=show_T,
+      each final m_flow_nominal=m_flow_nominal,
+      each final dp_nominal=dp_nominal,
+      each final energyDynamics=energyDynamics)
+    "Cooling tower type"
+    annotation (Placement(transformation(extent={{-10,-10}, {10, 10}})));
   Buildings.Fluid.Actuators.Valves.TwoWayEqualPercentage val[num](
-    redeclare package Medium = Medium,
+    redeclare package Medium=Medium,
     each final m_flow_nominal=m_flow_nominal,
     each final dpValve_nominal=dp_nominal)
     "Cooling tower valves"
-    annotation (Placement(transformation(extent={{-60,-10},{-40,10}})));
-
+    annotation (Placement(transformation(extent={{-60,-10}, {-40, 10}})));
 equation
-  for i in 1:num loop
-    connect(port_a, val[i].port_a) annotation (Line(points={{-100,0},{-60,0}},color={0,127,255}));
-    connect(val[i].port_b, cooTow[i].port_a) annotation (Line(points={{-40,0},{-10,0}},  color={0,127,255}));
-    connect(cooTow[i].port_b, port_b) annotation (Line(points={{10,0},{100,0}},
-                    color={0,127,255}));
-    connect(speFan, cooTow[i].y) annotation (Line(points={{-120,20},{-20,20},{-20,8},
-          {-12,8}},                 color={0,0,127}));
-    connect(TWetBul, cooTow[i].TAir) annotation (Line(points={{-120,-60},{-20,-60},{
-          -20,4},{-12,4}},
-                        color={0,0,127}));
-    connect(cooTow[i].PFan, PFan[i]) annotation (Line(points={{11,8},{20,8},{20,60},{110,
-          60}}, color={0,0,127}));
-    connect(cooTow[i].TLvg, TLvg[i]) annotation (Line(points={{11,-6},{26,-6},{26,30},{110,
-          30}}, color={0,0,127}));
+  for i in 1 : num loop
+    connect(port_a, val[i].port_a)
+      annotation (Line(points={{-100, 0}, {-60, 0}}, color={0, 127, 255}));
+    connect(val[i].port_b, cooTow[i].port_a)
+      annotation (Line(points={{-40, 0}, {-10, 0}}, color={0, 127, 255}));
+    connect(cooTow[i].port_b, port_b)
+      annotation (Line(points={{10, 0}, {100, 0}}, color={0, 127, 255}));
+    connect(speFan, cooTow[i].y)
+      annotation (Line(points={{-120, 20}, {-20, 20}, {-20, 8}, {-12, 8}}, color={0, 0, 127}));
+    connect(TWetBul, cooTow[i].TAir)
+      annotation (Line(points={{-120,-60}, {-20,-60}, {-20, 4}, {-12, 4}}, color={0, 0, 127}));
+    connect(cooTow[i].PFan, PFan[i])
+      annotation (Line(points={{11, 8}, {20, 8}, {20, 60}, {110, 60}}, color={0, 0, 127}));
+    connect(cooTow[i].TLvg, TLvg[i])
+      annotation (Line(points={{11,-6}, {26,-6}, {26, 30}, {110, 30}}, color={0, 0, 127}));
   end for;
   if use_inputFilter then
     connect(on, filter.u)
-      annotation (Line(points={{-120,60},{-60,60},{-60,84},{-55.2,84}},
-        color={0,0,127}));
+      annotation (Line(points={{-120, 60}, {-60, 60}, {-60, 84}, {-55.2, 84}}, color={0, 0, 127}));
   else
     connect(on, y_actual)
-      annotation (Line(points={{-120,60},{-60,60},{-60,74},{-20,74}},
-        color={0,0,127}));
+      annotation (Line(points={{-120, 60}, {-60, 60}, {-60, 74}, {-20, 74}}, color={0, 0, 127}));
   end if;
-  connect(y_actual, val.y) annotation (Line(points={{-20,74},{-14,74},{-14,60},{
-          -50,60},{-50,12}}, color={0,0,127}));
-  annotation (Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,
-            -100},{100,100}})),           Icon(coordinateSystem(
-          preserveAspectRatio=false, extent={{-100,-100},{100,100}}), graphics={
-        Rectangle(
-          extent={{-30,80},{30,6}},
-          lineColor={95,95,95},
-          fillColor={95,95,95},
-          fillPattern=FillPattern.Solid),
-        Ellipse(
-          extent={{-22,74},{0,66}},
-          lineColor={255,255,255},
-          fillColor={255,255,255},
-          fillPattern=FillPattern.Solid),
-        Ellipse(
-          extent={{0,74},{22,66}},
-          lineColor={255,255,255},
-          fillColor={255,255,255},
-          fillPattern=FillPattern.Solid),
-        Line(
-          points={{16,56},{22,44}},
-          color={255,0,0},
-          thickness=0.5),
-        Line(
-          points={{0,56},{6,44}},
-          color={255,0,0},
-          thickness=0.5),
-        Line(
-          points={{0,56},{-6,44}},
-          color={255,0,0},
-          thickness=0.5),
-        Line(
-          points={{16,56},{10,44}},
-          color={255,0,0},
-          thickness=0.5),
-        Rectangle(
-          extent={{-30,-6},{30,-80}},
-          lineColor={95,95,95},
-          fillColor={95,95,95},
-          fillPattern=FillPattern.Solid),
-        Text(
-          extent={{-149,-114},{151,-154}},
-          lineColor={0,0,255},
-          textString="%name"),
-        Ellipse(
-          extent={{-22,-12},{0,-20}},
-          lineColor={255,255,255},
-          fillColor={255,255,255},
-          fillPattern=FillPattern.Solid),
-        Ellipse(
-          extent={{0,-12},{22,-20}},
-          lineColor={255,255,255},
-          fillColor={255,255,255},
-          fillPattern=FillPattern.Solid),
-        Line(
-          points={{-16,-30},{-22,-42}},
-          color={255,0,0},
-          thickness=0.5),
-        Line(
-          points={{-16,-30},{-10,-42}},
-          color={255,0,0},
-          thickness=0.5),
-        Line(
-          points={{0,-30},{-6,-42}},
-          color={255,0,0},
-          thickness=0.5),
-        Line(
-          points={{0,-30},{6,-42}},
-          color={255,0,0},
-          thickness=0.5),
-        Line(
-          points={{16,-30},{10,-42}},
-          color={255,0,0},
-          thickness=0.5),
-        Line(
-          points={{16,-30},{22,-42}},
-          color={255,0,0},
-          thickness=0.5),
-        Rectangle(
-          extent={{30,10},{60,6}},
-          lineColor={0,0,255},
-          pattern=LinePattern.None,
-          fillColor={0,0,127},
-          fillPattern=FillPattern.Solid),
-        Rectangle(
-          extent={{30,-76},{60,-80}},
-          lineColor={0,0,255},
-          pattern=LinePattern.None,
-          fillColor={0,0,127},
-          fillPattern=FillPattern.Solid),
-        Rectangle(
-          extent={{62,2},{92,-2}},
-          lineColor={0,0,255},
-          pattern=LinePattern.None,
-          fillColor={0,0,127},
-          fillPattern=FillPattern.Solid),
-        Rectangle(
-          extent={{58,-80},{62,10}},
-          lineColor={0,0,255},
-          pattern=LinePattern.None,
-          fillColor={0,0,127},
-          fillPattern=FillPattern.Solid),
-        Rectangle(
-          extent={{-90,2},{-60,-2}},
-          lineColor={238,46,47},
-          pattern=LinePattern.None,
-          fillColor={238,46,47},
-          fillPattern=FillPattern.Solid),
-        Rectangle(
-          extent={{-64,-30},{-60,60}},
-          lineColor={238,46,47},
-          pattern=LinePattern.None,
-          fillColor={238,46,47},
-          fillPattern=FillPattern.Solid),
-        Rectangle(
-          extent={{-60,-26},{16,-30}},
-          lineColor={238,46,47},
-          pattern=LinePattern.None,
-          fillColor={238,46,47},
-          fillPattern=FillPattern.Solid),
-        Rectangle(
-          extent={{-60,60},{16,56}},
-          lineColor={238,46,47},
-          pattern=LinePattern.None,
-          fillColor={238,46,47},
-          fillPattern=FillPattern.Solid),
-        Line(
-          points={{-16,56},{-22,44}},
-          color={255,0,0},
-          thickness=0.5),
-        Line(
-          points={{-16,56},{-10,44}},
-          color={255,0,0},
-          thickness=0.5)}),
-    Documentation(revisions="<html>
+  connect(y_actual, val.y)
+    annotation (Line(points={{-20, 74}, {-14, 74}, {-14, 60}, {-50, 60}, {-50, 12}}, color={0, 0, 127}));
+  annotation (Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100}, {100, 100}})), Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100}, {100, 100}}), graphics={Rectangle(extent={{-30, 80}, {30, 6}}, lineColor={95, 95, 95}, fillColor={95, 95, 95}, fillPattern=FillPattern.Solid), Ellipse(extent={{-22, 74}, {0, 66}}, lineColor={255, 255, 255}, fillColor={255, 255, 255}, fillPattern=FillPattern.Solid), Ellipse(extent={{0, 74}, {22, 66}}, lineColor={255, 255, 255}, fillColor={255, 255, 255}, fillPattern=FillPattern.Solid), Line(points={{16, 56}, {22, 44}}, color={255, 0, 0}, thickness=0.5), Line(points={{0, 56}, {6, 44}}, color={255, 0, 0}, thickness=0.5), Line(points={{0, 56}, {-6, 44}}, color={255, 0, 0}, thickness=0.5), Line(points={{16, 56}, {10, 44}}, color={255, 0, 0}, thickness=0.5), Rectangle(extent={{-30,-6}, {30,-80}}, lineColor={95, 95, 95}, fillColor={95, 95, 95}, fillPattern=FillPattern.Solid), Text(extent={{-149,-114}, {151,-154}}, lineColor={0, 0, 255}, textString="%name"), Ellipse(extent={{-22,-12}, {0,-20}}, lineColor={255, 255, 255}, fillColor={255, 255, 255}, fillPattern=FillPattern.Solid), Ellipse(extent={{0,-12}, {22,-20}}, lineColor={255, 255, 255}, fillColor={255, 255, 255}, fillPattern=FillPattern.Solid), Line(points={{-16,-30}, {-22,-42}}, color={255, 0, 0}, thickness=0.5), Line(points={{-16,-30}, {-10,-42}}, color={255, 0, 0}, thickness=0.5), Line(points={{0,-30}, {-6,-42}}, color={255, 0, 0}, thickness=0.5), Line(points={{0,-30}, {6,-42}}, color={255, 0, 0}, thickness=0.5), Line(points={{16,-30}, {10,-42}}, color={255, 0, 0}, thickness=0.5), Line(points={{16,-30}, {22,-42}}, color={255, 0, 0}, thickness=0.5), Rectangle(extent={{30, 10}, {60, 6}}, lineColor={0, 0, 255}, pattern=LinePattern.None, fillColor={0, 0, 127}, fillPattern=FillPattern.Solid), Rectangle(extent={{30,-76}, {60,-80}}, lineColor={0, 0, 255}, pattern=LinePattern.None, fillColor={0, 0, 127}, fillPattern=FillPattern.Solid), Rectangle(extent={{62, 2}, {92,-2}}, lineColor={0, 0, 255}, pattern=LinePattern.None, fillColor={0, 0, 127}, fillPattern=FillPattern.Solid), Rectangle(extent={{58,-80}, {62, 10}}, lineColor={0, 0, 255}, pattern=LinePattern.None, fillColor={0, 0, 127}, fillPattern=FillPattern.Solid), Rectangle(extent={{-90, 2}, {-60,-2}}, lineColor={238, 46, 47}, pattern=LinePattern.None, fillColor={238, 46, 47}, fillPattern=FillPattern.Solid), Rectangle(extent={{-64,-30}, {-60, 60}}, lineColor={238, 46, 47}, pattern=LinePattern.None, fillColor={238, 46, 47}, fillPattern=FillPattern.Solid), Rectangle(extent={{-60,-26}, {16,-30}}, lineColor={238, 46, 47}, pattern=LinePattern.None, fillColor={238, 46, 47}, fillPattern=FillPattern.Solid), Rectangle(extent={{-60, 60}, {16, 56}}, lineColor={238, 46, 47}, pattern=LinePattern.None, fillColor={238, 46, 47}, fillPattern=FillPattern.Solid), Line(points={{-16, 56}, {-22, 44}}, color={255, 0, 0}, thickness=0.5), Line(points={{-16, 56}, {-10, 44}}, color={255, 0, 0}, thickness=0.5)}), Documentation(revisions="<html>
 <ul>
 <li>
 May 19, 2020 by Jing Wang:<br/>
@@ -290,6 +149,5 @@ This model implements a parallel cooling tower system with <code>num</code> iden
 The cooling tower type is replacable.
 <a href=\"modelica://Buildings.Fluid.HeatExchangers.CoolingTowers.Merkel\">Buildings.Fluid.HeatExchangers.CoolingTowers.Merkel</a> is currently used in this model.
 </p>
-</html>"),
-    __Dymola_Commands);
+</html>"), __Dymola_Commands);
 end CoolingTowerParellel;

--- a/geojson_modelica_translator/model_connectors/templates/CoolingTowerWithBypass.mo
+++ b/geojson_modelica_translator/model_connectors/templates/CoolingTowerWithBypass.mo
@@ -1,123 +1,112 @@
 //within geojson_modelica_translator.model_connectors.templates;
 model CoolingTowerWithBypass
-    "Cooling tower system with bypass valve"
-
+  "Cooling tower system with bypass valve"
   replaceable package Medium=Buildings.Media.Water
     "Condenser water medium";
-
-  parameter Integer num(min=1)=2 "Number of cooling towers";
-
+  parameter Integer num(
+    min=1)=2
+    "Number of cooling towers";
   parameter Modelica.Fluid.Types.Dynamics energyDynamics=Modelica.Fluid.Types.Dynamics.FixedInitial
     "Type of energy balance: dynamic (3 initialization options) or steady state"
-    annotation(Evaluate=true, Dialog(tab = "Dynamics", group="Equations"));
-
-  parameter Boolean show_T = true
+    annotation (Evaluate=true, Dialog(tab="Dynamics", group="Equations"));
+  parameter Boolean show_T=true
     "= true, if actual temperature at port is computed"
-    annotation(Dialog(tab="Advanced",group="Diagnostics"));
-
+    annotation (Dialog(tab="Advanced", group="Diagnostics"));
   parameter Modelica.SIunits.MassFlowRate m_flow_nominal
     "Total nominal mass flow rate of condenser water"
     annotation (Dialog(group="Nominal condition"));
-
   parameter Modelica.SIunits.Pressure dp_nominal
     "Nominal pressure difference of the tower"
     annotation (Dialog(group="Nominal condition"));
-
-  parameter Real ratWatAir_nominal(min=0, unit="1")=0.625
+  parameter Real ratWatAir_nominal(
+    min=0,
+    unit="1")=0.625
     "Design water-to-air ratio"
     annotation (Dialog(group="Nominal condition"));
-
   parameter Modelica.SIunits.Temperature TAirInWB_nominal
     "Nominal outdoor (air inlet) wetbulb temperature"
     annotation (Dialog(group="Heat transfer"));
-
   parameter Modelica.SIunits.Temperature TWatIn_nominal
     "Nominal water inlet temperature"
     annotation (Dialog(group="Heat transfer"));
-
   parameter Modelica.SIunits.TemperatureDifference dT_nominal
     "Temperature difference between inlet and outlet of the tower"
-     annotation (Dialog(group="Heat transfer"));
-
+    annotation (Dialog(group="Heat transfer"));
   parameter Modelica.SIunits.Power PFan_nominal
     "Fan power"
     annotation (Dialog(group="Fan"));
-
   parameter Modelica.SIunits.TemperatureDifference dTApp=3
     "Approach temperature"
     annotation (Dialog(group="Control Settings"));
-
   parameter Modelica.SIunits.Temperature TMin
     "Minimum allowed water temperature entering chiller"
     annotation (Dialog(group="Control Settings"));
-
   parameter Modelica.Blocks.Types.SimpleController controllerType=Modelica.Blocks.Types.SimpleController.PI
     "Type of fan speed controller"
     annotation (Dialog(group="Control Settings"));
-
-  parameter Real k(unit="1", min=0)=1
+  parameter Real k(
+    unit="1",
+    min=0)=1
     "Gain of the tower PID controller"
     annotation (Dialog(group="Control Settings"));
-
-  parameter Modelica.SIunits.Time Ti(min=Modelica.Constants.small)=60
+  parameter Modelica.SIunits.Time Ti(
+    min=Modelica.Constants.small)=60
     "Integrator time constant of the tower PID controller"
-    annotation (Dialog(enable=(
-    controllerType == Modelica.Blocks.Types.SimpleController.PI or
-    controllerType == Modelica.Blocks.Types.SimpleController.PID),
-    group="Control Settings"));
-
-  parameter Modelica.SIunits.Time Td(min=0)=0.1
+    annotation (Dialog(enable=(controllerType == Modelica.Blocks.Types.SimpleController.PI or controllerType == Modelica.Blocks.Types.SimpleController.PID), group="Control Settings"));
+  parameter Modelica.SIunits.Time Td(
+    min=0)=0.1
     "Derivative time constant of the tower PID controller"
-    annotation (Dialog(enable=(
-    controllerType==Modelica.Blocks.Types.SimpleController.PD or
-    controllerType==Modelica.Blocks.Types.SimpleController.PID),
-    group="Control Settings"));
-
-  Medium.ThermodynamicState sta_a=
-      Medium.setState_phX(port_a.p,
-                          noEvent(actualStream(port_a.h_outflow)),
-                          noEvent(actualStream(port_a.Xi_outflow))) if
-         show_T "Medium properties in port_a";
-
-  Medium.ThermodynamicState sta_b=
-      Medium.setState_phX(port_b.p,
-                          noEvent(actualStream(port_b.h_outflow)),
-                          noEvent(actualStream(port_b.Xi_outflow))) if
-          show_T "Medium properties in port_b";
-
-  Modelica.Fluid.Interfaces.FluidPort_a port_a(redeclare package Medium=Medium)
+    annotation (Dialog(enable=(controllerType == Modelica.Blocks.Types.SimpleController.PD or controllerType == Modelica.Blocks.Types.SimpleController.PID), group="Control Settings"));
+  Medium.ThermodynamicState sta_a=Medium.setState_phX(
+    port_a.p,
+    noEvent(
+      actualStream(
+        port_a.h_outflow)),
+    noEvent(
+      actualStream(
+        port_a.Xi_outflow))) if show_T
+    "Medium properties in port_a";
+  Medium.ThermodynamicState sta_b=Medium.setState_phX(
+    port_b.p,
+    noEvent(
+      actualStream(
+        port_b.h_outflow)),
+    noEvent(
+      actualStream(
+        port_b.Xi_outflow))) if show_T
+    "Medium properties in port_b";
+  Modelica.Fluid.Interfaces.FluidPort_a port_a(
+    redeclare package Medium=Medium)
     "Fluid connector a (positive design flow direction is from port_a to port_b)"
-    annotation (Placement(transformation(extent={{-110,-10},{-90,10}})));
-
-  Modelica.Fluid.Interfaces.FluidPort_b port_b(redeclare package Medium=Medium)
+    annotation (Placement(transformation(extent={{-110,-10}, {-90, 10}})));
+  Modelica.Fluid.Interfaces.FluidPort_b port_b(
+    redeclare package Medium=Medium)
     "Fluid connector b (positive design flow direction is from port_a to port_b)"
-    annotation (Placement(transformation(extent={{90,-10},{110,10}})));
-
+    annotation (Placement(transformation(extent={{90,-10}, {110, 10}})));
   Modelica.Blocks.Interfaces.RealInput on[num](
-    min=0, max=1, unit="1") "On signal for cooling towers"
-    annotation (Placement(transformation(extent={{-140,20},{-100,60}})));
-
+    min=0,
+    max=1,
+    unit="1")
+    "On signal for cooling towers"
+    annotation (Placement(transformation(extent={{-140, 20}, {-100, 60}})));
   Modelica.Blocks.Interfaces.RealInput TWetBul(
     final unit="K",
     displayUnit="degC")
     "Entering air wetbulb temperature"
-    annotation (Placement(transformation(extent={{-140,-40},{-100,0}})));
-
+    annotation (Placement(transformation(extent={{-140,-40}, {-100, 0}})));
   Modelica.Blocks.Interfaces.RealOutput PFan[num](
     final quantity="Power",
     final unit="W")
     "Electric power consumed by fan"
-    annotation (Placement(transformation(extent={{100,50},{120,70}})));
-
+    annotation (Placement(transformation(extent={{100, 50}, {120, 70}})));
   Modelica.Blocks.Interfaces.RealOutput TLvg[num](
     final unit="K",
     displayUnit="degC")
     "Leaving water temperature"
-    annotation (Placement(transformation(extent={{100,20},{120,40}})));
-
+    annotation (Placement(transformation(extent={{100, 20}, {120, 40}})));
   CoolingTowerParellel cooTowSys(
     use_inputFilter=true,
-    redeclare package Medium = Medium,
+    redeclare package Medium=Medium,
     num=num,
     show_T=show_T,
     m_flow_nominal=m_flow_nominal/num,
@@ -127,246 +116,102 @@ model CoolingTowerWithBypass
     TWatIn_nominal=TWatIn_nominal,
     dT_nominal=dT_nominal,
     PFan_nominal=PFan_nominal,
-    energyDynamics=energyDynamics) "Cooling tower system"
-    annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
-
+    energyDynamics=energyDynamics)
+    "Cooling tower system"
+    annotation (Placement(transformation(extent={{-10,-10}, {10, 10}})));
   Buildings.Fluid.Actuators.Valves.TwoWayEqualPercentage valByp(
-    redeclare package Medium = Medium,
+    redeclare package Medium=Medium,
     m_flow_nominal=m_flow_nominal*0.0001,
     dpValve_nominal=dp_nominal,
-    use_inputFilter=false) "Condenser water bypass valve"
-    annotation (Placement(transformation(
-        extent={{-10,-10},{10,10}},
-        origin={0,-40})));
-
+    use_inputFilter=false)
+    "Condenser water bypass valve"
+    annotation (Placement(transformation(extent={{-10,-10}, {10, 10}}, origin={0,-40})));
   Buildings.Fluid.Sensors.TemperatureTwoPort senTCWSup(
-    redeclare package Medium = Medium,
+    redeclare package Medium=Medium,
     m_flow_nominal=m_flow_nominal,
     T_start=Medium.T_default)
-    annotation (Placement(transformation(extent={{60,10},{80,-10}})));
-
-  Modelica.Blocks.Sources.RealExpression TSetCWSup(y=max(TWetBul + dTApp, TMin))
+    annotation (Placement(transformation(extent={{60, 10}, {80,-10}})));
+  Modelica.Blocks.Sources.RealExpression TSetCWSup(
+    y=max(
+      TWetBul + dTApp,
+      TMin))
     "Condenser water supply temperature setpoint"
-    annotation (Placement(transformation(extent={{-60,50},{-40,70}})));
-
-  Modelica.Blocks.Sources.Constant TSetByPas(k=TMin)
+    annotation (Placement(transformation(extent={{-60, 50}, {-40, 70}})));
+  Modelica.Blocks.Sources.Constant TSetByPas(
+    k=TMin)
     "Bypass loop temperature setpoint"
-    annotation (Placement(transformation(extent={{-90,-60},{-70,-40}})));
-
+    annotation (Placement(transformation(extent={{-90,-60}, {-70,-40}})));
   Buildings.Controls.Continuous.LimPID bypValCon(
-    u_s(unit="K", displayUnit="degC"),
-    u_m(unit="K", displayUnit="degC"),
+    u_s(
+      unit="K",
+      displayUnit="degC"),
+    u_m(
+      unit="K",
+      displayUnit="degC"),
     controllerType=Modelica.Blocks.Types.SimpleController.PI,
     k=1,
     Ti=60,
     final reverseActing=true,
     reset=Buildings.Types.Reset.Parameter,
     y_reset=0)
-           "Bypass valve controller"
-    annotation (Placement(transformation(extent={{-60,-60},{-40,-40}})));
-
+    "Bypass valve controller"
+    annotation (Placement(transformation(extent={{-60,-60}, {-40,-40}})));
   Buildings.Controls.Continuous.LimPID cooTowSpeCon(
-    u_s(unit="K", displayUnit="degC"),
-    u_m(unit="K", displayUnit="degC"),
+    u_s(
+      unit="K",
+      displayUnit="degC"),
+    u_m(
+      unit="K",
+      displayUnit="degC"),
     final reverseActing=false,
     controllerType=controllerType,
     k=k,
-    Ti=Ti) "Cooling tower fan speed controller"
-    annotation (Placement(transformation(extent={{-12,50},{8,70}})));
-
-  Modelica.Blocks.Sources.RealExpression TLvgCooTow(y=senTCWSup.T)
-      "Condenser water temperature leaving the towers"
-      annotation (Placement(transformation(extent={{-30,30},{-10,50}})));
-
-  Modelica.Blocks.Math.RealToBoolean reaToBoo "Real to boolean signal"
-    annotation (Placement(transformation(extent={{-90,-90},{-70,-70}})));
+    Ti=Ti)
+    "Cooling tower fan speed controller"
+    annotation (Placement(transformation(extent={{-12, 50}, {8, 70}})));
+  Modelica.Blocks.Sources.RealExpression TLvgCooTow(
+    y=senTCWSup.T)
+    "Condenser water temperature leaving the towers"
+    annotation (Placement(transformation(extent={{-30, 30}, {-10, 50}})));
+  Modelica.Blocks.Math.RealToBoolean reaToBoo
+    "Real to boolean signal"
+    annotation (Placement(transformation(extent={{-90,-90}, {-70,-70}})));
 equation
-  connect(cooTowSys.TWetBul, TWetBul) annotation (Line(points={{-12,-6},{-40,-6},
-          {-40,-20},{-120,-20}}, color={0,0,127}));
-  connect(on, cooTowSys.on) annotation (Line(points={{-120,40},{-40,40},{-40,6},
-          {-12,6}},   color={0,0,127}));
-  connect(port_a, cooTowSys.port_a) annotation (Line(points={{-100,0},{-10,0}}, color={0,127,255}));
-  connect(cooTowSys.port_b, senTCWSup.port_a) annotation (Line(points={{10,0},{60,0}}, color={0,127,255}));
-  connect(senTCWSup.port_b, port_b) annotation (Line(points={{80,0},{100,0}}, color={0,127,255}));
-  connect(TSetByPas.y, bypValCon.u_s) annotation (Line(points={{-69,-50},{-62,-50}}, color={0,0,127}));
-  connect(senTCWSup.T, bypValCon.u_m) annotation (Line(points={{70,-11},{70,-80},
-          {-50,-80},{-50,-62}},
-                            color={0,0,127}));
-  connect(valByp.port_a, cooTowSys.port_a) annotation (Line(points={{-10,-40},{-30,
-          -40},{-30,0},{-10,0}}, color={0,127,255}));
-  connect(valByp.port_b, senTCWSup.port_a) annotation (Line(points={{10,-40},{30,-40},{30,0},{60,0}}, color={0,127,255}));
-  connect(TSetCWSup.y, cooTowSpeCon.u_s) annotation (Line(points={{-39,60},{-14,
-          60}},                                                                       color={0,0,127}));
-  connect(cooTowSpeCon.y, cooTowSys.speFan) annotation (Line(points={{9,60},{20,
-          60},{20,20},{-20,20},{-20,2},{-12,2}}, color={0,0,127}));
-  connect(cooTowSys.PFan, PFan) annotation (Line(points={{11,6},{40,6},{40,60},{
-          110,60}}, color={0,0,127}));
-  connect(cooTowSys.TLvg, TLvg) annotation (Line(points={{11,3},{44,3},{44,30},{
-          110,30}}, color={0,0,127}));
-  connect(bypValCon.y, valByp.y) annotation (Line(points={{-39,-50},{-20,-50},{-20,
-          -20},{0,-20},{0,-28}}, color={0,0,127}));
-  connect(TLvgCooTow.y, cooTowSpeCon.u_m) annotation (Line(points={{-9,40},{-2,40},{-2,48}},
-                                                     color={0,0,127}));
-  connect(reaToBoo.y, bypValCon.trigger) annotation (Line(points={{-69,-80},{
-          -58,-80},{-58,-62}}, color={255,0,255}));
-  connect(on[1], reaToBoo.u) annotation (Line(points={{-120,30},{-96,30},{-96,
-          -80},{-92,-80}}, color={0,0,127}));
-  annotation (Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,
-            -100},{100,100}})),           Icon(coordinateSystem(
-          preserveAspectRatio=false, extent={{-100,-100},{100,100}}), graphics={
-        Polygon(
-          points={{0,-80},{-10,-72},{-10,-88},{0,-80}},
-          lineColor={0,0,0},
-          fillColor={255,255,255},
-          fillPattern=FillPattern.Solid),
-        Polygon(
-          points={{0,-80},{10,-72},{10,-88},{0,-80}},
-          lineColor={0,0,0},
-          fillColor={255,255,255},
-          fillPattern=FillPattern.Solid),
-        Text(
-          extent={{-149,-114},{151,-154}},
-          lineColor={0,0,255},
-          textString="%name"),
-        Rectangle(
-          extent={{-30,94},{30,20}},
-          lineColor={95,95,95},
-          fillColor={95,95,95},
-          fillPattern=FillPattern.Solid),
-        Ellipse(
-          extent={{-22,88},{0,80}},
-          lineColor={255,255,255},
-          fillColor={255,255,255},
-          fillPattern=FillPattern.Solid),
-        Ellipse(
-          extent={{0,88},{22,80}},
-          lineColor={255,255,255},
-          fillColor={255,255,255},
-          fillPattern=FillPattern.Solid),
-        Line(
-          points={{16,70},{22,58}},
-          color={255,0,0},
-          thickness=0.5),
-        Line(
-          points={{0,70},{6,58}},
-          color={255,0,0},
-          thickness=0.5),
-        Line(
-          points={{0,70},{-6,58}},
-          color={255,0,0},
-          thickness=0.5),
-        Line(
-          points={{16,70},{10,58}},
-          color={255,0,0},
-          thickness=0.5),
-        Rectangle(
-          extent={{-30,8},{30,-66}},
-          lineColor={95,95,95},
-          fillColor={95,95,95},
-          fillPattern=FillPattern.Solid),
-        Ellipse(
-          extent={{-22,2},{0,-6}},
-          lineColor={255,255,255},
-          fillColor={255,255,255},
-          fillPattern=FillPattern.Solid),
-        Ellipse(
-          extent={{0,2},{22,-6}},
-          lineColor={255,255,255},
-          fillColor={255,255,255},
-          fillPattern=FillPattern.Solid),
-        Line(
-          points={{-16,-16},{-22,-28}},
-          color={255,0,0},
-          thickness=0.5),
-        Line(
-          points={{-16,-16},{-10,-28}},
-          color={255,0,0},
-          thickness=0.5),
-        Line(
-          points={{0,-16},{-6,-28}},
-          color={255,0,0},
-          thickness=0.5),
-        Line(
-          points={{0,-16},{6,-28}},
-          color={255,0,0},
-          thickness=0.5),
-        Line(
-          points={{16,-16},{10,-28}},
-          color={255,0,0},
-          thickness=0.5),
-        Line(
-          points={{16,-16},{22,-28}},
-          color={255,0,0},
-          thickness=0.5),
-        Rectangle(
-          extent={{30,24},{60,20}},
-          lineColor={0,0,255},
-          pattern=LinePattern.None,
-          fillColor={0,0,127},
-          fillPattern=FillPattern.Solid),
-        Rectangle(
-          extent={{30,-62},{60,-66}},
-          lineColor={0,0,255},
-          pattern=LinePattern.None,
-          fillColor={0,0,127},
-          fillPattern=FillPattern.Solid),
-        Rectangle(
-          extent={{62,2},{92,-2}},
-          lineColor={0,0,255},
-          pattern=LinePattern.None,
-          fillColor={0,0,127},
-          fillPattern=FillPattern.Solid),
-        Rectangle(
-          extent={{58,-80},{62,24}},
-          lineColor={0,0,255},
-          pattern=LinePattern.None,
-          fillColor={0,0,127},
-          fillPattern=FillPattern.Solid),
-        Rectangle(
-          extent={{-90,2},{-60,-2}},
-          lineColor={238,46,47},
-          pattern=LinePattern.None,
-          fillColor={238,46,47},
-          fillPattern=FillPattern.Solid),
-        Rectangle(
-          extent={{-64,-82},{-60,74}},
-          lineColor={238,46,47},
-          pattern=LinePattern.None,
-          fillColor={238,46,47},
-          fillPattern=FillPattern.Solid),
-        Rectangle(
-          extent={{-60,-12},{16,-16}},
-          lineColor={238,46,47},
-          pattern=LinePattern.None,
-          fillColor={238,46,47},
-          fillPattern=FillPattern.Solid),
-        Rectangle(
-          extent={{-60,74},{16,70}},
-          lineColor={238,46,47},
-          pattern=LinePattern.None,
-          fillColor={238,46,47},
-          fillPattern=FillPattern.Solid),
-        Line(
-          points={{-16,70},{-22,58}},
-          color={255,0,0},
-          thickness=0.5),
-        Line(
-          points={{-16,70},{-10,58}},
-          color={255,0,0},
-          thickness=0.5),
-        Rectangle(
-          extent={{-60,-78},{-10,-82}},
-          lineColor={238,46,47},
-          pattern=LinePattern.None,
-          fillColor={238,46,47},
-          fillPattern=FillPattern.Solid),
-        Rectangle(
-          extent={{10,-78},{62,-82}},
-          lineColor={0,0,255},
-          pattern=LinePattern.None,
-          fillColor={0,0,127},
-          fillPattern=FillPattern.Solid)}),
-    Documentation(revisions="<html>
+  connect(cooTowSys.TWetBul, TWetBul)
+    annotation (Line(points={{-12,-6}, {-40,-6}, {-40,-20}, {-120,-20}}, color={0, 0, 127}));
+  connect(on, cooTowSys.on)
+    annotation (Line(points={{-120, 40}, {-40, 40}, {-40, 6}, {-12, 6}}, color={0, 0, 127}));
+  connect(port_a, cooTowSys.port_a)
+    annotation (Line(points={{-100, 0}, {-10, 0}}, color={0, 127, 255}));
+  connect(cooTowSys.port_b, senTCWSup.port_a)
+    annotation (Line(points={{10, 0}, {60, 0}}, color={0, 127, 255}));
+  connect(senTCWSup.port_b, port_b)
+    annotation (Line(points={{80, 0}, {100, 0}}, color={0, 127, 255}));
+  connect(TSetByPas.y, bypValCon.u_s)
+    annotation (Line(points={{-69,-50}, {-62,-50}}, color={0, 0, 127}));
+  connect(senTCWSup.T, bypValCon.u_m)
+    annotation (Line(points={{70,-11}, {70,-80}, {-50,-80}, {-50,-62}}, color={0, 0, 127}));
+  connect(valByp.port_a, cooTowSys.port_a)
+    annotation (Line(points={{-10,-40}, {-30,-40}, {-30, 0}, {-10, 0}}, color={0, 127, 255}));
+  connect(valByp.port_b, senTCWSup.port_a)
+    annotation (Line(points={{10,-40}, {30,-40}, {30, 0}, {60, 0}}, color={0, 127, 255}));
+  connect(TSetCWSup.y, cooTowSpeCon.u_s)
+    annotation (Line(points={{-39, 60}, {-14, 60}}, color={0, 0, 127}));
+  connect(cooTowSpeCon.y, cooTowSys.speFan)
+    annotation (Line(points={{9, 60}, {20, 60}, {20, 20}, {-20, 20}, {-20, 2}, {-12, 2}}, color={0, 0, 127}));
+  connect(cooTowSys.PFan, PFan)
+    annotation (Line(points={{11, 6}, {40, 6}, {40, 60}, {110, 60}}, color={0, 0, 127}));
+  connect(cooTowSys.TLvg, TLvg)
+    annotation (Line(points={{11, 3}, {44, 3}, {44, 30}, {110, 30}}, color={0, 0, 127}));
+  connect(bypValCon.y, valByp.y)
+    annotation (Line(points={{-39,-50}, {-20,-50}, {-20,-20}, {0,-20}, {0,-28}}, color={0, 0, 127}));
+  connect(TLvgCooTow.y, cooTowSpeCon.u_m)
+    annotation (Line(points={{-9, 40}, {-2, 40}, {-2, 48}}, color={0, 0, 127}));
+  connect(reaToBoo.y, bypValCon.trigger)
+    annotation (Line(points={{-69,-80}, {-58,-80}, {-58,-62}}, color={255, 0, 255}));
+  connect(on[1], reaToBoo.u)
+    annotation (Line(points={{-120, 30}, {-96, 30}, {-96,-80}, {-92,-80}}, color={0, 0, 127}));
+  annotation (Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100}, {100, 100}})), Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100}, {100, 100}}), graphics={Polygon(points={{0,-80}, {-10,-72}, {-10,-88}, {0,-80}}, lineColor={0, 0, 0}, fillColor={255, 255, 255}, fillPattern=FillPattern.Solid), Polygon(points={{0,-80}, {10,-72}, {10,-88}, {0,-80}}, lineColor={0, 0, 0}, fillColor={255, 255, 255}, fillPattern=FillPattern.Solid), Text(extent={{-149,-114}, {151,-154}}, lineColor={0, 0, 255}, textString="%name"), Rectangle(extent={{-30, 94}, {30, 20}}, lineColor={95, 95, 95}, fillColor={95, 95, 95}, fillPattern=FillPattern.Solid), Ellipse(extent={{-22, 88}, {0, 80}}, lineColor={255, 255, 255}, fillColor={255, 255, 255}, fillPattern=FillPattern.Solid), Ellipse(extent={{0, 88}, {22, 80}}, lineColor={255, 255, 255}, fillColor={255, 255, 255}, fillPattern=FillPattern.Solid), Line(points={{16, 70}, {22, 58}}, color={255, 0, 0}, thickness=0.5), Line(points={{0, 70}, {6, 58}}, color={255, 0, 0}, thickness=0.5), Line(points={{0, 70}, {-6, 58}}, color={255, 0, 0}, thickness=0.5), Line(points={{16, 70}, {10, 58}}, color={255, 0, 0}, thickness=0.5), Rectangle(extent={{-30, 8}, {30,-66}}, lineColor={95, 95, 95}, fillColor={95, 95, 95}, fillPattern=FillPattern.Solid), Ellipse(extent={{-22, 2}, {0,-6}}, lineColor={255, 255, 255}, fillColor={255, 255, 255}, fillPattern=FillPattern.Solid), Ellipse(extent={{0, 2}, {22,-6}}, lineColor={255, 255, 255}, fillColor={255, 255, 255}, fillPattern=FillPattern.Solid), Line(points={{-16,-16}, {-22,-28}}, color={255, 0, 0}, thickness=0.5), Line(points={{-16,-16}, {-10,-28}}, color={255, 0, 0}, thickness=0.5), Line(points={{0,-16}, {-6,-28}}, color={255, 0, 0}, thickness=0.5), Line(points={{0,-16}, {6,-28}}, color={255, 0, 0}, thickness=0.5), Line(points={{16,-16}, {10,-28}}, color={255, 0, 0}, thickness=0.5), Line(points={{16,-16}, {22,-28}}, color={255, 0, 0}, thickness=0.5), Rectangle(extent={{30, 24}, {60, 20}}, lineColor={0, 0, 255}, pattern=LinePattern.None, fillColor={0, 0, 127}, fillPattern=FillPattern.Solid), Rectangle(extent={{30,-62}, {60,-66}}, lineColor={0, 0, 255}, pattern=LinePattern.None, fillColor={0, 0, 127}, fillPattern=FillPattern.Solid), Rectangle(extent={{62, 2}, {92,-2}}, lineColor={0, 0, 255}, pattern=LinePattern.None, fillColor={0, 0, 127}, fillPattern=FillPattern.Solid), Rectangle(extent={{58,-80}, {62, 24}}, lineColor={0, 0, 255}, pattern=LinePattern.None, fillColor={0, 0, 127}, fillPattern=FillPattern.Solid), Rectangle(extent={{-90, 2}, {-60,-2}}, lineColor={238, 46, 47}, pattern=LinePattern.None, fillColor={238, 46, 47}, fillPattern=FillPattern.Solid), Rectangle(extent={{-64,-82}, {-60, 74}}, lineColor={238, 46, 47}, pattern=LinePattern.None, fillColor={238, 46, 47}, fillPattern=FillPattern.Solid), Rectangle(extent={{-60,-12}, {16,-16}}, lineColor={238, 46, 47}, pattern=LinePattern.None, fillColor={238, 46, 47}, fillPattern=FillPattern.Solid), Rectangle(extent={{-60, 74}, {16, 70}}, lineColor={238, 46, 47}, pattern=LinePattern.None, fillColor={238, 46, 47}, fillPattern=FillPattern.Solid), Line(points={{-16, 70}, {-22, 58}}, color={255, 0, 0}, thickness=0.5), Line(points={{-16, 70}, {-10, 58}}, color={255, 0, 0}, thickness=0.5), Rectangle(extent={{-60,-78}, {-10,-82}}, lineColor={238, 46, 47}, pattern=LinePattern.None, fillColor={238, 46, 47}, fillPattern=FillPattern.Solid), Rectangle(extent={{10,-78}, {62,-82}}, lineColor={0, 0, 255}, pattern=LinePattern.None, fillColor={0, 0, 127}, fillPattern=FillPattern.Solid)}), Documentation(revisions="<html>
 <ul>
 <li>
 March 30, 2014 by Sen Huang:<br/>

--- a/geojson_modelica_translator/model_connectors/templates/DesignDataParallel4GDC.mo
+++ b/geojson_modelica_translator/model_connectors/templates/DesignDataParallel4GDC.mo
@@ -2,26 +2,30 @@
 record DesignDataParallel4GDC
   "Record with design data for parallel network"
   extends Modelica.Icons.Record;
-  parameter Integer nBui = 3
+  parameter Integer nBui=3
     "Number of served buildings"
-    annotation(Evaluate=true);
-   parameter Modelica.SIunits.MassFlowRate mDis_flow_nominal
-     "Nominal mass flow rate of the distribution pump";
+    annotation (Evaluate=true);
+  parameter Modelica.SIunits.MassFlowRate mDis_flow_nominal
+    "Nominal mass flow rate of the distribution pump";
   parameter Modelica.SIunits.MassFlowRate mCon_flow_nominal[nBui]
     "Nominal mass flow rate in each connection line";
-  parameter Modelica.SIunits.Length lDis[nBui] = fill(100, nBui)
+  parameter Modelica.SIunits.Length lDis[nBui]=fill(
+    100,
+    nBui)
     "Length of distribution pipe (only counting warm or cold line, but not sum)";
-  parameter Modelica.SIunits.Length lCon[nBui] = fill(10, nBui)
+  parameter Modelica.SIunits.Length lCon[nBui]=fill(
+    10,
+    nBui)
     "Length of connection pipe (only counting warm or cold line, but not sum)";
-  parameter Modelica.SIunits.Length lEnd = 10
+  parameter Modelica.SIunits.Length lEnd=10
     "Length of the end of the distribution line (supply only, not counting return line)";
-  parameter Modelica.SIunits.Length dhDis[nBui] = {0.15, 0.1, 0.05}
+  parameter Modelica.SIunits.Length dhDis[nBui]={0.15, 0.1, 0.05}
     "Hydraulic diameter of the distribution pipe before each connection";
-  parameter Modelica.SIunits.Length dhCon[nBui] = fill(0.05, nBui)
+  parameter Modelica.SIunits.Length dhCon[nBui]=fill(
+    0.05,
+    nBui)
     "Hydraulic diameter of each connection pipe";
-  parameter Modelica.SIunits.Length dhEnd = dhDis[nBui]
+  parameter Modelica.SIunits.Length dhEnd=dhDis[nBui]
     "Hydraulic diameter of the end of the distribution line";
-  annotation (
-    defaultComponentPrefix="datDes",
-    defaultComponentPrefixes="inner");
+  annotation (defaultComponentPrefix="datDes", defaultComponentPrefixes="inner");
 end DesignDataParallel4GDC;

--- a/geojson_modelica_translator/model_connectors/templates/DistrictCoolingSystem.mo
+++ b/geojson_modelica_translator/model_connectors/templates/DistrictCoolingSystem.mo
@@ -1,70 +1,78 @@
 // within geojson_modelica_translator.model_connectors.templates;
-
-model DistrictCoolingSystem "Example to test the district cooling system."
+model DistrictCoolingSystem
+  "Example to test the district cooling system."
   extends Modelica.Icons.Example;
- package MediumW = Buildings.Media.Water "Medium model for water";
-  inner parameter
-   DesignDataParallel4GDC datDes(
-   nBui=nBui,
-   mDis_flow_nominal=sum({bui_ETS[i].ets.mDis_flow_nominal for i in 1:nBui})*1.01,
-   mCon_flow_nominal={bui_ETS[i].ets.mDis_flow_nominal for i in 1:nBui},
-   lDis=fill(15, nBui),
-   lCon=fill(20, nBui),
-   dhDis={0.125,0.125,0.1,0.085,0.08,0.075,0.06,0.05},
-   dhCon=fill(0.05, nBui)) "Design data"
-   annotation (Placement(transformation(extent={{80,40},{100,60}})));
+  package MediumW=Buildings.Media.Water
+    "Medium model for water";
+  inner parameter DesignDataParallel4GDC datDes(
+    nBui=nBui,
+    mDis_flow_nominal=sum(
+      {bui_ETS[i].ets.mDis_flow_nominal for i in 1 : nBui})*1.01,
+    mCon_flow_nominal={bui_ETS[i].ets.mDis_flow_nominal for i in 1 : nBui},
+    lDis=fill(
+      15,
+      nBui),
+    lCon=fill(
+      20,
+      nBui),
+    dhDis={0.125, 0.125, 0.1, 0.085, 0.08, 0.075, 0.06, 0.05},
+    dhCon=fill(
+      0.05,
+      nBui))
+    "Design data"
+    annotation (Placement(transformation(extent={{80, 40}, {100, 60}})));
   parameter Integer nBui=8
- "number of coonected buildings";
+    "number of coonected buildings";
   parameter Modelica.SIunits.MassFlowRate mCHW_flow_nominal=cooPla.numChi*(cooPla.perChi.mEva_flow_nominal)
-   "Nominal chilled water mass flow rate";
+    "Nominal chilled water mass flow rate";
   parameter Modelica.SIunits.MassFlowRate mCW_flow_nominal=cooPla.perChi.mCon_flow_nominal
-   "Nominal condenser water mass flow rate";                                                                                                                             //cooPla.mulChiSys.per[1].mEva_flow_nominal//40
+    "Nominal condenser water mass flow rate";
+  //cooPla.mulChiSys.per[1].mEva_flow_nominal//40
   parameter Modelica.SIunits.PressureDifference dpCHW_nominal=44.8*1000
-   "Nominal chilled water side pressure";
+    "Nominal chilled water side pressure";
   parameter Modelica.SIunits.PressureDifference dpCW_nominal=46.2*1000
-   "Nominal condenser water side pressure";
-  parameter Modelica.SIunits.Power QEva_nominal=mCHW_flow_nominal*4200*(5 - 14)
-   "Nominal cooling capaciaty (Negative means cooling)";
-  parameter Modelica.SIunits.MassFlowRate mMin_flow= 0.2*mCHW_flow_nominal/cooPla.numChi
-   "Minimum mass flow rate of single chiller";
-  parameter Boolean allowFlowReversal = false;
- // control settings
+    "Nominal condenser water side pressure";
+  parameter Modelica.SIunits.Power QEva_nominal=mCHW_flow_nominal*4200*(5-14)
+    "Nominal cooling capaciaty (Negative means cooling)";
+  parameter Modelica.SIunits.MassFlowRate mMin_flow=0.2*mCHW_flow_nominal/cooPla.numChi
+    "Minimum mass flow rate of single chiller";
+  parameter Boolean allowFlowReversal=false;
+  // control settings
   parameter Modelica.SIunits.Pressure dpSetPoi=70000
-   "Differential pressure setpoint";
-  parameter Modelica.SIunits.Pressure pumDP=dpCHW_nominal+dpSetPoi+200000;
+    "Differential pressure setpoint";
+  parameter Modelica.SIunits.Pressure pumDP=dpCHW_nominal + dpSetPoi + 200000;
   parameter Modelica.SIunits.Temperature TCHWSet=273.15 + 5
-   "Chilled water temperature setpoint";
-  parameter Modelica.SIunits.Time tWai=30 "Waiting time";
- // pumps
+    "Chilled water temperature setpoint";
+  parameter Modelica.SIunits.Time tWai=30
+    "Waiting time";
+  // pumps
   parameter Buildings.Fluid.Movers.Data.Generic perCHWPum(
-     pressure=Buildings.Fluid.Movers.BaseClasses.Characteristics.flowParameters(
-     V_flow={0,mCHW_flow_nominal/cooPla.numChi}/1000,
-     dp={pumDP,0}))
-   "Performance data for chilled water pumps";
+    pressure=Buildings.Fluid.Movers.BaseClasses.Characteristics.flowParameters(
+      V_flow={0, mCHW_flow_nominal/cooPla.numChi}/1000,
+      dp={pumDP, 0}))
+    "Performance data for chilled water pumps";
   parameter Buildings.Fluid.Movers.Data.Generic perCWPum(
-     pressure=Buildings.Fluid.Movers.BaseClasses.Characteristics.flowParameters(
-     V_flow=mCW_flow_nominal/1000*{0.2,0.6,1.0,1.2},
-     dp=(dpCW_nominal+60000+6000)*{1.2,1.1,1.0,0.6}))
-   "Performance data for condenser water pumps";
+    pressure=Buildings.Fluid.Movers.BaseClasses.Characteristics.flowParameters(
+      V_flow=mCW_flow_nominal/1000*{0.2, 0.6, 1.0, 1.2},
+      dp=(dpCW_nominal + 60000 + 6000)*{1.2, 1.1, 1.0, 0.6}))
+    "Performance data for condenser water pumps";
   parameter Modelica.SIunits.Pressure dpCHWPum_nominal=6000
-   "Nominal pressure drop of chilled water pumps";
+    "Nominal pressure drop of chilled water pumps";
   parameter Modelica.SIunits.Pressure dpCWPum_nominal=6000
-   "Nominal pressure drop of chilled water pumps";
+    "Nominal pressure drop of chilled water pumps";
   Buildings.BoundaryConditions.WeatherData.ReaderTMY3 weaDat(
-   final computeWetBulbTemperature=true,
-   filNam= Modelica.Utilities.Files.loadResource(
-          "modelica://Buildings/Resources/weatherdata/USA_CA_San.Francisco.Intl.AP.724940_TMY3.mos"))
-    annotation (Placement(transformation(extent={{-100,-84},{-80,-64}})));
-  Buildings.BoundaryConditions.WeatherData.Bus weaBus "Weather data bus"
-    annotation (Placement(transformation(extent={{-114,-54},{-94,-34}}),
-        iconTransformation(extent={{-114,-54},{-94,-34}})));
-  Modelica.Blocks.Sources.BooleanConstant on "On signal of the plant"
-    annotation (Placement(transformation(extent={{-100,0},{-80,20}})));
-
+    final computeWetBulbTemperature=true,
+    filNam=Modelica.Utilities.Files.loadResource(
+      "modelica://Buildings/Resources/weatherdata/USA_CA_San.Francisco.Intl.AP.724940_TMY3.mos"))
+    annotation (Placement(transformation(extent={{-100,-84}, {-80,-64}})));
+  Buildings.BoundaryConditions.WeatherData.Bus weaBus
+    "Weather data bus"
+    annotation (Placement(transformation(extent={{-114,-54}, {-94,-34}}), iconTransformation(extent={{-114,-54}, {-94,-34}})));
+  Modelica.Blocks.Sources.BooleanConstant on
+    "On signal of the plant"
+    annotation (Placement(transformation(extent={{-100, 0}, {-80, 20}})));
   CentralCoolingPlant cooPla(
-    redeclare
-      Buildings.Fluid.Chillers.Data.ElectricEIR.ElectricEIRChiller_Trane_CGWD_207kW_3_99COP_None
-      perChi,
+    redeclare Buildings.Fluid.Chillers.Data.ElectricEIR.ElectricEIRChiller_Trane_CGWD_207kW_3_99COP_None perChi,
     perCHWPum=perCHWPum,
     perCWPum=perCWPum,
     mCHW_flow_nominal=mCHW_flow_nominal,
@@ -84,24 +92,25 @@ model DistrictCoolingSystem "Example to test the district cooling system."
     dpSetPoi=dpSetPoi,
     energyDynamics=Modelica.Fluid.Types.Dynamics.FixedInitial)
     "District cooling plant."
-    annotation (Placement(transformation(extent={{-34,-46},{-14,-26}})));
-
+    annotation (Placement(transformation(extent={{-34,-46}, {-14,-26}})));
   BuildingSpawnZ6WithCoolingIndirectETS bui_ETS[nBui](
     idfName="modelica://Buildings/Resources/Data/ThermalZones/EnergyPlus/Validation/RefBldgSmallOffice/RefBldgSmallOfficeNew2004_Chicago.idf",
     weaName="modelica://Buildings/Resources/weatherdata/USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.mos")
-   "Vectorized spawn building."
-  annotation (Placement(transformation(extent={{20,60},{40,80}})));
-
+    "Vectorized spawn building."
+    annotation (Placement(transformation(extent={{20, 60}, {40, 80}})));
   Buildings.Fluid.Sources.Boundary_pT heaSou(
-    redeclare package Medium = MediumW,
+    redeclare package Medium=MediumW,
     T=313.15,
-    nPorts=nBui) "Heating source."
-    annotation (Placement(transformation(extent={{-42,70},{-22,90}})));
-  Buildings.Fluid.Sources.Boundary_pT heaSin(redeclare package Medium = MediumW,
-    nPorts=nBui) "Heating sink"
-    annotation (Placement(transformation(extent={{82,72},{62,92}})));
+    nPorts=nBui)
+    "Heating source."
+    annotation (Placement(transformation(extent={{-42, 70}, {-22, 90}})));
+  Buildings.Fluid.Sources.Boundary_pT heaSin(
+    redeclare package Medium=MediumW,
+    nPorts=nBui)
+    "Heating sink"
+    annotation (Placement(transformation(extent={{82, 72}, {62, 92}})));
   UnidirectionalParallel disNet(
-    redeclare final package Medium = MediumW,
+    redeclare final package Medium=MediumW,
     final nCon=nBui,
     iConDpSen=nBui,
     final mDis_flow_nominal=datDes.mDis_flow_nominal,
@@ -114,60 +123,51 @@ model DistrictCoolingSystem "Example to test the district cooling system."
     final dhEnd=datDes.dhEnd,
     final allowFlowReversal=allowFlowReversal)
     "Distribution network."
-    annotation (Placement(transformation(extent={{16,20},{44,32}})));
-  Modelica.Blocks.Sources.RealExpression TSetChiWatDis(y=5 + 273.15)
+    annotation (Placement(transformation(extent={{16, 20}, {44, 32}})));
+  Modelica.Blocks.Sources.RealExpression TSetChiWatDis(
+    y=5 + 273.15)
     "Chilled water supply temperature set point on district level."
-    annotation (Placement(transformation(extent={{-80,-40},{-60,-20}})));
-  Modelica.Blocks.Sources.RealExpression TSetChiWatBui[nBui](each y=7 + 273.15)
+    annotation (Placement(transformation(extent={{-80,-40}, {-60,-20}})));
+  Modelica.Blocks.Sources.RealExpression TSetChiWatBui[nBui](
+    each y=7 + 273.15)
     "Chilled water supply temperature set point on building level."
-    annotation (Placement(transformation(extent={{-60,40},{-40,60}})));
+    annotation (Placement(transformation(extent={{-60, 40}, {-40, 60}})));
   Modelica.Blocks.Continuous.FirstOrder firOrdDel(
     T=60,
     initType=Modelica.Blocks.Types.Init.InitialOutput,
-    y_start=80000) "First order delay"
-    annotation (Placement(transformation(extent={{50,-70},{30,-90}})));
-
+    y_start=80000)
+    "First order delay"
+    annotation (Placement(transformation(extent={{50,-70}, {30,-90}})));
 equation
-  connect(weaDat.weaBus, weaBus) annotation (Line(
-        points={{-80,-74},{-60,-74},{-60,-44},{-104,-44}},
-        color={255,204,51},
-        thickness=0.5));
-  connect(weaBus.TWetBul,cooPla. TWetBul) annotation (Line(
-      points={{-104,-44},{-36,-44}},
-      color={255,204,51},
-      thickness=0.5));
-  connect(on.y,cooPla. on) annotation (Line(points={{-79,10},{-44,10},{-44,-28},
-          {-36,-28}}, color={255,0,255}));
-  connect(disNet.port_bDisRet, cooPla.port_a) annotation (Line(points={{16,22.4},
-          {0,22.4},{0,-31},{-14,-31}}, color={0,127,255}));
-  connect(cooPla.port_b, disNet.port_aDisSup) annotation (Line(points={{-14,-41},
-          {-4,-41},{-4,26},{16,26}}, color={0,127,255}));
-  connect(disNet.port_bDisSup, disNet.port_aDisRet) annotation (Line(points={{44,
-          26},{52,26},{52,22.4},{44,22.4}}, color={0,127,255}));
-  connect(TSetChiWatDis.y, cooPla.TCHWSupSet) annotation (Line(points={{-59,-30},
-          {-48,-30},{-48,-33},{-36,-33}}, color={0,0,127}));
- for i in 1:nBui loop
-  connect(heaSou.ports[i], bui_ETS[i].port_a1) annotation (Line(points={{-22,80},
-          {8,80},{8,76},{20,76}}, color={0,127,255}));
-  connect(heaSin.ports[i], bui_ETS[i].port_b1) annotation (Line(points={{62,82},
-          {52,82},{52,76},{40,76}}, color={0,127,255}));
-  connect(disNet.ports_bCon[i], bui_ETS[i].port_a2) annotation (Line(points={{
-          21.6,32},{22,32},{22,40},{52,40},{52,64},{40,64}}, color={0,127,255}));
-  connect(disNet.ports_aCon[i], bui_ETS[i].port_b2) annotation (Line(points={{
-          38.4,32},{38.4,40},{8,40},{8,64},{20,64}}, color={0,127,255}));
- end for;
- connect(firOrdDel.y, cooPla.dpMea) annotation (Line(points={{29,-80},{-48,-80},
-          {-48,-39},{-36,-39}}, color={0,0,127}));
- connect(disNet.dp, firOrdDel.u) annotation (Line(points={{44.7,27.8},{80,27.8},
-          {80,-80},{52,-80}}, color={0,0,127}));
- connect(TSetChiWatBui.y, bui_ETS.TSetChiWat) annotation (Line(points={{-61,50},
-          {0,50},{0,73},{19,73}}, color={0,0,127}));
-
-annotation (Icon(coordinateSystem(preserveAspectRatio=false)), Diagram(
-        coordinateSystem(preserveAspectRatio=false)),
-    experiment(
-      StartTime=13392000,
-      StopTime=13478400,
-      Tolerance=1e-06,
-      __Dymola_Algorithm="Cvode"));
+  connect(weaDat.weaBus, weaBus)
+    annotation (Line(points={{-80,-74}, {-60,-74}, {-60,-44}, {-104,-44}}, color={255, 204, 51}, thickness=0.5));
+  connect(weaBus.TWetBul, cooPla.TWetBul)
+    annotation (Line(points={{-104,-44}, {-36,-44}}, color={255, 204, 51}, thickness=0.5));
+  connect(on.y, cooPla.on)
+    annotation (Line(points={{-79, 10}, {-44, 10}, {-44,-28}, {-36,-28}}, color={255, 0, 255}));
+  connect(disNet.port_bDisRet, cooPla.port_a)
+    annotation (Line(points={{16, 22.4}, {0, 22.4}, {0,-31}, {-14,-31}}, color={0, 127, 255}));
+  connect(cooPla.port_b, disNet.port_aDisSup)
+    annotation (Line(points={{-14,-41}, {-4,-41}, {-4, 26}, {16, 26}}, color={0, 127, 255}));
+  connect(disNet.port_bDisSup, disNet.port_aDisRet)
+    annotation (Line(points={{44, 26}, {52, 26}, {52, 22.4}, {44, 22.4}}, color={0, 127, 255}));
+  connect(TSetChiWatDis.y, cooPla.TCHWSupSet)
+    annotation (Line(points={{-59,-30}, {-48,-30}, {-48,-33}, {-36,-33}}, color={0, 0, 127}));
+  for i in 1 : nBui loop
+    connect(heaSou.ports[i], bui_ETS[i].port_a1)
+      annotation (Line(points={{-22, 80}, {8, 80}, {8, 76}, {20, 76}}, color={0, 127, 255}));
+    connect(heaSin.ports[i], bui_ETS[i].port_b1)
+      annotation (Line(points={{62, 82}, {52, 82}, {52, 76}, {40, 76}}, color={0, 127, 255}));
+    connect(disNet.ports_bCon[i], bui_ETS[i].port_a2)
+      annotation (Line(points={{21.6, 32}, {22, 32}, {22, 40}, {52, 40}, {52, 64}, {40, 64}}, color={0, 127, 255}));
+    connect(disNet.ports_aCon[i], bui_ETS[i].port_b2)
+      annotation (Line(points={{38.4, 32}, {38.4, 40}, {8, 40}, {8, 64}, {20, 64}}, color={0, 127, 255}));
+  end for;
+  connect(firOrdDel.y, cooPla.dpMea)
+    annotation (Line(points={{29,-80}, {-48,-80}, {-48,-39}, {-36,-39}}, color={0, 0, 127}));
+  connect(disNet.dp, firOrdDel.u)
+    annotation (Line(points={{44.7, 27.8}, {80, 27.8}, {80,-80}, {52,-80}}, color={0, 0, 127}));
+  connect(TSetChiWatBui.y, bui_ETS.TSetChiWat)
+    annotation (Line(points={{-61, 50}, {0, 50}, {0, 73}, {19, 73}}, color={0, 0, 127}));
+  annotation (Icon(coordinateSystem(preserveAspectRatio=false)), Diagram(coordinateSystem(preserveAspectRatio=false)), experiment(StartTime=13392000, StopTime=13478400, Tolerance=1e-06, __Dymola_Algorithm="Cvode"));
 end DistrictCoolingSystem;

--- a/geojson_modelica_translator/model_connectors/templates/DistrictCoolingSystem.mo
+++ b/geojson_modelica_translator/model_connectors/templates/DistrictCoolingSystem.mo
@@ -2,7 +2,6 @@
 
 model DistrictCoolingSystem "Example to test the district cooling system."
   extends Modelica.Icons.Example;
-{% raw %}
  package MediumW = Buildings.Media.Water "Medium model for water";
   inner parameter
    DesignDataParallel4GDC datDes(
@@ -172,4 +171,3 @@ annotation (Icon(coordinateSystem(preserveAspectRatio=false)), Diagram(
       Tolerance=1e-06,
       __Dymola_Algorithm="Cvode"));
 end DistrictCoolingSystem;
-{% endraw %}

--- a/geojson_modelica_translator/model_connectors/templates/HydraulicHeader.mo
+++ b/geojson_modelica_translator/model_connectors/templates/HydraulicHeader.mo
@@ -1,90 +1,67 @@
 // within geojson_modelica_translator.model_connectors.templates;
-model HydraulicHeader "Hydraulic header manifold"
-  replaceable package Medium = Modelica.Media.Interfaces.PartialMedium
+model HydraulicHeader
+  "Hydraulic header manifold"
+  replaceable package Medium=Modelica.Media.Interfaces.PartialMedium
     "Medium model";
   parameter Modelica.SIunits.MassFlowRate m_flow_nominal
     "Nominal mass flow rate";
-  parameter Integer nPorts_a = 0
+  parameter Integer nPorts_a=0
     "Number of ports"
-    annotation(Dialog(connectorSizing=true, tab="General",group="Ports"), Evaluate=true);
-  parameter Integer nPorts_b = 0
+    annotation (Dialog(connectorSizing=true, tab="General", group="Ports"), Evaluate=true);
+  parameter Integer nPorts_b=0
     "Number of ports"
-    annotation(Dialog(connectorSizing=true, tab="General",group="Ports"), Evaluate=true);
-  parameter Boolean allowFlowReversal = true
+    annotation (Dialog(connectorSizing=true, tab="General", group="Ports"), Evaluate=true);
+  parameter Boolean allowFlowReversal=true
     "= true to allow flow reversal, false restricts to design direction (port_a -> port_b)"
-    annotation(Dialog(tab="Assumptions"), Evaluate=true);
+    annotation (Dialog(tab="Assumptions"), Evaluate=true);
   Modelica.Fluid.Interfaces.FluidPorts_a ports_a[nPorts_a](
     redeclare each final package Medium=Medium,
-    each m_flow(min=if allowFlowReversal then -Modelica.Constants.inf else 0),
-    each h_outflow(start=Medium.h_default, nominal=Medium.h_default))
+    each m_flow(
+      min=
+        if allowFlowReversal then
+          -Modelica.Constants.inf
+        else
+          0),
+    each h_outflow(
+      start=Medium.h_default,
+      nominal=Medium.h_default))
     "Fluid connectors a (positive design flow direction is from ports_a to ports_b)"
-    annotation (Placement(
-      transformation(extent={{-110,-40},{-90,40}}),
-        iconTransformation(extent={{-10,-40}, {10,40}},
-       rotation=90,
-       origin={-60,0})));
+    annotation (Placement(transformation(extent={{-110,-40}, {-90, 40}}), iconTransformation(extent={{-10,-40}, {10, 40}}, rotation=90, origin={-60, 0})));
   Modelica.Fluid.Interfaces.FluidPorts_b ports_b[nPorts_b](
     redeclare each final package Medium=Medium,
-    each m_flow(max=if allowFlowReversal then +Modelica.Constants.inf else 0),
-    each h_outflow(start=Medium.h_default, nominal=Medium.h_default))
+    each m_flow(
+      max=
+        if allowFlowReversal then
+          + Modelica.Constants.inf
+        else
+          0),
+    each h_outflow(
+      start=Medium.h_default,
+      nominal=Medium.h_default))
     "Fluid connectors b (positive design flow direction is from ports_a to ports_b)"
-    annotation (Placement(
-       transformation(extent={{90,-40},{110,40}}),
-       iconTransformation(extent={{-10,-40}, {10,40}},
-       rotation=90,
-       origin={60,0})));
+    annotation (Placement(transformation(extent={{90,-40}, {110, 40}}), iconTransformation(extent={{-10,-40}, {10, 40}}, rotation=90, origin={60, 0})));
   Buildings.Fluid.FixedResistances.LosslessPipe pip(
     redeclare final package Medium=Medium,
     final allowFlowReversal=allowFlowReversal,
     final m_flow_nominal=m_flow_nominal)
     "Dummy pipe component used to model ideal mixing at each port"
-    annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
+    annotation (Placement(transformation(extent={{-10,-10}, {10, 10}})));
 equation
-  for i in 1:nPorts_a loop
+  for i in 1 : nPorts_a loop
     connect(ports_a[i], pip.port_a)
-      annotation (Line(points={{-100,0},{-10,0}}, color={0,127,255}));
+      annotation (Line(points={{-100, 0}, {-10, 0}}, color={0, 127, 255}));
   end for;
-  for i in 1:nPorts_b loop
+  for i in 1 : nPorts_b loop
     connect(pip.port_b, ports_b[i])
-      annotation (Line(points={{10,0},{100,0},{100,0}}, color={0,127,255}));
-    end for;
-annotation (Icon(graphics={
-  Rectangle(
-   extent={{-90,40},{90,-40}},
-   lineColor={0,128,255},
-   lineThickness=0.5,
-   fillColor={170,213,255},
-   fillPattern=FillPattern.HorizontalCylinder,
-          pattern=LinePattern.None),
-  Rectangle(
-   extent={{-100,40},{-90,-40}},
-   lineColor={217,67,180},
-   lineThickness=0.5,
-   fillColor={0,0,0},
-   fillPattern=FillPattern.Solid,
-          pattern=LinePattern.None),
-  Rectangle(
-   extent={{90,40},{100,-40}},
-   lineColor={217,67,180},
-   lineThickness=0.5,
-   fillColor={0,0,0},
-   fillPattern=FillPattern.Solid,
-          pattern=LinePattern.None),
-  Text(
-   extent={{-149,93},{151,53}},
-   lineColor={0,0,255},
-   fillPattern=FillPattern.HorizontalCylinder,
-   fillColor={0,127,255},
-   textString="%name")}),
-   defaultComponentName="hdr",
-Documentation(info="<html>
+      annotation (Line(points={{10, 0}, {100, 0}, {100, 0}}, color={0, 127, 255}));
+  end for;
+  annotation (Icon(graphics={Rectangle(extent={{-90, 40}, {90,-40}}, lineColor={0, 128, 255}, lineThickness=0.5, fillColor={170, 213, 255}, fillPattern=FillPattern.HorizontalCylinder, pattern=LinePattern.None), Rectangle(extent={{-100, 40}, {-90,-40}}, lineColor={217, 67, 180}, lineThickness=0.5, fillColor={0, 0, 0}, fillPattern=FillPattern.Solid, pattern=LinePattern.None), Rectangle(extent={{90, 40}, {100,-40}}, lineColor={217, 67, 180}, lineThickness=0.5, fillColor={0, 0, 0}, fillPattern=FillPattern.Solid, pattern=LinePattern.None), Text(extent={{-149, 93}, {151, 53}}, lineColor={0, 0, 255}, fillPattern=FillPattern.HorizontalCylinder, fillColor={0, 127, 255}, textString="%name")}), defaultComponentName="hdr", Documentation(info="<html>
 <h4>Hydraulic header</h4>
 <p>
 The model represents a header or a common pipe which hydraulically splits
 up the entering flow into the branch circuits attached to it with zero head loss.
 </p>
-</html>",
-revisions="<html>
+</html>", revisions="<html>
 <ul>
 <li>
 January 16, 2020 by Antoine Gauitier:<br/>

--- a/geojson_modelica_translator/model_connectors/templates/PartialBuilding.mo
+++ b/geojson_modelica_translator/model_connectors/templates/PartialBuilding.mo
@@ -1,136 +1,151 @@
 //within geojson_modelica_translator.model_connectors.templates
-partial model PartialBuilding "Partial class for building model"
-  replaceable package Medium = Modelica.Media.Interfaces.PartialMedium
+partial model PartialBuilding
+  "Partial class for building model"
+  replaceable package Medium=Modelica.Media.Interfaces.PartialMedium
     "Source side medium (heating or chilled water)"
-    annotation(choices(
-      choice(redeclare package Medium = Buildings.Media.Water "Water"),
-      choice(redeclare package Medium =
-        Buildings.Media.Antifreeze.PropyleneGlycolWater (
-          property_T=293.15, X_a=0.40) "Propylene glycol water, 40% mass fraction")));
-  parameter Integer nPorts_aHeaWat = 0
+    annotation (choices(choice(redeclare package Medium=Buildings.Media.Water
+      "Water"), choice(redeclare package Medium=Buildings.Media.Antifreeze.PropyleneGlycolWater(property_T=293.15, X_a=0.40)
+      "Propylene glycol water, 40% mass fraction")));
+  parameter Integer nPorts_aHeaWat=0
     "Number of heating water inlet ports"
-     annotation(Evaluate=true, Dialog(connectorSizing=true));
-  parameter Integer nPorts_bHeaWat = 0
+    annotation (Evaluate=true, Dialog(connectorSizing=true));
+  parameter Integer nPorts_bHeaWat=0
     "Number of heating water outlet ports"
-     annotation(Evaluate=true, Dialog(connectorSizing=true));
-  parameter Integer nPorts_aChiWat = 0
+    annotation (Evaluate=true, Dialog(connectorSizing=true));
+  parameter Integer nPorts_aChiWat=0
     "Number of chilled water inlet ports"
-     annotation(Evaluate=true, Dialog(connectorSizing=true));
-  parameter Integer nPorts_bChiWat = 0
+    annotation (Evaluate=true, Dialog(connectorSizing=true));
+  parameter Integer nPorts_bChiWat=0
     "Number of chilled water outlet ports"
-     annotation(Evaluate=true, Dialog(connectorSizing=true));
-  parameter Boolean have_watHea = true
+    annotation (Evaluate=true, Dialog(connectorSizing=true));
+  parameter Boolean have_watHea=true
     "Set to true if the building has water based heating system"
-    annotation(Evaluate=true);
-  parameter Boolean have_watCoo = true
+    annotation (Evaluate=true);
+  parameter Boolean have_watCoo=true
     "Set to true if the building has water based cooling system"
-    annotation(Evaluate=true);
-  parameter Boolean have_eleHea = true
+    annotation (Evaluate=true);
+  parameter Boolean have_eleHea=true
     "Set to true if the building has decentralized electric heating equipment"
-    annotation(Evaluate=true);
-  parameter Boolean have_eleCoo = true
+    annotation (Evaluate=true);
+  parameter Boolean have_eleCoo=true
     "Set to true if the building has decentralized electric cooling equipment"
-    annotation(Evaluate=true);
-  parameter Boolean have_fan = true
+    annotation (Evaluate=true);
+  parameter Boolean have_fan=true
     "Set to true if the power drawn by fan motors is computed"
-    annotation(Evaluate=true);
-  parameter Boolean have_pum = true
+    annotation (Evaluate=true);
+  parameter Boolean have_pum=true
     "Set to true if the power drawn by pump motors is computed"
-    annotation(Evaluate=true);
-  parameter Boolean have_weaBus = true
+    annotation (Evaluate=true);
+  parameter Boolean have_weaBus=true
     "Set to true for weather bus"
-    annotation(Evaluate=true);
+    annotation (Evaluate=true);
   parameter Boolean allowFlowReversal=false
     "= true to allow flow reversal, false restricts to design direction (port_a -> port_b)"
-    annotation(Dialog(tab="Assumptions"), Evaluate=true);
-  final parameter Boolean have_heaLoa = have_watHea or have_eleHea
+    annotation (Dialog(tab="Assumptions"), Evaluate=true);
+  final parameter Boolean have_heaLoa=have_watHea or have_eleHea
     "Set to true if the building has heating loads"
-    annotation(Evaluate=true);
-  final parameter Boolean have_cooLoa = have_watCoo or have_eleCoo
+    annotation (Evaluate=true);
+  final parameter Boolean have_cooLoa=have_watCoo or have_eleCoo
     "Set to true if the building has cooling loads"
-    annotation(Evaluate=true);
+    annotation (Evaluate=true);
   // IO CONNECTORS
   Buildings.BoundaryConditions.WeatherData.Bus weaBus if have_weaBus
     "Weather data bus"
-    annotation (Placement(
-    transformation(extent={{-16,284},{18,316}}),
-    iconTransformation(extent={{-16,198},{18,230}})));
+    annotation (Placement(transformation(extent={{-16, 284}, {18, 316}}), iconTransformation(extent={{-16, 198}, {18, 230}})));
   Modelica.Fluid.Interfaces.FluidPorts_a ports_aHeaWat[nPorts_aHeaWat](
-    redeclare each package Medium = Medium,
-    each m_flow(min=if allowFlowReversal then -Modelica.Constants.inf else 0),
-    each h_outflow(start=Medium.h_default, nominal=Medium.h_default)) if
-    have_watHea
+    redeclare each package Medium=Medium,
+    each m_flow(
+      min=
+        if allowFlowReversal then
+          -Modelica.Constants.inf
+        else
+          0),
+    each h_outflow(
+      start=Medium.h_default,
+      nominal=Medium.h_default)) if have_watHea
     "Heating water inlet ports"
-    annotation (Placement(transformation(extent={{-310,-100},{-290,-20}}),
-      iconTransformation(extent={{-310,-100},{-290,-20}})));
+    annotation (Placement(transformation(extent={{-310,-100}, {-290,-20}}), iconTransformation(extent={{-310,-100}, {-290,-20}})));
   Modelica.Fluid.Interfaces.FluidPorts_b ports_bHeaWat[nPorts_bHeaWat](
-    redeclare each package Medium = Medium,
-    each m_flow(max=if allowFlowReversal then +Modelica.Constants.inf else 0),
-    each h_outflow(start=Medium.h_default, nominal=Medium.h_default)) if
-    have_watHea
+    redeclare each package Medium=Medium,
+    each m_flow(
+      max=
+        if allowFlowReversal then
+          + Modelica.Constants.inf
+        else
+          0),
+    each h_outflow(
+      start=Medium.h_default,
+      nominal=Medium.h_default)) if have_watHea
     "Heating water outlet ports"
-    annotation (Placement(transformation(extent={{290,-100},{310,-20}}),
-      iconTransformation(extent={{290,-100},{310,-20}})));
+    annotation (Placement(transformation(extent={{290,-100}, {310,-20}}), iconTransformation(extent={{290,-100}, {310,-20}})));
   Modelica.Fluid.Interfaces.FluidPorts_a ports_aChiWat[nPorts_aChiWat](
-    redeclare each package Medium = Medium,
-    each m_flow(min=if allowFlowReversal then -Modelica.Constants.inf else 0),
-    each h_outflow(start=Medium.h_default, nominal=Medium.h_default)) if
-    have_watCoo
+    redeclare each package Medium=Medium,
+    each m_flow(
+      min=
+        if allowFlowReversal then
+          -Modelica.Constants.inf
+        else
+          0),
+    each h_outflow(
+      start=Medium.h_default,
+      nominal=Medium.h_default)) if have_watCoo
     "Chilled water inlet ports"
-    annotation (Placement(transformation(extent={{-310,-300},{-290,-220}}),
-      iconTransformation(extent={{-310,-220},{-290,-140}})));
+    annotation (Placement(transformation(extent={{-310,-300}, {-290,-220}}), iconTransformation(extent={{-310,-220}, {-290,-140}})));
   Modelica.Fluid.Interfaces.FluidPorts_b ports_bChiWat[nPorts_bChiWat](
-    redeclare each package Medium = Medium,
-    each m_flow(max=if allowFlowReversal then +Modelica.Constants.inf else 0),
-    each h_outflow(start=Medium.h_default, nominal=Medium.h_default)) if
-    have_watCoo
+    redeclare each package Medium=Medium,
+    each m_flow(
+      max=
+        if allowFlowReversal then
+          + Modelica.Constants.inf
+        else
+          0),
+    each h_outflow(
+      start=Medium.h_default,
+      nominal=Medium.h_default)) if have_watCoo
     "Chilled water outlet ports"
-    annotation (Placement(transformation(extent={{290,-300},{310,-220}}),
-      iconTransformation(extent={{290,-220},{310,-140}})));
+    annotation (Placement(transformation(extent={{290,-300}, {310,-220}}), iconTransformation(extent={{290,-220}, {310,-140}})));
   Modelica.Blocks.Interfaces.RealOutput QHea_flow(
-    final quantity="HeatFlowRate", final unit="W") if have_heaLoa
+    final quantity="HeatFlowRate",
+    final unit="W") if have_heaLoa
     "Total heating heat flow rate transferred to the loads (>=0)"
-    annotation (Placement(transformation(extent={{300,260},{340,300}}),
-      iconTransformation(extent={{300,240},{340,280}})));
+    annotation (Placement(transformation(extent={{300, 260}, {340, 300}}), iconTransformation(extent={{300, 240}, {340, 280}})));
   Modelica.Blocks.Interfaces.RealOutput QCoo_flow(
-    final quantity="HeatFlowRate", final unit="W") if have_cooLoa
+    final quantity="HeatFlowRate",
+    final unit="W") if have_cooLoa
     "Total cooling heat flow rate transferred to the loads (<=0)"
-    annotation (Placement(transformation(
-      extent={{300,220},{340,260}}),
-      iconTransformation(extent={{300,200},{340, 240}})));
+    annotation (Placement(transformation(extent={{300, 220}, {340, 260}}), iconTransformation(extent={{300, 200}, {340, 240}})));
   Modelica.Blocks.Interfaces.RealOutput PHea(
-    final quantity="Power", final unit="W") if have_eleHea
+    final quantity="Power",
+    final unit="W") if have_eleHea
     "Power drawn by decentralized heating equipment"
-    annotation (Placement(transformation(
-      extent={{300,180},{340,220}}),
-      iconTransformation(extent={{300,160},{340, 200}})));
+    annotation (Placement(transformation(extent={{300, 180}, {340, 220}}), iconTransformation(extent={{300, 160}, {340, 200}})));
   Modelica.Blocks.Interfaces.RealOutput PCoo(
-    quantity="Power", final unit="W") if have_eleCoo
+    quantity="Power",
+    final unit="W") if have_eleCoo
     "Power drawn by decentralized cooling equipment"
-    annotation (Placement(transformation(extent={{300,140},{340,180}}),
-      iconTransformation(extent={{300,120},{340,160}})));
+    annotation (Placement(transformation(extent={{300, 140}, {340, 180}}), iconTransformation(extent={{300, 120}, {340, 160}})));
   Modelica.Blocks.Interfaces.RealOutput PFan(
-    final quantity="Power", final unit="W") if have_fan
+    final quantity="Power",
+    final unit="W") if have_fan
     "Power drawn by fan motors"
-    annotation (Placement(transformation(extent={{300,100},{340,140}}),
-      iconTransformation(extent={{300,80},{340,120}})));
+    annotation (Placement(transformation(extent={{300, 100}, {340, 140}}), iconTransformation(extent={{300, 80}, {340, 120}})));
   Modelica.Blocks.Interfaces.RealOutput PPum(
-    final quantity="Power", final unit="W") if have_pum
+    final quantity="Power",
+    final unit="W") if have_pum
     "Power drawn by pump motors"
-    annotation (Placement(transformation(extent={{300,60},{340,100}}),
-      iconTransformation(extent={{300,40},{340,80}})));
+    annotation (Placement(transformation(extent={{300, 60}, {340, 100}}), iconTransformation(extent={{300, 40}, {340, 80}})));
 initial equation
-  assert(nPorts_aHeaWat == nPorts_bHeaWat,
-    "In " + getInstanceName() +
-    ": The numbers of heating water inlet ports (" + String(nPorts_aHeaWat) +
-    ") and outlet ports (" + String(nPorts_bHeaWat) + ") must be equal.");
-  assert(nPorts_aChiWat == nPorts_bChiWat,
-    "In " + getInstanceName() +
-    ": The numbers of chilled water inlet ports (" + String(nPorts_aChiWat) +
-    ") and outlet ports (" + String(nPorts_bChiWat) + ") must be equal.");
-annotation (
-  defaultComponentName="bui",
-  Documentation(info="<html>
+  assert(
+    nPorts_aHeaWat == nPorts_bHeaWat,
+    "In " + getInstanceName() + ": The numbers of heating water inlet ports (" + String(
+      nPorts_aHeaWat) + ") and outlet ports (" + String(
+      nPorts_bHeaWat) + ") must be equal.");
+  assert(
+    nPorts_aChiWat == nPorts_bChiWat,
+    "In " + getInstanceName() + ": The numbers of chilled water inlet ports (" + String(
+      nPorts_aChiWat) + ") and outlet ports (" + String(
+      nPorts_bChiWat) + ") must be equal.");
+  annotation (defaultComponentName="bui", Documentation(info="<html>
 <p>
 Partial model to be used for modeling the thermal loads on an energy
 transfer station or a dedicated plant.
@@ -154,86 +169,12 @@ Buildings.Applications.DHC.Loads.Examples</a>.
 <img alt=\"image\"
 src=\"modelica://Buildings/Resources/Images/Applications/DHC/Loads/PartialBuilding.png\"/>
 </p>
-</html>",
-revisions=
-"<html>
+</html>", revisions="<html>
 <ul>
 <li>
 February 21, 2020, by Antoine Gautier:<br/>
 First implementation.
 </li>
 </ul>
-</html>"),
-  Icon(
-  coordinateSystem(extent={{-300,-300},{300,300}}, preserveAspectRatio=false),
-  graphics={Rectangle(
-        extent={{-300,-300},{300,300}},
-        lineColor={0,0,127},
-        fillColor={255,255,255},
-        fillPattern=FillPattern.Solid),
-        Rectangle(
-          extent={{20,-188},{300,-172}},
-          lineColor={0,0,255},
-          pattern=LinePattern.None,
-          fillColor={255,0,0},
-          fillPattern=FillPattern.Solid),
-        Rectangle(
-          extent={{-300,-172},{-20,-188}},
-          lineColor={0,0,255},
-          pattern=LinePattern.None,
-          fillColor={0,0,255},
-          fillPattern=FillPattern.Solid),
-      Rectangle(
-        extent={{18,-38},{46,-10}},
-        lineColor={255,255,255},
-        fillColor={255,255,255},
-        fillPattern=FillPattern.Solid),
-        Text(
-          extent={{-150,-328},{150,-368}},
-          lineColor={0,0,255},
-          textString="%name"),
-        Rectangle(
-          extent={{20,-52},{300,-68}},
-          lineColor={0,0,255},
-          pattern=LinePattern.None,
-          fillColor={0,0,255},
-          fillPattern=FillPattern.Solid),
-        Rectangle(
-          extent={{-300,-68},{-20,-52}},
-          lineColor={0,0,255},
-          pattern=LinePattern.None,
-          fillColor={255,0,0},
-          fillPattern=FillPattern.Solid),
-      Rectangle(
-          extent={{-180,180},{174,-220}},
-          lineColor={150,150,150},
-          fillPattern=FillPattern.Sphere,
-          fillColor={255,255,255}),
-      Rectangle(
-        extent={{36,42},{108,114}},
-        lineColor={255,255,255},
-        fillColor={255,255,255},
-        fillPattern=FillPattern.Solid),
-      Rectangle(
-        extent={{-124,42},{-52,114}},
-        lineColor={255,255,255},
-        fillColor={255,255,255},
-        fillPattern=FillPattern.Solid),
-      Rectangle(
-        extent={{-126,-122},{-54,-50}},
-        lineColor={255,255,255},
-        fillColor={255,255,255},
-        fillPattern=FillPattern.Solid),
-      Rectangle(
-        extent={{40,-122},{112,-50}},
-        lineColor={255,255,255},
-        fillColor={255,255,255},
-        fillPattern=FillPattern.Solid),
-      Polygon(
-        points={{0,264},{-218,164},{220,164},{0,264}},
-        lineColor={95,95,95},
-        smooth=Smooth.None,
-        fillPattern=FillPattern.Solid,
-        fillColor={95,95,95})}),
-  Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-300,-300},{300,300}})));
+</html>"), Icon(coordinateSystem(extent={{-300,-300}, {300, 300}}, preserveAspectRatio=false), graphics={Rectangle(extent={{-300,-300}, {300, 300}}, lineColor={0, 0, 127}, fillColor={255, 255, 255}, fillPattern=FillPattern.Solid), Rectangle(extent={{20,-188}, {300,-172}}, lineColor={0, 0, 255}, pattern=LinePattern.None, fillColor={255, 0, 0}, fillPattern=FillPattern.Solid), Rectangle(extent={{-300,-172}, {-20,-188}}, lineColor={0, 0, 255}, pattern=LinePattern.None, fillColor={0, 0, 255}, fillPattern=FillPattern.Solid), Rectangle(extent={{18,-38}, {46,-10}}, lineColor={255, 255, 255}, fillColor={255, 255, 255}, fillPattern=FillPattern.Solid), Text(extent={{-150,-328}, {150,-368}}, lineColor={0, 0, 255}, textString="%name"), Rectangle(extent={{20,-52}, {300,-68}}, lineColor={0, 0, 255}, pattern=LinePattern.None, fillColor={0, 0, 255}, fillPattern=FillPattern.Solid), Rectangle(extent={{-300,-68}, {-20,-52}}, lineColor={0, 0, 255}, pattern=LinePattern.None, fillColor={255, 0, 0}, fillPattern=FillPattern.Solid), Rectangle(extent={{-180, 180}, {174,-220}}, lineColor={150, 150, 150}, fillPattern=FillPattern.Sphere, fillColor={255, 255, 255}), Rectangle(extent={{36, 42}, {108, 114}}, lineColor={255, 255, 255}, fillColor={255, 255, 255}, fillPattern=FillPattern.Solid), Rectangle(extent={{-124, 42}, {-52, 114}}, lineColor={255, 255, 255}, fillColor={255, 255, 255}, fillPattern=FillPattern.Solid), Rectangle(extent={{-126,-122}, {-54,-50}}, lineColor={255, 255, 255}, fillColor={255, 255, 255}, fillPattern=FillPattern.Solid), Rectangle(extent={{40,-122}, {112,-50}}, lineColor={255, 255, 255}, fillColor={255, 255, 255}, fillPattern=FillPattern.Solid), Polygon(points={{0, 264}, {-218, 164}, {220, 164}, {0, 264}}, lineColor={95, 95, 95}, smooth=Smooth.None, fillPattern=FillPattern.Solid, fillColor={95, 95, 95})}), Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-300,-300}, {300, 300}})));
 end PartialBuilding;

--- a/geojson_modelica_translator/model_connectors/templates/PartialBuildingETS.mo
+++ b/geojson_modelica_translator/model_connectors/templates/PartialBuildingETS.mo
@@ -6,163 +6,38 @@ partial model PartialBuildingETS
     final m2_flow_small=1E-4*m2_flow_nominal,
     final allowFlowReversal1=allowFlowReversalDis,
     final allowFlowReversal2=allowFlowReversalBui);
-
-  parameter Boolean allowFlowReversalBui = false
+  parameter Boolean allowFlowReversalBui=false
     "Set to true to allow flow reversal on the building side"
-    annotation(Dialog(tab="Assumptions"), Evaluate=true);
-  parameter Boolean allowFlowReversalDis = false
+    annotation (Dialog(tab="Assumptions"), Evaluate=true);
+  parameter Boolean allowFlowReversalDis=false
     "Set to true to allow flow reversal on the district side"
-    annotation(Dialog(tab="Assumptions"), Evaluate=true);
+    annotation (Dialog(tab="Assumptions"), Evaluate=true);
   parameter Modelica.SIunits.TemperatureDifference dT_nominal=5
     "Water temperature drop/increase accross load and source-side HX (always positive)"
-    annotation(Dialog(group="ETS model parameters"));
+    annotation (Dialog(group="ETS model parameters"));
   parameter Modelica.SIunits.Temperature TChiWatSup_nominal
     "Chilled water supply temperature"
-    annotation(Dialog(group="ETS model parameters"));
-  parameter Modelica.SIunits.Temperature TChiWatRet_nominal= TChiWatSup_nominal + dT_nominal
-     "Chilled water return temperature"
-    annotation(Dialog(group="ETS model parameters"));
+    annotation (Dialog(group="ETS model parameters"));
+  parameter Modelica.SIunits.Temperature TChiWatRet_nominal=TChiWatSup_nominal + dT_nominal
+    "Chilled water return temperature"
+    annotation (Dialog(group="ETS model parameters"));
   parameter Modelica.SIunits.Temperature THeaWatSup_nominal=273.15 + 40
     "Heating water supply temperature"
-    annotation(Dialog(group="ETS model parameters"));
-  parameter Modelica.SIunits.Temperature THeaWatRet_nominal= THeaWatSup_nominal - dT_nominal
-     "Heating water return temperature"
-    annotation(Dialog(group="ETS model parameters"));
+    annotation (Dialog(group="ETS model parameters"));
+  parameter Modelica.SIunits.Temperature THeaWatRet_nominal=THeaWatSup_nominal-dT_nominal
+    "Heating water return temperature"
+    annotation (Dialog(group="ETS model parameters"));
   parameter Modelica.SIunits.Pressure dp_nominal=50000
-   "Pressure difference at nominal flow rate (for each flow leg)"
-    annotation(Dialog(group="ETS model parameters"));
-
+    "Pressure difference at nominal flow rate (for each flow leg)"
+    annotation (Dialog(group="ETS model parameters"));
   // IO CONNECTORS
   Modelica.Blocks.Interfaces.RealInput TSetChiWat
     "Chilled water set point"
-    annotation (Placement(transformation(
-        extent={{-20,-20},{20,20}},
-        rotation=0,
-        origin={-120,20}),
-        iconTransformation(
-        extent={{-10,-10},{10,10}},
-        rotation=0,
-        origin={-110,30})));
+    annotation (Placement(transformation(extent={{-20,-20}, {20, 20}}, rotation=0, origin={-120, 20}), iconTransformation(extent={{-10,-10}, {10, 10}}, rotation=0, origin={-110, 30})));
   // COMPONENTS
   replaceable Buildings.Applications.DHC.Loads.BaseClasses.PartialBuilding bui(
     final allowFlowReversal=allowFlowReversalBui)
     "Building model "
-    annotation (Placement(transformation(extent={{-30,8},{30,68}})));
-    annotation(Dialog(group="ETS model parameters"),
-    DefaultComponentName="bui",
-    Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},
-            {100,100}}), graphics={
-        Rectangle(
-          extent={{-60,-34},{0,-28}},
-          lineColor={0,0,255},
-          pattern=LinePattern.None,
-          fillColor={255,0,0},
-          fillPattern=FillPattern.Solid),
-        Rectangle(
-          extent={{-60,-34},{0,-40}},
-          lineColor={0,0,255},
-          pattern=LinePattern.None,
-          fillColor={0,0,255},
-          fillPattern=FillPattern.Solid),
-        Rectangle(
-          extent={{0,-40},{60,-34}},
-          lineColor={0,0,255},
-          pattern=LinePattern.None,
-          fillColor={255,0,0},
-          fillPattern=FillPattern.Solid),
-        Rectangle(
-          extent={{0,-28},{60,-34}},
-          lineColor={0,0,255},
-          pattern=LinePattern.None,
-          fillColor={0,0,255},
-          fillPattern=FillPattern.Solid),
-        Rectangle(
-          extent={{60,6},{100,0}},
-          lineColor={0,0,255},
-          pattern=LinePattern.None,
-          fillColor={0,0,255},
-          fillPattern=FillPattern.Solid),
-        Rectangle(
-          extent={{-100,0},{-60,-6}},
-          lineColor={0,0,255},
-          pattern=LinePattern.None,
-          fillColor={0,0,255},
-          fillPattern=FillPattern.Solid),
-        Rectangle(
-          extent={{-100,0},{-60,6}},
-          lineColor={0,0,255},
-          pattern=LinePattern.None,
-          fillColor={255,0,0},
-          fillPattern=FillPattern.Solid),
-        Rectangle(
-          extent={{60,-6},{100,0}},
-          lineColor={0,0,255},
-          pattern=LinePattern.None,
-          fillColor={255,0,0},
-          fillPattern=FillPattern.Solid),
-      Polygon(
-        points={{0,80},{-40,60},{40,60},{0,80}},
-        lineColor={95,95,95},
-        smooth=Smooth.None,
-        fillPattern=FillPattern.Solid,
-        fillColor={95,95,95}),
-      Rectangle(
-          extent={{-40,60},{40,-40}},
-          lineColor={150,150,150},
-          fillPattern=FillPattern.Sphere,
-          fillColor={255,255,255}),
-      Rectangle(
-        extent={{-30,30},{-10,50}},
-        lineColor={255,255,255},
-        fillColor={255,255,255},
-        fillPattern=FillPattern.Solid),
-      Rectangle(
-        extent={{10,30},{30,50}},
-        lineColor={255,255,255},
-        fillColor={255,255,255},
-        fillPattern=FillPattern.Solid),
-      Rectangle(
-        extent={{-30,-10},{-10,10}},
-        lineColor={255,255,255},
-        fillColor={255,255,255},
-        fillPattern=FillPattern.Solid),
-      Rectangle(
-        extent={{10,-10},{30,10}},
-        lineColor={255,255,255},
-        fillColor={255,255,255},
-        fillPattern=FillPattern.Solid),
-        Rectangle(extent={{-100,100},{100,-100}}, lineColor={0,0,0}),
-        Rectangle(
-          extent={{-20,-3},{20,3}},
-          lineColor={0,0,255},
-          pattern=LinePattern.None,
-          fillColor={255,0,0},
-          fillPattern=FillPattern.Solid,
-          origin={63,-20},
-          rotation=90),
-        Rectangle(
-          extent={{-19,3},{19,-3}},
-          lineColor={0,0,255},
-          pattern=LinePattern.None,
-          fillColor={0,0,255},
-          fillPattern=FillPattern.Solid,
-          origin={-63,-21},
-          rotation=90),
-        Rectangle(
-          extent={{-19,-3},{19,3}},
-          lineColor={0,0,255},
-          pattern=LinePattern.None,
-          fillColor={255,0,0},
-          fillPattern=FillPattern.Solid,
-          origin={-57,-13},
-          rotation=90),
-        Rectangle(
-          extent={{-19,3},{19,-3}},
-          lineColor={0,0,255},
-          pattern=LinePattern.None,
-          fillColor={0,0,255},
-          fillPattern=FillPattern.Solid,
-          origin={57,-13},
-          rotation=90)}),                                        Diagram(
-        coordinateSystem(preserveAspectRatio=false)));
+    annotation (Placement(transformation(extent={{-30, 8}, {30, 68}})));
+  annotation (Dialog(group="ETS model parameters"), DefaultComponentName="bui", Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100}, {100, 100}}), graphics={Rectangle(extent={{-60,-34}, {0,-28}}, lineColor={0, 0, 255}, pattern=LinePattern.None, fillColor={255, 0, 0}, fillPattern=FillPattern.Solid), Rectangle(extent={{-60,-34}, {0,-40}}, lineColor={0, 0, 255}, pattern=LinePattern.None, fillColor={0, 0, 255}, fillPattern=FillPattern.Solid), Rectangle(extent={{0,-40}, {60,-34}}, lineColor={0, 0, 255}, pattern=LinePattern.None, fillColor={255, 0, 0}, fillPattern=FillPattern.Solid), Rectangle(extent={{0,-28}, {60,-34}}, lineColor={0, 0, 255}, pattern=LinePattern.None, fillColor={0, 0, 255}, fillPattern=FillPattern.Solid), Rectangle(extent={{60, 6}, {100, 0}}, lineColor={0, 0, 255}, pattern=LinePattern.None, fillColor={0, 0, 255}, fillPattern=FillPattern.Solid), Rectangle(extent={{-100, 0}, {-60,-6}}, lineColor={0, 0, 255}, pattern=LinePattern.None, fillColor={0, 0, 255}, fillPattern=FillPattern.Solid), Rectangle(extent={{-100, 0}, {-60, 6}}, lineColor={0, 0, 255}, pattern=LinePattern.None, fillColor={255, 0, 0}, fillPattern=FillPattern.Solid), Rectangle(extent={{60,-6}, {100, 0}}, lineColor={0, 0, 255}, pattern=LinePattern.None, fillColor={255, 0, 0}, fillPattern=FillPattern.Solid), Polygon(points={{0, 80}, {-40, 60}, {40, 60}, {0, 80}}, lineColor={95, 95, 95}, smooth=Smooth.None, fillPattern=FillPattern.Solid, fillColor={95, 95, 95}), Rectangle(extent={{-40, 60}, {40,-40}}, lineColor={150, 150, 150}, fillPattern=FillPattern.Sphere, fillColor={255, 255, 255}), Rectangle(extent={{-30, 30}, {-10, 50}}, lineColor={255, 255, 255}, fillColor={255, 255, 255}, fillPattern=FillPattern.Solid), Rectangle(extent={{10, 30}, {30, 50}}, lineColor={255, 255, 255}, fillColor={255, 255, 255}, fillPattern=FillPattern.Solid), Rectangle(extent={{-30,-10}, {-10, 10}}, lineColor={255, 255, 255}, fillColor={255, 255, 255}, fillPattern=FillPattern.Solid), Rectangle(extent={{10,-10}, {30, 10}}, lineColor={255, 255, 255}, fillColor={255, 255, 255}, fillPattern=FillPattern.Solid), Rectangle(extent={{-100, 100}, {100,-100}}, lineColor={0, 0, 0}), Rectangle(extent={{-20,-3}, {20, 3}}, lineColor={0, 0, 255}, pattern=LinePattern.None, fillColor={255, 0, 0}, fillPattern=FillPattern.Solid, origin={63,-20}, rotation=90), Rectangle(extent={{-19, 3}, {19,-3}}, lineColor={0, 0, 255}, pattern=LinePattern.None, fillColor={0, 0, 255}, fillPattern=FillPattern.Solid, origin={-63,-21}, rotation=90), Rectangle(extent={{-19,-3}, {19, 3}}, lineColor={0, 0, 255}, pattern=LinePattern.None, fillColor={255, 0, 0}, fillPattern=FillPattern.Solid, origin={-57,-13}, rotation=90), Rectangle(extent={{-19, 3}, {19,-3}}, lineColor={0, 0, 255}, pattern=LinePattern.None, fillColor={0, 0, 255}, fillPattern=FillPattern.Solid, origin={57,-13}, rotation=90)}), Diagram(coordinateSystem(preserveAspectRatio=false)));
 end PartialBuildingETS;

--- a/geojson_modelica_translator/model_connectors/templates/PartialBuildingWithCoolingIndirectETS.mo
+++ b/geojson_modelica_translator/model_connectors/templates/PartialBuildingWithCoolingIndirectETS.mo
@@ -6,173 +6,49 @@ partial model PartialBuildingWithCoolingIndirectETS
     final m2_flow_small=1E-4*m2_flow_nominal,
     final allowFlowReversal1=allowFlowReversalDis,
     final allowFlowReversal2=allowFlowReversalBui);
-
-  parameter Boolean allowFlowReversalBui = false
+  parameter Boolean allowFlowReversalBui=false
     "Set to true to allow flow reversal on the building side"
-    annotation(Dialog(tab="Assumptions"), Evaluate=true);
-  parameter Boolean allowFlowReversalDis = false
+    annotation (Dialog(tab="Assumptions"), Evaluate=true);
+  parameter Boolean allowFlowReversalDis=false
     "Set to true to allow flow reversal on the district side"
-    annotation(Dialog(tab="Assumptions"), Evaluate=true);
+    annotation (Dialog(tab="Assumptions"), Evaluate=true);
   // IO CONNECTORS
   Modelica.Blocks.Interfaces.RealInput TSetChiWat
     "Chilled water set point"
-    annotation (Placement(transformation(
-        extent={{-20,-20},{20,20}},
-        rotation=0,
-        origin={-120,20}),
-        iconTransformation(
-        extent={{-10,-10},{10,10}},
-        rotation=0,
-        origin={-110,30})));
+    annotation (Placement(transformation(extent={{-20,-20}, {20, 20}}, rotation=0, origin={-120, 20}), iconTransformation(extent={{-10,-10}, {10, 10}}, rotation=0, origin={-110, 30})));
   // COMPONENTS
   replaceable PartialBuilding bui(
     final allowFlowReversal=allowFlowReversalBui)
     "Building model "
-    annotation (Placement(transformation(extent={{-30,8},{30,68}})));
+    annotation (Placement(transformation(extent={{-30, 8}, {30, 68}})));
   replaceable CoolingIndirect ets
-      annotation (Placement(transformation(extent={{-30,-82},{30,-22}})));
+    annotation (Placement(transformation(extent={{-30,-82}, {30,-22}})));
   Buildings.Fluid.Actuators.Valves.TwoWayLinear val(
     use_inputFilter=false,
     final linearized=false)
     "Two way modulating valve"
-    annotation (Placement(transformation(extent={{10,10},{-10,-10}}, origin={60,-86})));
+    annotation (Placement(transformation(extent={{10, 10}, {-10,-10}}, origin={60,-86})));
   Modelica.Fluid.Sources.FixedBoundary preSou(
     nPorts=1)
-      annotation (Placement(transformation(extent={{-100,-98},{-80,-78}})));
+    annotation (Placement(transformation(extent={{-100,-98}, {-80,-78}})));
 equation
-  connect(TSetChiWat, ets.TSetBuiSup) annotation (Line(points={{-120,20},{-74,20},
-                    {-74,-52},{-36,-52}}, color={0,0,127}));
-  connect(port_b1, bui.ports_bHeaWat[1]) annotation (Line(points={{100,60},{60,60},
-              {60,32},{30,32}}, color={0,127,255}));
-  connect(port_a1, bui.ports_aHeaWat[1]) annotation (Line(points={{-100,60},{-60,
-              60},{-60,32},{-30,32}}, color={0,127,255}));
-  connect(val.port_b, ets.port_a1) annotation (Line(points={{50,-86},{-54,-86},{
-            -54,-34},{-30,-34}},  color={0,127,255}));
-  connect(port_a2,val. port_a) annotation (Line(points={{100,-60},{76,-60},{76,-86},
-            {70,-86}}, color={0,127,255}));
-  connect(ets.port_b1, port_b2) annotation (Line(points={{30,-34},{46,-34},{46,0},
-            {-80,0},{-80,-60},{-100,-60}}, color={0,127,255}));
-  connect(ets.port_a2, bui.ports_bChiWat[1]) annotation (Line(points={{30,-70},{
-            60,-70},{60,20},{30,20}}, color={0,127,255}));
-  connect(ets.port_b2,preSou. ports[1]) annotation (Line(points={{-30,-70},{-62,
-          -70},{-62,-88},{-80,-88}},     color={0,127,255}));
-  connect(ets.port_b2, bui.ports_aChiWat[1]) annotation (Line(points={{-30,-70},
-          {-62,-70},{-62,20},{-30,20}}, color={0,127,255}));
-annotation(Dialog(group="ETS model parameters"),
-    DefaultComponentName="bui",
-    Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},
-            {100,100}}), graphics={
-        Rectangle(
-          extent={{-60,-34},{0,-28}},
-          lineColor={0,0,255},
-          pattern=LinePattern.None,
-          fillColor={255,0,0},
-          fillPattern=FillPattern.Solid),
-        Rectangle(
-          extent={{-60,-34},{0,-40}},
-          lineColor={0,0,255},
-          pattern=LinePattern.None,
-          fillColor={0,0,255},
-          fillPattern=FillPattern.Solid),
-        Rectangle(
-          extent={{0,-40},{60,-34}},
-          lineColor={0,0,255},
-          pattern=LinePattern.None,
-          fillColor={255,0,0},
-          fillPattern=FillPattern.Solid),
-        Rectangle(
-          extent={{0,-28},{60,-34}},
-          lineColor={0,0,255},
-          pattern=LinePattern.None,
-          fillColor={0,0,255},
-          fillPattern=FillPattern.Solid),
-        Rectangle(
-          extent={{60,6},{100,0}},
-          lineColor={0,0,255},
-          pattern=LinePattern.None,
-          fillColor={0,0,255},
-          fillPattern=FillPattern.Solid),
-        Rectangle(
-          extent={{-100,0},{-60,-6}},
-          lineColor={0,0,255},
-          pattern=LinePattern.None,
-          fillColor={0,0,255},
-          fillPattern=FillPattern.Solid),
-        Rectangle(
-          extent={{-100,0},{-60,6}},
-          lineColor={0,0,255},
-          pattern=LinePattern.None,
-          fillColor={255,0,0},
-          fillPattern=FillPattern.Solid),
-        Rectangle(
-          extent={{60,-6},{100,0}},
-          lineColor={0,0,255},
-          pattern=LinePattern.None,
-          fillColor={255,0,0},
-          fillPattern=FillPattern.Solid),
-      Polygon(
-        points={{0,80},{-40,60},{40,60},{0,80}},
-        lineColor={95,95,95},
-        smooth=Smooth.None,
-        fillPattern=FillPattern.Solid,
-        fillColor={95,95,95}),
-      Rectangle(
-          extent={{-40,60},{40,-40}},
-          lineColor={150,150,150},
-          fillPattern=FillPattern.Sphere,
-          fillColor={255,255,255}),
-      Rectangle(
-        extent={{-30,30},{-10,50}},
-        lineColor={255,255,255},
-        fillColor={255,255,255},
-        fillPattern=FillPattern.Solid),
-      Rectangle(
-        extent={{10,30},{30,50}},
-        lineColor={255,255,255},
-        fillColor={255,255,255},
-        fillPattern=FillPattern.Solid),
-      Rectangle(
-        extent={{-30,-10},{-10,10}},
-        lineColor={255,255,255},
-        fillColor={255,255,255},
-        fillPattern=FillPattern.Solid),
-      Rectangle(
-        extent={{10,-10},{30,10}},
-        lineColor={255,255,255},
-        fillColor={255,255,255},
-        fillPattern=FillPattern.Solid),
-        Rectangle(extent={{-100,100},{100,-100}}, lineColor={0,0,0}),
-        Rectangle(
-          extent={{-20,-3},{20,3}},
-          lineColor={0,0,255},
-          pattern=LinePattern.None,
-          fillColor={255,0,0},
-          fillPattern=FillPattern.Solid,
-          origin={63,-20},
-          rotation=90),
-        Rectangle(
-          extent={{-19,3},{19,-3}},
-          lineColor={0,0,255},
-          pattern=LinePattern.None,
-          fillColor={0,0,255},
-          fillPattern=FillPattern.Solid,
-          origin={-63,-21},
-          rotation=90),
-        Rectangle(
-          extent={{-19,-3},{19,3}},
-          lineColor={0,0,255},
-          pattern=LinePattern.None,
-          fillColor={255,0,0},
-          fillPattern=FillPattern.Solid,
-          origin={-57,-13},
-          rotation=90),
-        Rectangle(
-          extent={{-19,3},{19,-3}},
-          lineColor={0,0,255},
-          pattern=LinePattern.None,
-          fillColor={0,0,255},
-          fillPattern=FillPattern.Solid,
-          origin={57,-13},
-          rotation=90)}),                                        Diagram(
-        coordinateSystem(preserveAspectRatio=false)));
+  connect(TSetChiWat, ets.TSetBuiSup)
+    annotation (Line(points={{-120, 20}, {-74, 20}, {-74,-52}, {-36,-52}}, color={0, 0, 127}));
+  connect(port_b1, bui.ports_bHeaWat[1])
+    annotation (Line(points={{100, 60}, {60, 60}, {60, 32}, {30, 32}}, color={0, 127, 255}));
+  connect(port_a1, bui.ports_aHeaWat[1])
+    annotation (Line(points={{-100, 60}, {-60, 60}, {-60, 32}, {-30, 32}}, color={0, 127, 255}));
+  connect(val.port_b, ets.port_a1)
+    annotation (Line(points={{50,-86}, {-54,-86}, {-54,-34}, {-30,-34}}, color={0, 127, 255}));
+  connect(port_a2, val.port_a)
+    annotation (Line(points={{100,-60}, {76,-60}, {76,-86}, {70,-86}}, color={0, 127, 255}));
+  connect(ets.port_b1, port_b2)
+    annotation (Line(points={{30,-34}, {46,-34}, {46, 0}, {-80, 0}, {-80,-60}, {-100,-60}}, color={0, 127, 255}));
+  connect(ets.port_a2, bui.ports_bChiWat[1])
+    annotation (Line(points={{30,-70}, {60,-70}, {60, 20}, {30, 20}}, color={0, 127, 255}));
+  connect(ets.port_b2, preSou.ports[1])
+    annotation (Line(points={{-30,-70}, {-62,-70}, {-62,-88}, {-80,-88}}, color={0, 127, 255}));
+  connect(ets.port_b2, bui.ports_aChiWat[1])
+    annotation (Line(points={{-30,-70}, {-62,-70}, {-62, 20}, {-30, 20}}, color={0, 127, 255}));
+  annotation (Dialog(group="ETS model parameters"), DefaultComponentName="bui", Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100}, {100, 100}}), graphics={Rectangle(extent={{-60,-34}, {0,-28}}, lineColor={0, 0, 255}, pattern=LinePattern.None, fillColor={255, 0, 0}, fillPattern=FillPattern.Solid), Rectangle(extent={{-60,-34}, {0,-40}}, lineColor={0, 0, 255}, pattern=LinePattern.None, fillColor={0, 0, 255}, fillPattern=FillPattern.Solid), Rectangle(extent={{0,-40}, {60,-34}}, lineColor={0, 0, 255}, pattern=LinePattern.None, fillColor={255, 0, 0}, fillPattern=FillPattern.Solid), Rectangle(extent={{0,-28}, {60,-34}}, lineColor={0, 0, 255}, pattern=LinePattern.None, fillColor={0, 0, 255}, fillPattern=FillPattern.Solid), Rectangle(extent={{60, 6}, {100, 0}}, lineColor={0, 0, 255}, pattern=LinePattern.None, fillColor={0, 0, 255}, fillPattern=FillPattern.Solid), Rectangle(extent={{-100, 0}, {-60,-6}}, lineColor={0, 0, 255}, pattern=LinePattern.None, fillColor={0, 0, 255}, fillPattern=FillPattern.Solid), Rectangle(extent={{-100, 0}, {-60, 6}}, lineColor={0, 0, 255}, pattern=LinePattern.None, fillColor={255, 0, 0}, fillPattern=FillPattern.Solid), Rectangle(extent={{60,-6}, {100, 0}}, lineColor={0, 0, 255}, pattern=LinePattern.None, fillColor={255, 0, 0}, fillPattern=FillPattern.Solid), Polygon(points={{0, 80}, {-40, 60}, {40, 60}, {0, 80}}, lineColor={95, 95, 95}, smooth=Smooth.None, fillPattern=FillPattern.Solid, fillColor={95, 95, 95}), Rectangle(extent={{-40, 60}, {40,-40}}, lineColor={150, 150, 150}, fillPattern=FillPattern.Sphere, fillColor={255, 255, 255}), Rectangle(extent={{-30, 30}, {-10, 50}}, lineColor={255, 255, 255}, fillColor={255, 255, 255}, fillPattern=FillPattern.Solid), Rectangle(extent={{10, 30}, {30, 50}}, lineColor={255, 255, 255}, fillColor={255, 255, 255}, fillPattern=FillPattern.Solid), Rectangle(extent={{-30,-10}, {-10, 10}}, lineColor={255, 255, 255}, fillColor={255, 255, 255}, fillPattern=FillPattern.Solid), Rectangle(extent={{10,-10}, {30, 10}}, lineColor={255, 255, 255}, fillColor={255, 255, 255}, fillPattern=FillPattern.Solid), Rectangle(extent={{-100, 100}, {100,-100}}, lineColor={0, 0, 0}), Rectangle(extent={{-20,-3}, {20, 3}}, lineColor={0, 0, 255}, pattern=LinePattern.None, fillColor={255, 0, 0}, fillPattern=FillPattern.Solid, origin={63,-20}, rotation=90), Rectangle(extent={{-19, 3}, {19,-3}}, lineColor={0, 0, 255}, pattern=LinePattern.None, fillColor={0, 0, 255}, fillPattern=FillPattern.Solid, origin={-63,-21}, rotation=90), Rectangle(extent={{-19,-3}, {19, 3}}, lineColor={0, 0, 255}, pattern=LinePattern.None, fillColor={255, 0, 0}, fillPattern=FillPattern.Solid, origin={-57,-13}, rotation=90), Rectangle(extent={{-19, 3}, {19,-3}}, lineColor={0, 0, 255}, pattern=LinePattern.None, fillColor={0, 0, 255}, fillPattern=FillPattern.Solid, origin={57,-13}, rotation=90)}), Diagram(coordinateSystem(preserveAspectRatio=false)));
 end PartialBuildingWithCoolingIndirectETS;

--- a/geojson_modelica_translator/model_connectors/templates/PartialConnection2Pipe.mo
+++ b/geojson_modelica_translator/model_connectors/templates/PartialConnection2Pipe.mo
@@ -1,209 +1,231 @@
 //within Buildings.Applications.DHC.Examples.Combined.Generation5.Unidirectional.Networks;
 partial model PartialConnection2Pipe
   "Partial model for connecting an agent to a two-pipe distribution network"
-  replaceable package Medium = Modelica.Media.Interfaces.PartialMedium
+  replaceable package Medium=Modelica.Media.Interfaces.PartialMedium
     "Medium model"
-    annotation(choices(
-      choice(redeclare package Medium = Buildings.Media.Water "Water"),
-      choice(redeclare package Medium =
-        Buildings.Media.Antifreeze.PropyleneGlycolWater (
-          property_T=293.15, X_a=0.40) "Propylene glycol water, 40% mass fraction")));
-  replaceable model Model_pipDis = Buildings.Fluid.Interfaces.PartialTwoPortInterface (
-    redeclare final package Medium = Medium,
+    annotation (choices(choice(redeclare package Medium=Buildings.Media.Water
+      "Water"), choice(redeclare package Medium=Buildings.Media.Antifreeze.PropyleneGlycolWater(property_T=293.15, X_a=0.40)
+      "Propylene glycol water, 40% mass fraction")));
+  replaceable model Model_pipDis=Buildings.Fluid.Interfaces.PartialTwoPortInterface(
+    redeclare final package Medium=Medium,
     final m_flow_nominal=mDis_flow_nominal,
     final allowFlowReversal=allowFlowReversal);
-  replaceable model Model_pipCon = Buildings.Fluid.Interfaces.PartialTwoPortInterface (
-    redeclare final package Medium = Medium,
+  replaceable model Model_pipCon=Buildings.Fluid.Interfaces.PartialTwoPortInterface(
+    redeclare final package Medium=Medium,
     final m_flow_nominal=mCon_flow_nominal,
     final allowFlowReversal=allowFlowReversal);
-  parameter Boolean show_heaFlo = false
+  parameter Boolean show_heaFlo=false
     "Set to true to output the heat flow rate transferred to the connected load"
-    annotation(Evaluate=true);
+    annotation (Evaluate=true);
   parameter Modelica.SIunits.MassFlowRate mDis_flow_nominal
     "Nominal mass flow rate in the distribution line"
-    annotation(Dialog(tab="General", group="Nominal condition"));
+    annotation (Dialog(tab="General", group="Nominal condition"));
   parameter Modelica.SIunits.MassFlowRate mCon_flow_nominal
     "Nominal mass flow rate in the connection line"
-    annotation(Dialog(tab="General", group="Nominal condition"));
-  parameter Boolean allowFlowReversal = false
+    annotation (Dialog(tab="General", group="Nominal condition"));
+  parameter Boolean allowFlowReversal=false
     "= true to allow flow reversal, false restricts to design direction (port_a -> port_b)"
-    annotation(Dialog(tab="Assumptions"), Evaluate=true);
-  parameter Modelica.Fluid.Types.Dynamics energyDynamics=
-    Modelica.Fluid.Types.Dynamics.FixedInitial
+    annotation (Dialog(tab="Assumptions"), Evaluate=true);
+  parameter Modelica.Fluid.Types.Dynamics energyDynamics=Modelica.Fluid.Types.Dynamics.FixedInitial
     "Type of energy balance: dynamic (3 initialization options) or steady state"
-    annotation(Evaluate=true, Dialog(tab = "Dynamics", group="Equations"));
+    annotation (Evaluate=true, Dialog(tab="Dynamics", group="Equations"));
   final parameter Modelica.Fluid.Types.Dynamics massDynamics=energyDynamics
     "Type of mass balance: dynamic (3 initialization options) or steady state"
-    annotation(Evaluate=true, Dialog(tab = "Dynamics", group="Equations"));
+    annotation (Evaluate=true, Dialog(tab="Dynamics", group="Equations"));
   parameter Modelica.SIunits.Time tau=10
     "Time constant at nominal flow for dynamic energy and momentum balance"
-    annotation (
-      Dialog(tab="Dynamics", group="Nominal condition",
-      enable=not energyDynamics==Modelica.Fluid.Types.Dynamics.SteadyState));
+    annotation (Dialog(tab="Dynamics", group="Nominal condition", enable=not energyDynamics == Modelica.Fluid.Types.Dynamics.SteadyState));
   // IO CONNECTORS
   Modelica.Fluid.Interfaces.FluidPort_a port_aDisSup(
-    redeclare final package Medium = Medium,
-    m_flow(min=if allowFlowReversal then -Modelica.Constants.inf else 0),
-    h_outflow(start=Medium.h_default, nominal=Medium.h_default))
+    redeclare final package Medium=Medium,
+    m_flow(
+      min=
+        if allowFlowReversal then
+          -Modelica.Constants.inf
+        else
+          0),
+    h_outflow(
+      start=Medium.h_default,
+      nominal=Medium.h_default))
     "Distribution supply inlet port"
-    annotation (Placement(transformation(extent={{-110,-50},{-90,-30}}),
-      iconTransformation(extent={{-110,-10}, {-90,10}})));
+    annotation (Placement(transformation(extent={{-110,-50}, {-90,-30}}), iconTransformation(extent={{-110,-10}, {-90, 10}})));
   Modelica.Fluid.Interfaces.FluidPort_b port_bDisSup(
-    redeclare final package Medium = Medium,
-    m_flow(max=if allowFlowReversal then +Modelica.Constants.inf else 0),
-    h_outflow(start=Medium.h_default, nominal=Medium.h_default))
+    redeclare final package Medium=Medium,
+    m_flow(
+      max=
+        if allowFlowReversal then
+          + Modelica.Constants.inf
+        else
+          0),
+    h_outflow(
+      start=Medium.h_default,
+      nominal=Medium.h_default))
     "Distribution supply outlet port"
-    annotation (Placement(transformation(extent={{90,-50},{110,-30}}),
-      iconTransformation(extent={{90,-10},{ 110,10}})));
+    annotation (Placement(transformation(extent={{90,-50}, {110,-30}}), iconTransformation(extent={{90,-10}, {110, 10}})));
   Modelica.Fluid.Interfaces.FluidPort_a port_aDisRet(
-    redeclare final package Medium = Medium,
-    m_flow(min=if allowFlowReversal then -Modelica.Constants.inf else 0),
-    h_outflow(start=Medium.h_default, nominal=Medium.h_default))
+    redeclare final package Medium=Medium,
+    m_flow(
+      min=
+        if allowFlowReversal then
+          -Modelica.Constants.inf
+        else
+          0),
+    h_outflow(
+      start=Medium.h_default,
+      nominal=Medium.h_default))
     "Distribution return inlet port"
-    annotation (Placement(transformation(extent={{90,-90},{110,-70}}),
-      iconTransformation(extent={{90,-70},{ 110,-50}})));
+    annotation (Placement(transformation(extent={{90,-90}, {110,-70}}), iconTransformation(extent={{90,-70}, {110,-50}})));
   Modelica.Fluid.Interfaces.FluidPort_b port_bDisRet(
-    redeclare final package Medium = Medium,
-    m_flow(max=if allowFlowReversal then +Modelica.Constants.inf else 0),
-    h_outflow(start=Medium.h_default, nominal=Medium.h_default))
+    redeclare final package Medium=Medium,
+    m_flow(
+      max=
+        if allowFlowReversal then
+          + Modelica.Constants.inf
+        else
+          0),
+    h_outflow(
+      start=Medium.h_default,
+      nominal=Medium.h_default))
     "Distribution return outlet port"
-    annotation (Placement(transformation(extent={{-110,-90},{-90,-70}}),
-      iconTransformation(extent={{-110,-70}, {-90,-50}})));
+    annotation (Placement(transformation(extent={{-110,-90}, {-90,-70}}), iconTransformation(extent={{-110,-70}, {-90,-50}})));
   Modelica.Fluid.Interfaces.FluidPort_b port_bCon(
-    redeclare final package Medium = Medium,
-    m_flow(max=if allowFlowReversal then +Modelica.Constants.inf else 0),
-    h_outflow(start=Medium.h_default, nominal=Medium.h_default))
+    redeclare final package Medium=Medium,
+    m_flow(
+      max=
+        if allowFlowReversal then
+          + Modelica.Constants.inf
+        else
+          0),
+    h_outflow(
+      start=Medium.h_default,
+      nominal=Medium.h_default))
     "Connection supply port"
-    annotation (Placement(transformation(extent={{-30,110},{-10,130}}),
-      iconTransformation(extent={{-10,90},{10,110}})));
+    annotation (Placement(transformation(extent={{-30, 110}, {-10, 130}}), iconTransformation(extent={{-10, 90}, {10, 110}})));
   Modelica.Fluid.Interfaces.FluidPort_a port_aCon(
-    redeclare final package Medium = Medium,
-    m_flow(min=if allowFlowReversal then -Modelica.Constants.inf else 0),
-    h_outflow(start=Medium.h_default, nominal=Medium.h_default))
+    redeclare final package Medium=Medium,
+    m_flow(
+      min=
+        if allowFlowReversal then
+          -Modelica.Constants.inf
+        else
+          0),
+    h_outflow(
+      start=Medium.h_default,
+      nominal=Medium.h_default))
     "Connection return port"
-    annotation (Placement(transformation(extent={{10,110},{30,130}}),
-      iconTransformation(extent={{50,90},{70,110}})));
+    annotation (Placement(transformation(extent={{10, 110}, {30, 130}}), iconTransformation(extent={{50, 90}, {70, 110}})));
   Modelica.Blocks.Interfaces.RealOutput mCon_flow(
-    final quantity="MassFlowRate", final unit="kg/s")
+    final quantity="MassFlowRate",
+    final unit="kg/s")
     "Connection supply mass flow rate"
-    annotation (Placement(transformation(
-      extent={{100,20},{140,60}}),
-      iconTransformation(extent={{100,50},{120, 70}})));
+    annotation (Placement(transformation(extent={{100, 20}, {140, 60}}), iconTransformation(extent={{100, 50}, {120, 70}})));
   Modelica.Blocks.Interfaces.RealOutput Q_flow(
-    final quantity="HeatFlowRate", final unit="W") if show_heaFlo
+    final quantity="HeatFlowRate",
+    final unit="W") if show_heaFlo
     "Heat flow rate transferred to the connected load (>=0 for heating)"
-    annotation (Placement(transformation(extent={{100,60},{140,100}}),
-      iconTransformation(extent={{100,70},{120,90}})));
+    annotation (Placement(transformation(extent={{100, 60}, {140, 100}}), iconTransformation(extent={{100, 70}, {120, 90}})));
   Modelica.Blocks.Interfaces.RealOutput dp(
     final quantity="PressureDifference",
-    final unit="Pa", final displayUnit="Pa")
+    final unit="Pa",
+    final displayUnit="Pa")
     "Pressure drop accross the connection (measured)"
-    annotation (Placement(transformation(extent={{100,-20},{140,20}}),
-      iconTransformation(extent={{100,30},{120,50}})));
+    annotation (Placement(transformation(extent={{100,-20}, {140, 20}}), iconTransformation(extent={{100, 30}, {120, 50}})));
   // COMPONENTS
   Model_pipDis pipDisSup
     "Distribution supply pipe"
-    annotation (Placement(transformation(extent={{-80,-50},{-60,-30}})));
+    annotation (Placement(transformation(extent={{-80,-50}, {-60,-30}})));
   Model_pipDis pipDisRet
     "Distribution return pipe"
-    annotation (Placement(transformation(extent={{-60,-90},{-80,-70}})));
+    annotation (Placement(transformation(extent={{-60,-90}, {-80,-70}})));
   Model_pipCon pipCon
     "Connection pipe"
-    annotation (Placement(transformation(
-      extent={{-10,-10},{10,10}},
-      rotation=90,
-      origin={-20,-10})));
+    annotation (Placement(transformation(extent={{-10,-10}, {10, 10}}, rotation=90, origin={-20,-10})));
   Buildings.Fluid.FixedResistances.Junction junConSup(
-    redeclare final package Medium = Medium,
-    final portFlowDirection_1=if allowFlowReversal then
-      Modelica.Fluid.Types.PortFlowDirection.Bidirectional
-      else Modelica.Fluid.Types.PortFlowDirection.Entering,
-    final portFlowDirection_2=if allowFlowReversal then
-      Modelica.Fluid.Types.PortFlowDirection.Bidirectional
-      else Modelica.Fluid.Types.PortFlowDirection.Leaving,
-    final portFlowDirection_3=if allowFlowReversal then
-      Modelica.Fluid.Types.PortFlowDirection.Bidirectional
-      else Modelica.Fluid.Types.PortFlowDirection.Leaving,
-    final dp_nominal = {0, 0, 0},
+    redeclare final package Medium=Medium,
+    final portFlowDirection_1=
+      if allowFlowReversal then
+        Modelica.Fluid.Types.PortFlowDirection.Bidirectional
+      else
+        Modelica.Fluid.Types.PortFlowDirection.Entering,
+    final portFlowDirection_2=
+      if allowFlowReversal then
+        Modelica.Fluid.Types.PortFlowDirection.Bidirectional
+      else
+        Modelica.Fluid.Types.PortFlowDirection.Leaving,
+    final portFlowDirection_3=
+      if allowFlowReversal then
+        Modelica.Fluid.Types.PortFlowDirection.Bidirectional
+      else
+        Modelica.Fluid.Types.PortFlowDirection.Leaving,
+    final dp_nominal={0, 0, 0},
     final energyDynamics=energyDynamics,
     final massDynamics=massDynamics,
     final tau=tau,
     final m_flow_nominal={mDis_flow_nominal,-mDis_flow_nominal,-mCon_flow_nominal})
     "Junction with connection supply"
-    annotation (Placement(transformation(extent={{-30,-30},{-10,-50}})));
+    annotation (Placement(transformation(extent={{-30,-30}, {-10,-50}})));
   Buildings.Fluid.FixedResistances.Junction junConRet(
-    redeclare final package Medium = Medium,
-    final portFlowDirection_1=if allowFlowReversal then
-      Modelica.Fluid.Types.PortFlowDirection.Bidirectional
-      else Modelica.Fluid.Types.PortFlowDirection.Entering,
-    final portFlowDirection_2=if allowFlowReversal then
-      Modelica.Fluid.Types.PortFlowDirection.Bidirectional
-      else Modelica.Fluid.Types.PortFlowDirection.Leaving,
-    final portFlowDirection_3=if allowFlowReversal then
-      Modelica.Fluid.Types.PortFlowDirection.Bidirectional
-      else Modelica.Fluid.Types.PortFlowDirection.Entering,
-    final dp_nominal = {0, 0, 0},
+    redeclare final package Medium=Medium,
+    final portFlowDirection_1=
+      if allowFlowReversal then
+        Modelica.Fluid.Types.PortFlowDirection.Bidirectional
+      else
+        Modelica.Fluid.Types.PortFlowDirection.Entering,
+    final portFlowDirection_2=
+      if allowFlowReversal then
+        Modelica.Fluid.Types.PortFlowDirection.Bidirectional
+      else
+        Modelica.Fluid.Types.PortFlowDirection.Leaving,
+    final portFlowDirection_3=
+      if allowFlowReversal then
+        Modelica.Fluid.Types.PortFlowDirection.Bidirectional
+      else
+        Modelica.Fluid.Types.PortFlowDirection.Entering,
+    final dp_nominal={0, 0, 0},
     final energyDynamics=energyDynamics,
     final massDynamics=massDynamics,
     final tau=tau,
-    final m_flow_nominal={mDis_flow_nominal,-mDis_flow_nominal,mCon_flow_nominal})
+    final m_flow_nominal={mDis_flow_nominal,-mDis_flow_nominal, mCon_flow_nominal})
     "Junction with connection return"
-    annotation (Placement(transformation(extent={{30,-70},{10,-90}})));
-  Buildings.Fluid.Sensors.MassFlowRate senMasFloCon(redeclare final package
-      Medium = Medium,
+    annotation (Placement(transformation(extent={{30,-70}, {10,-90}})));
+  Buildings.Fluid.Sensors.MassFlowRate senMasFloCon(
+    redeclare final package Medium=Medium,
     final allowFlowReversal=allowFlowReversal)
     "Connection supply mass flow rate (measured)"
-    annotation (Placement(
-      transformation(
-      extent={{-10,10},{10,-10}},
-      rotation=90,
-      origin={-20,30})));
+    annotation (Placement(transformation(extent={{-10, 10}, {10,-10}}, rotation=90, origin={-20, 30})));
   Buildings.Fluid.Sensors.RelativePressure senRelPre(
     redeclare final package Medium=Medium)
     "Relative pressure sensor"
-    annotation (Placement(transformation(
-        extent={{-10,10},{10,-10}},
-        rotation=-90,
-        origin={-40,-60})));
+    annotation (Placement(transformation(extent={{-10, 10}, {10,-10}}, rotation=-90, origin={-40,-60})));
   Buildings.Fluid.Sensors.TemperatureTwoPort senTConSup(
-    redeclare final package Medium = Medium,
+    redeclare final package Medium=Medium,
     final allowFlowReversal=allowFlowReversal,
     final m_flow_nominal=mCon_flow_nominal) if show_heaFlo
     "Connection supply temperature sensor"
-    annotation (Placement(
-        transformation(
-        extent={{-10,-10},{10,10}},
-        rotation=90,
-        origin={-40,90})));
+    annotation (Placement(transformation(extent={{-10,-10}, {10, 10}}, rotation=90, origin={-40, 90})));
   Buildings.Fluid.Sensors.TemperatureTwoPort senTConRet(
-    redeclare final package Medium = Medium,
+    redeclare final package Medium=Medium,
     final allowFlowReversal=allowFlowReversal,
     final m_flow_nominal=mCon_flow_nominal) if show_heaFlo
     "Connection return temperature sensor"
-    annotation (Placement(transformation(
-        extent={{-10,10},{10,-10}},
-        rotation=-90,
-        origin={0,90})));
-  Buildings.Controls.OBC.CDL.Continuous.Add sub(final k1=-1) if show_heaFlo
+    annotation (Placement(transformation(extent={{-10, 10}, {10,-10}}, rotation=-90, origin={0, 90})));
+  Buildings.Controls.OBC.CDL.Continuous.Add sub(
+    final k1=-1) if show_heaFlo
     "Delta T"
-    annotation (Placement(transformation(extent={{-10,50},{10,70}})));
+    annotation (Placement(transformation(extent={{-10, 50}, {10, 70}})));
   Buildings.Controls.OBC.CDL.Continuous.Product pro if show_heaFlo
     "Delta T times flow rate"
-    annotation (Placement(transformation(extent={{40,50},{60,70}})));
+    annotation (Placement(transformation(extent={{40, 50}, {60, 70}})));
   Buildings.Controls.OBC.CDL.Continuous.Gain gai(
     final k=cp_default) if show_heaFlo
     "Times cp"
-    annotation (
-      Placement(transformation(
-        extent={{-10,-10},{10,10}},
-        rotation=0,
-        origin={82,80})));
+    annotation (Placement(transformation(extent={{-10,-10}, {10, 10}}, rotation=0, origin={82, 80})));
 protected
-  parameter Modelica.SIunits.SpecificHeatCapacity cp_default=
-    Medium.specificHeatCapacityCp(Medium.setState_pTX(
-      p = Medium.p_default,
-      T = Medium.T_default,
-      X = Medium.X_default))
+  parameter Modelica.SIunits.SpecificHeatCapacity cp_default=Medium.specificHeatCapacityCp(
+    Medium.setState_pTX(
+      p=Medium.p_default,
+      T=Medium.T_default,
+      X=Medium.X_default))
     "Specific heat capacity of medium at default medium state";
 equation
   // Connect statements involving conditionally removed components are
@@ -212,62 +234,55 @@ equation
   // to be programmatically removed.
   if not show_heaFlo then
     connect(port_bCon, senMasFloCon.port_b)
-      annotation (Line(points={{-20,120},{-20,40}}, color={0,127,255}));
+      annotation (Line(points={{-20, 120}, {-20, 40}}, color={0, 127, 255}));
     connect(port_aCon, junConRet.port_3)
-      annotation (Line(points={{20,120},{20,-70}}, color={0,127,255}));
+      annotation (Line(points={{20, 120}, {20,-70}}, color={0, 127, 255}));
   end if;
   connect(junConSup.port_3, pipCon.port_a)
-    annotation (Line(points={{-20,-30},{-20,-20}}, color={0,127,255}));
+    annotation (Line(points={{-20,-30}, {-20,-20}}, color={0, 127, 255}));
   connect(pipDisSup.port_b, junConSup.port_1)
-    annotation (Line(points={{-60,-40},{-30,-40}}, color={0,127,255}));
+    annotation (Line(points={{-60,-40}, {-30,-40}}, color={0, 127, 255}));
   connect(senMasFloCon.m_flow, mCon_flow)
-    annotation (Line(points={{-9,30},{54,30},{54,40},{120,40}},
-      color={0,0,127}));
+    annotation (Line(points={{-9, 30}, {54, 30}, {54, 40}, {120, 40}}, color={0, 0, 127}));
   connect(pipCon.port_b, senMasFloCon.port_a)
-    annotation (Line(points={{-20,0},{-20,20}}, color={0,127,255}));
+    annotation (Line(points={{-20, 0}, {-20, 20}}, color={0, 127, 255}));
   connect(port_aDisSup, pipDisSup.port_a)
-    annotation (Line(points={{-100,-40},{-80,-40}}, color={0,127,255}));
+    annotation (Line(points={{-100,-40}, {-80,-40}}, color={0, 127, 255}));
   connect(port_aDisRet, junConRet.port_1)
-    annotation (Line(points={{100,-80},{30,-80}}, color={0,127,255}));
+    annotation (Line(points={{100,-80}, {30,-80}}, color={0, 127, 255}));
   connect(junConSup.port_2, port_bDisSup)
-    annotation (Line(points={{-10,-40},{100,-40}}, color={0,127,255}));
+    annotation (Line(points={{-10,-40}, {100,-40}}, color={0, 127, 255}));
   connect(junConRet.port_2, pipDisRet.port_a)
-    annotation (Line(points={{10,-80},{-60,-80}}, color={0,127,255}));
+    annotation (Line(points={{10,-80}, {-60,-80}}, color={0, 127, 255}));
   connect(pipDisRet.port_b, port_bDisRet)
-    annotation (Line(points={{-80,-80},{-100,-80}}, color={0,127,255}));
+    annotation (Line(points={{-80,-80}, {-100,-80}}, color={0, 127, 255}));
   connect(senRelPre.port_a, junConSup.port_1)
-    annotation (Line(points={{-40,-50}, {-40,-40},{-30,-40}}, color={0,127,255}));
+    annotation (Line(points={{-40,-50}, {-40,-40}, {-30,-40}}, color={0, 127, 255}));
   connect(senRelPre.port_b, junConRet.port_2)
-    annotation (Line(points={{-40,-70}, {-40,-80},{10,-80}}, color={0,127,255}));
+    annotation (Line(points={{-40,-70}, {-40,-80}, {10,-80}}, color={0, 127, 255}));
   connect(senRelPre.p_rel, dp)
-    annotation (Line(points={{-31,-60},{80,-60},{80,0}, {120,0}}, color={0,0,127}));
+    annotation (Line(points={{-31,-60}, {80,-60}, {80, 0}, {120, 0}}, color={0, 0, 127}));
   connect(senMasFloCon.port_b, senTConSup.port_a)
-    annotation (Line(points={{-20,40},{-20,76},{-40,76},{-40,80}},
-      color={0,127,255}));
+    annotation (Line(points={{-20, 40}, {-20, 76}, {-40, 76}, {-40, 80}}, color={0, 127, 255}));
   connect(senTConSup.port_b, port_bCon)
-    annotation (Line(points={{-40,100},{-40,110},{-20,110},{-20,120}},
-      color={0,127,255}));
+    annotation (Line(points={{-40, 100}, {-40, 110}, {-20, 110}, {-20, 120}}, color={0, 127, 255}));
   connect(port_aCon, senTConRet.port_a)
-    annotation (Line(points={{20,120},{20,110},{0,110},{0,100},{1.77636e-15,
-      100}}, color={0,127,255}));
+    annotation (Line(points={{20, 120}, {20, 110}, {0, 110}, {0, 100}, {1.77636e-15, 100}}, color={0, 127, 255}));
   connect(senTConRet.port_b, junConRet.port_3)
-    annotation (Line(points={{-1.77636e-15,80},{-1.77636e-15,78},{0,78},{0,76},
-      {20,76},{20,-70}}, color={0,127,255}));
+    annotation (Line(points={{-1.77636e-15, 80}, {-1.77636e-15, 78}, {0, 78}, {0, 76}, {20, 76}, {20,-70}}, color={0, 127, 255}));
   connect(Q_flow, gai.y)
-    annotation (Line(points={{120,80},{94,80}}, color={0,0,127}));
+    annotation (Line(points={{120, 80}, {94, 80}}, color={0, 0, 127}));
   connect(pro.y, gai.u)
-    annotation (Line(points={{62,60},{66,60},{66,80},{70,80}}, color={0,0,127}));
+    annotation (Line(points={{62, 60}, {66, 60}, {66, 80}, {70, 80}}, color={0, 0, 127}));
   connect(senMasFloCon.m_flow, pro.u2)
-    annotation (Line(points={{-9,30},{30,30}, {30,54},{38,54}}, color={0,0,127}));
+    annotation (Line(points={{-9, 30}, {30, 30}, {30, 54}, {38, 54}}, color={0, 0, 127}));
   connect(sub.y, pro.u1)
-    annotation (Line(points={{12,60},{30,60},{30,66},{38, 66}}, color={0,0,127}));
+    annotation (Line(points={{12, 60}, {30, 60}, {30, 66}, {38, 66}}, color={0, 0, 127}));
   connect(senTConSup.T, sub.u2)
-    annotation (Line(points={{-51,90},{-60,90},{-60, 54},{-12,54}}, color={0,0,127}));
+    annotation (Line(points={{-51, 90}, {-60, 90}, {-60, 54}, {-12, 54}}, color={0, 0, 127}));
   connect(senTConRet.T, sub.u1)
-    annotation (Line(points={{-11,90},{-16,90},{-16, 66},{-12,66}}, color={0,0,127}));
-  annotation (
-    defaultComponentName="con",
-    Documentation(info="
+    annotation (Line(points={{-11, 90}, {-16, 90}, {-16, 66}, {-12, 66}}, color={0, 0, 127}));
+  annotation (defaultComponentName="con", Documentation(info="
 <html>
 <p>
 Partial model to be used for connecting an agent (e.g. an energy transfer station)
@@ -292,81 +307,12 @@ one must double the length so that both the supply and return lines are
 accounted for.
 </li>
 </ul>
-</html>",
-revisions=
-"<html>
+</html>", revisions="<html>
 <ul>
 <li>
 February 21, 2020, by Antoine Gautier:<br/>
 First implementation.
 </li>
 </ul>
-</html>"),
-    Icon(graphics={   Rectangle(
-          extent={{-100,-100},{100,100}},
-          lineColor={0,0,127},
-          fillColor={255,255,255},
-          fillPattern=FillPattern.Solid),
-        Rectangle(
-          extent={{-100,2},{100,-2}},
-          fillColor={0,0,0},
-          fillPattern=FillPattern.Solid,
-          pattern=LinePattern.None,
-          lineColor={0,0,0}),
-        Rectangle(
-          extent={{-2,-2},{2,100}},
-          fillColor={0,0,0},
-          fillPattern=FillPattern.Solid,
-          pattern=LinePattern.None,
-          lineColor={0,0,0}),           Text(
-        extent={{-152,-104},{148,-144}},
-        textString="%name",
-        lineColor={0,0,255}),
-        Rectangle(
-          extent={{-76,12},{-20,-12}},
-          fillColor={0,0,0},
-          fillPattern=FillPattern.Solid,
-          pattern=LinePattern.None,
-          lineColor={0,0,0}),
-        Rectangle(
-          extent={{-25,8},{25,-8}},
-          fillColor={0,0,0},
-          fillPattern=FillPattern.Solid,
-          pattern=LinePattern.None,
-          lineColor={0,0,0},
-          origin={0,45},
-          rotation=90),
-        Rectangle(
-          extent={{58,6},{62,100}},
-          fillColor={0,0,0},
-          fillPattern=FillPattern.Solid,
-          pattern=LinePattern.None,
-          lineColor={0,0,0}),
-        Rectangle(
-          extent={{-100,-58},{100,-62}},
-          fillColor={0,0,0},
-          fillPattern=FillPattern.Solid,
-          pattern=LinePattern.None,
-          lineColor={0,0,0}),
-        Rectangle(
-          extent={{-76,-48},{-20,-72}},
-          fillColor={0,0,0},
-          fillPattern=FillPattern.Solid,
-          pattern=LinePattern.None,
-          lineColor={0,0,0}),
-        Rectangle(
-          extent={{58,-62},{62,-6}},
-          fillColor={0,0,0},
-          fillPattern=FillPattern.Solid,
-          pattern=LinePattern.None,
-          lineColor={0,0,0}),
-        Rectangle(
-          extent={{-25.5,7.5},{25.5,-7.5}},
-          fillColor={0,0,0},
-          fillPattern=FillPattern.Solid,
-          pattern=LinePattern.None,
-          lineColor={0,0,0},
-          origin={59.5,45.5},
-          rotation=90)}),       Diagram(coordinateSystem(extent={{-100,-120},{100,
-            120}})));
+</html>"), Icon(graphics={Rectangle(extent={{-100,-100}, {100, 100}}, lineColor={0, 0, 127}, fillColor={255, 255, 255}, fillPattern=FillPattern.Solid), Rectangle(extent={{-100, 2}, {100,-2}}, fillColor={0, 0, 0}, fillPattern=FillPattern.Solid, pattern=LinePattern.None, lineColor={0, 0, 0}), Rectangle(extent={{-2,-2}, {2, 100}}, fillColor={0, 0, 0}, fillPattern=FillPattern.Solid, pattern=LinePattern.None, lineColor={0, 0, 0}), Text(extent={{-152,-104}, {148,-144}}, textString="%name", lineColor={0, 0, 255}), Rectangle(extent={{-76, 12}, {-20,-12}}, fillColor={0, 0, 0}, fillPattern=FillPattern.Solid, pattern=LinePattern.None, lineColor={0, 0, 0}), Rectangle(extent={{-25, 8}, {25,-8}}, fillColor={0, 0, 0}, fillPattern=FillPattern.Solid, pattern=LinePattern.None, lineColor={0, 0, 0}, origin={0, 45}, rotation=90), Rectangle(extent={{58, 6}, {62, 100}}, fillColor={0, 0, 0}, fillPattern=FillPattern.Solid, pattern=LinePattern.None, lineColor={0, 0, 0}), Rectangle(extent={{-100,-58}, {100,-62}}, fillColor={0, 0, 0}, fillPattern=FillPattern.Solid, pattern=LinePattern.None, lineColor={0, 0, 0}), Rectangle(extent={{-76,-48}, {-20,-72}}, fillColor={0, 0, 0}, fillPattern=FillPattern.Solid, pattern=LinePattern.None, lineColor={0, 0, 0}), Rectangle(extent={{58,-62}, {62,-6}}, fillColor={0, 0, 0}, fillPattern=FillPattern.Solid, pattern=LinePattern.None, lineColor={0, 0, 0}), Rectangle(extent={{-25.5, 7.5}, {25.5,-7.5}}, fillColor={0, 0, 0}, fillPattern=FillPattern.Solid, pattern=LinePattern.None, lineColor={0, 0, 0}, origin={59.5, 45.5}, rotation=90)}), Diagram(coordinateSystem(extent={{-100,-120}, {100, 120}})));
 end PartialConnection2Pipe;

--- a/geojson_modelica_translator/model_connectors/templates/PartialDistribution.mo
+++ b/geojson_modelica_translator/model_connectors/templates/PartialDistribution.mo
@@ -1,88 +1,82 @@
 //within Buildings.Applications.DHC.Examples.Combined.Generation5.Unidirectional.Networks;
 partial model PartialDistribution
   "Partial model for distribution network"
-  replaceable package Medium = Modelica.Media.Interfaces.PartialMedium
+  replaceable package Medium=Modelica.Media.Interfaces.PartialMedium
     "Medium model"
-    annotation(choices(
-      choice(redeclare package Medium = Buildings.Media.Water "Water"),
-      choice(redeclare package Medium =
-        Buildings.Media.Antifreeze.PropyleneGlycolWater (
-          property_T=293.15, X_a=0.40) "Propylene glycol water, 40% mass fraction")));
+    annotation (choices(choice(redeclare package Medium=Buildings.Media.Water
+      "Water"), choice(redeclare package Medium=Buildings.Media.Antifreeze.PropyleneGlycolWater(property_T=293.15, X_a=0.40)
+      "Propylene glycol water, 40% mass fraction")));
   parameter Integer nCon
     "Number of connections"
-    annotation(Dialog(tab="General"), Evaluate=true);
-  parameter Boolean allowFlowReversal = false
+    annotation (Dialog(tab="General"), Evaluate=true);
+  parameter Boolean allowFlowReversal=false
     "= true to allow flow reversal, false restricts to design direction (port_a -> port_b)"
-    annotation(Dialog(tab="Assumptions"), Evaluate=true);
+    annotation (Dialog(tab="Assumptions"), Evaluate=true);
   // IO CONNECTORS
   Modelica.Fluid.Interfaces.FluidPorts_a ports_aCon[nCon](
-    redeclare each final package Medium = Medium,
-    each m_flow(min=if allowFlowReversal then -Modelica.Constants.inf else 0),
-    each h_outflow(start=Medium.h_default, nominal=Medium.h_default))
+    redeclare each final package Medium=Medium,
+    each m_flow(
+      min=
+        if allowFlowReversal then
+          -Modelica.Constants.inf
+        else
+          0),
+    each h_outflow(
+      start=Medium.h_default,
+      nominal=Medium.h_default))
     "Connection return ports"
-    annotation (Placement(transformation(
-      extent={{-10,-40},{10,40}},
-      rotation=90,
-      origin={80,100}), iconTransformation(
-      extent={{-20,-80},{20,80}},
-      rotation=90,
-      origin={120,100})));
+    annotation (Placement(transformation(extent={{-10,-40}, {10, 40}}, rotation=90, origin={80, 100}), iconTransformation(extent={{-20,-80}, {20, 80}}, rotation=90, origin={120, 100})));
   Modelica.Fluid.Interfaces.FluidPorts_b ports_bCon[nCon](
-    redeclare each package Medium = Medium,
-    each m_flow(max=if allowFlowReversal then +Modelica.Constants.inf else 0),
-    each h_outflow(start=Medium.h_default, nominal=Medium.h_default))
+    redeclare each package Medium=Medium,
+    each m_flow(
+      max=
+        if allowFlowReversal then
+          + Modelica.Constants.inf
+        else
+          0),
+    each h_outflow(
+      start=Medium.h_default,
+      nominal=Medium.h_default))
     "Connection supply ports"
-    annotation (Placement(transformation(
-      extent={{-10,-40},{10,40}},
-      rotation=90,
-      origin={-80,100}), iconTransformation(
-      extent={{-20,-80},{20,80}},
-      rotation=90,
-      origin={-120,100})));
+    annotation (Placement(transformation(extent={{-10,-40}, {10, 40}}, rotation=90, origin={-80, 100}), iconTransformation(extent={{-20,-80}, {20, 80}}, rotation=90, origin={-120, 100})));
   Modelica.Fluid.Interfaces.FluidPort_a port_aDisSup(
-    redeclare final package Medium = Medium,
-    m_flow(min=if allowFlowReversal then -Modelica.Constants.inf else 0),
-    h_outflow(start=Medium.h_default, nominal=Medium.h_default))
+    redeclare final package Medium=Medium,
+    m_flow(
+      min=
+        if allowFlowReversal then
+          -Modelica.Constants.inf
+        else
+          0),
+    h_outflow(
+      start=Medium.h_default,
+      nominal=Medium.h_default))
     "Distribution supply inlet port"
-    annotation (Placement(transformation(extent={{-110,-10},{-90,10}}),
-      iconTransformation(extent={{-220,-20}, {-180,20}})));
+    annotation (Placement(transformation(extent={{-110,-10}, {-90, 10}}), iconTransformation(extent={{-220,-20}, {-180, 20}})));
   Modelica.Fluid.Interfaces.FluidPort_b port_bDisSup(
-    redeclare final package Medium = Medium,
-    m_flow(max=if allowFlowReversal then +Modelica.Constants.inf else 0),
-    h_outflow(start=Medium.h_default, nominal=Medium.h_default))
+    redeclare final package Medium=Medium,
+    m_flow(
+      max=
+        if allowFlowReversal then
+          + Modelica.Constants.inf
+        else
+          0),
+    h_outflow(
+      start=Medium.h_default,
+      nominal=Medium.h_default))
     "Distribution supply outlet port"
-    annotation (Placement(transformation( extent={{90,-10},{110,10}}),
-      iconTransformation(extent={{180,-20},{220,20}})));
-  annotation (
-    defaultComponentName="dis",
-    Documentation(info="
+    annotation (Placement(transformation(extent={{90,-10}, {110, 10}}), iconTransformation(extent={{180,-20}, {220, 20}})));
+  annotation (defaultComponentName="dis", Documentation(info="
 <html>
 <p>
 Partial model to be used for modeling various distribution networks e.g.
 one-pipe or two-pipe hydraulic distribution.
 </p>
-</html>",
-revisions=
-"<html>
+</html>", revisions="<html>
 <ul>
 <li>
 February 21, 2020, by Antoine Gautier:<br/>
 First implementation.
 </li>
 </ul>
-</html>"),
-  Icon(coordinateSystem(preserveAspectRatio=false,
-   extent={{-200,-100},{200,100}}),
-   graphics={
-    Text(
-      extent={{-149,-104},{151,-144}},
-      lineColor={0,0,255},
-      textString="%name"),
-      Rectangle(
-          extent={{-200,-100},{200,100}},
-          lineColor={0,0,127},
-          fillColor={255,255,255},
-          fillPattern=FillPattern.Solid)}),
-      Diagram(
-    coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{100,100}})));
+</html>"), Icon(coordinateSystem(preserveAspectRatio=false, extent={{-200,-100}, {200, 100}}), graphics={Text(extent={{-149,-104}, {151,-144}}, lineColor={0, 0, 255}, textString="%name"), Rectangle(extent={{-200,-100}, {200, 100}}, lineColor={0, 0, 127}, fillColor={255, 255, 255}, fillPattern=FillPattern.Solid)}), Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100}, {100, 100}})));
 end PartialDistribution;

--- a/geojson_modelica_translator/model_connectors/templates/PartialDistribution2Pipe.mo
+++ b/geojson_modelica_translator/model_connectors/templates/PartialDistribution2Pipe.mo
@@ -2,74 +2,84 @@
 partial model PartialDistribution2Pipe
   "Partial model for two-pipe distribution network"
   extends Buildings.Applications.DHC.Networks.BaseClasses.PartialDistribution;
-  replaceable model Model_pipDis = Buildings.Fluid.Interfaces.PartialTwoPortInterface (
-    redeclare final package Medium = Medium,
+  replaceable model Model_pipDis=Buildings.Fluid.Interfaces.PartialTwoPortInterface(
+    redeclare final package Medium=Medium,
     final allowFlowReversal=allowFlowReversal)
     "Model for distribution pipe";
-  parameter Integer iConDpSen(final max=nCon) = nCon
+  parameter Integer iConDpSen(
+    final max=nCon)=nCon
     "Index of the connection where the pressure drop is measured"
-    annotation(Dialog(tab="General"), Evaluate=true);
-  parameter Boolean show_heaFlo = false
+    annotation (Dialog(tab="General"), Evaluate=true);
+  parameter Boolean show_heaFlo=false
     "Set to true to output the heat flow rate transferred to each connected load"
-    annotation(Evaluate=true);
+    annotation (Evaluate=true);
   parameter Modelica.SIunits.MassFlowRate mDis_flow_nominal
     "Nominal mass flow rate in the distribution line before the first connection"
-    annotation(Dialog(tab="General", group="Nominal condition"));
+    annotation (Dialog(tab="General", group="Nominal condition"));
   parameter Modelica.SIunits.MassFlowRate mCon_flow_nominal[nCon]
     "Nominal mass flow rate in each connection line"
-    annotation(Dialog(tab="General", group="Nominal condition"));
-  final parameter Modelica.SIunits.MassFlowRate mEnd_flow_nominal=
-    mDis_flow_nominal - sum(mCon_flow_nominal)
+    annotation (Dialog(tab="General", group="Nominal condition"));
+  final parameter Modelica.SIunits.MassFlowRate mEnd_flow_nominal=mDis_flow_nominal-sum(
+    mCon_flow_nominal)
     "Nominal mass flow rate in the end of the distribution line"
-    annotation(Dialog(tab="General", group="Nominal condition"));
+    annotation (Dialog(tab="General", group="Nominal condition"));
   final parameter Modelica.SIunits.MassFlowRate mDisCon_flow_nominal[nCon]=cat(
     1,
     {mDis_flow_nominal},
-    {mDis_flow_nominal - sum(mCon_flow_nominal[1:i]) for i in 1:(nCon-1)})
+    {mDis_flow_nominal-sum(mCon_flow_nominal[1 : i]) for i in 1 :(nCon-1)})
     "Nominal mass flow rate in the distribution line before each connection";
   parameter Modelica.Fluid.Types.Dynamics energyDynamics=Modelica.Fluid.Types.Dynamics.FixedInitial
     "Type of energy balance: dynamic (3 initialization options) or steady state"
-    annotation(Evaluate=true, Dialog(tab = "Dynamics", group="Equations"));
-  parameter Modelica.SIunits.Time tau = 10
+    annotation (Evaluate=true, Dialog(tab="Dynamics", group="Equations"));
+  parameter Modelica.SIunits.Time tau=10
     "Time constant at nominal flow for dynamic energy and momentum balance"
-    annotation (
-      Dialog(tab="Dynamics", group="Nominal condition",
-      enable=not energyDynamics==Modelica.Fluid.Types.Dynamics.SteadyState));
+    annotation (Dialog(tab="Dynamics", group="Nominal condition", enable=not energyDynamics == Modelica.Fluid.Types.Dynamics.SteadyState));
   // IO CONNECTORS
   Modelica.Fluid.Interfaces.FluidPort_b port_bDisRet(
-    redeclare final package Medium = Medium,
-    m_flow(max=if allowFlowReversal then +Modelica.Constants.inf else 0),
-    h_outflow(start=Medium.h_default, nominal=Medium.h_default))
+    redeclare final package Medium=Medium,
+    m_flow(
+      max=
+        if allowFlowReversal then
+          + Modelica.Constants.inf
+        else
+          0),
+    h_outflow(
+      start=Medium.h_default,
+      nominal=Medium.h_default))
     "Distribution return outlet port"
-    annotation (Placement(transformation(extent={{-110,-70},{-90,-50}}),
-      iconTransformation(extent={{-220,-80}, {-180,-40}})));
+    annotation (Placement(transformation(extent={{-110,-70}, {-90,-50}}), iconTransformation(extent={{-220,-80}, {-180,-40}})));
   Modelica.Fluid.Interfaces.FluidPort_a port_aDisRet(
-    redeclare final package Medium = Medium,
-    m_flow(min=if allowFlowReversal then -Modelica.Constants.inf else 0),
-    h_outflow(start=Medium.h_default, nominal=Medium.h_default))
+    redeclare final package Medium=Medium,
+    m_flow(
+      min=
+        if allowFlowReversal then
+          -Modelica.Constants.inf
+        else
+          0),
+    h_outflow(
+      start=Medium.h_default,
+      nominal=Medium.h_default))
     "Distribution return inlet port"
-    annotation (Placement(transformation( extent={{90,-70},{110,-50}}),
-      iconTransformation(extent={{180,-80},{ 220,-40}})));
+    annotation (Placement(transformation(extent={{90,-70}, {110,-50}}), iconTransformation(extent={{180,-80}, {220,-40}})));
   Modelica.Blocks.Interfaces.RealOutput dp(
     final quantity="PressureDifference",
-    final unit="Pa", displayUnit="Pa") if iConDpSen >= 0
+    final unit="Pa",
+    displayUnit="Pa") if iConDpSen >= 0
     "Pressure difference at given location (measured)"
-    annotation (Placement(transformation(extent={{100,20},{140,60}}),
-      iconTransformation(extent={{200,20},{220,40}})));
+    annotation (Placement(transformation(extent={{100, 20}, {140, 60}}), iconTransformation(extent={{200, 20}, {220, 40}})));
   Modelica.Blocks.Interfaces.RealOutput Q_flow[nCon](
-    each final quantity="HeatFlowRate", each final unit="W") if show_heaFlo
+    each final quantity="HeatFlowRate",
+    each final unit="W") if show_heaFlo
     "Heat flow rate transferred to the connected load (>=0 for heating)"
-    annotation (Placement(transformation(extent={{100,60},{140,100}}),
-      iconTransformation(extent={{200,60},{220,80}})));
+    annotation (Placement(transformation(extent={{100, 60}, {140, 100}}), iconTransformation(extent={{200, 60}, {220, 80}})));
   Modelica.Blocks.Interfaces.RealOutput mCon_flow[nCon](
-    each final quantity="MassFlowRate", each final unit="kg/s")
+    each final quantity="MassFlowRate",
+    each final unit="kg/s")
     "Connection supply mass flow rate (measured)"
-    annotation (Placement(transformation(
-      extent={{100,40},{140,80}}),
-      iconTransformation(extent={{200,40},{220,60}})));
+    annotation (Placement(transformation(extent={{100, 40}, {140, 80}}), iconTransformation(extent={{200, 40}, {220, 60}})));
   // COMPONENTS
   replaceable PartialConnection2Pipe con[nCon](
-    redeclare each final package Medium = Medium,
+    redeclare each final package Medium=Medium,
     each final show_heaFlo=show_heaFlo,
     final mDis_flow_nominal=mDisCon_flow_nominal,
     final mCon_flow_nominal=mCon_flow_nominal,
@@ -77,67 +87,69 @@ partial model PartialDistribution2Pipe
     each final energyDynamics=energyDynamics,
     each final tau=tau)
     "Connection to agent"
-    annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
+    annotation (Placement(transformation(extent={{-10,-10}, {10, 10}})));
   Model_pipDis pipEnd(
     final m_flow_nominal=mEnd_flow_nominal)
     "Pipe representing the end of the distribution line (after last connection)"
-    annotation (Placement(transformation(extent={{60,-10},{80,10}})));
+    annotation (Placement(transformation(extent={{60,-10}, {80, 10}})));
   Buildings.Fluid.Sensors.RelativePressure senRelPre(
-    redeclare final package Medium = Medium) if iConDpSen == 0
+    redeclare final package Medium=Medium) if iConDpSen == 0
     "Relative pressure sensor"
-    annotation (Placement(transformation(extent={{-10,10},{10,-10}},
-      rotation=-90, origin={-60,-30})));
+    annotation (Placement(transformation(extent={{-10, 10}, {10,-10}}, rotation=-90, origin={-60,-30})));
 initial equation
-  assert(iConDpSen <= nCon, "In " + getInstanceName() +
-    ": iConDpSen = " + String(iConDpSen) + " whereas it must be lower than " +
-    String(nCon) + ".");
-  assert(mDis_flow_nominal >= sum(mCon_flow_nominal), "In " + getInstanceName() +
-    ": mDis_flow_nominal = " + String(mDis_flow_nominal) +
-    " whereas it must be higher than sum(mCon_flow_nominal) = " +
-    String(sum(mCon_flow_nominal)) + ".");
+  assert(
+    iConDpSen <= nCon,
+    "In " + getInstanceName() + ": iConDpSen = " + String(
+      iConDpSen) + " whereas it must be lower than " + String(
+      nCon) + ".");
+  assert(
+    mDis_flow_nominal >= sum(
+      mCon_flow_nominal),
+    "In " + getInstanceName() + ": mDis_flow_nominal = " + String(
+      mDis_flow_nominal) + " whereas it must be higher than sum(mCon_flow_nominal) = " + String(
+      sum(
+        mCon_flow_nominal)) + ".");
 equation
   // Connecting outlets to inlets for all instances of connection component.
   if nCon >= 2 then
-    for i in 2:nCon loop
-      connect(con[i - 1].port_bDisSup, con[i].port_aDisSup);
-      connect(con[i - 1].port_aDisRet, con[i].port_bDisRet);
+    for i in 2 : nCon loop
+      connect(con[i-1].port_bDisSup, con[i].port_aDisSup);
+      connect(con[i-1].port_aDisRet, con[i].port_bDisRet);
     end for;
   end if;
   // Connecting dp sensor (needs to be explicit because con[iConDpSen] is
   // undefined if iConDpSen <= 0).
   if iConDpSen > 0 then
     connect(con[iConDpSen].dp, dp)
-      annotation (Line(points={{11,4},{20,4},{20,20},{90,20},{90,40},{120,40}},
-        color={0,0,127}));
+      annotation (Line(points={{11, 4}, {20, 4}, {20, 20}, {90, 20}, {90, 40}, {120, 40}}, color={0, 0, 127}));
   end if;
   connect(senRelPre.p_rel, dp)
-    annotation (Line(points={{-51,-30},{90,-30},{90,40}, {120,40}}, color={0,0,127}));
+    annotation (Line(points={{-51,-30}, {90,-30}, {90, 40}, {120, 40}}, color={0, 0, 127}));
   connect(con.port_bCon, ports_bCon)
-    annotation (Line(points={{0,10},{0,40},{-80, 40},{-80,100}}, color={0,127,255}));
+    annotation (Line(points={{0, 10}, {0, 40}, {-80, 40}, {-80, 100}}, color={0, 127, 255}));
   connect(ports_aCon, con.port_aCon)
-    annotation (Line(points={{80,100},{80,40}, {6,40},{6,10}}, color={0,127,255}));
+    annotation (Line(points={{80, 100}, {80, 40}, {6, 40}, {6, 10}}, color={0, 127, 255}));
   connect(port_aDisSup, con[1].port_aDisSup)
-    annotation (Line(points={{-100,0},{-10,0}}, color={0,127,255}));
+    annotation (Line(points={{-100, 0}, {-10, 0}}, color={0, 127, 255}));
   connect(port_bDisRet, con[1].port_bDisRet)
-    annotation (Line(points={{-100,-60},{-40,-60},{-40,-6},{-10,-6}}, color={0,127,255}));
+    annotation (Line(points={{-100,-60}, {-40,-60}, {-40,-6}, {-10,-6}}, color={0, 127, 255}));
   connect(con[nCon].port_aDisRet, port_aDisRet)
-    annotation (Line(points={{10,-6},{40,-6},{40,-60},{100,-60}}, color={0,127,255}));
+    annotation (Line(points={{10,-6}, {40,-6}, {40,-60}, {100,-60}}, color={0, 127, 255}));
   connect(con[nCon].port_bDisSup, pipEnd.port_a)
-    annotation (Line(points={{10,0},{60,0}}, color={0,127,255}));
+    annotation (Line(points={{10, 0}, {60, 0}}, color={0, 127, 255}));
   connect(pipEnd.port_b, port_bDisSup)
-    annotation (Line(points={{80,0},{100,0}}, color={0,127,255}));
+    annotation (Line(points={{80, 0}, {100, 0}}, color={0, 127, 255}));
   connect(con.Q_flow, Q_flow)
-    annotation (Line(points={{11,8},{16,8},{16,24},{86, 24},{86,80},{120,80}}, color={0,0,127}));
+    annotation (Line(points={{11, 8}, {16, 8}, {16, 24}, {86, 24}, {86, 80}, {120, 80}}, color={0, 0, 127}));
   connect(con.mCon_flow, mCon_flow)
-    annotation (Line(points={{11,6},{18,6},{18,22}, {88,22},{88,60},{120,60}}, color={0,0,127}));
+    annotation (Line(points={{11, 6}, {18, 6}, {18, 22}, {88, 22}, {88, 60}, {120, 60}}, color={0, 0, 127}));
   connect(port_aDisSup, port_aDisSup)
-    annotation (Line(points={{-100,0},{-100,0}}, color={0,127,255}));
+    annotation (Line(points={{-100, 0}, {-100, 0}}, color={0, 127, 255}));
   connect(port_aDisSup, senRelPre.port_a)
-    annotation (Line(points={{-100,0},{-60,0},{-60,-20}}, color={0,127,255}));
+    annotation (Line(points={{-100, 0}, {-60, 0}, {-60,-20}}, color={0, 127, 255}));
   connect(senRelPre.port_b, port_bDisRet)
-    annotation (Line(points={{-60,-40},{-60, -60},{-100,-60}}, color={0,127,255}));
-  annotation (
-    Documentation(info="
+    annotation (Line(points={{-60,-40}, {-60,-60}, {-100,-60}}, color={0, 127, 255}));
+  annotation (Documentation(info="
 <html>
 <p>
 Partial model of a two-pipe distribution network.
@@ -160,56 +172,12 @@ Use a negative value if no sensor is needed.
 <p>
 Optionally the heat flow rate transferred to each connected load can be output.
 </p>
-</html>",
-revisions=
-"<html>
+</html>", revisions="<html>
 <ul>
 <li>
 February 21, 2020, by Antoine Gautier:<br/>
 First implementation.
 </li>
 </ul>
-</html>"),
-    Icon(coordinateSystem(preserveAspectRatio=false), graphics={
-        Rectangle(
-          extent={{-6,-200},{6,200}},
-          lineColor={0,0,255},
-          pattern=LinePattern.None,
-          fillColor={0,0,0},
-          fillPattern=FillPattern.Solid,
-          origin={0,0},
-          rotation=90),
-        Rectangle(
-          extent={{-53,4},{53,-4}},
-          lineColor={0,0,255},
-          pattern=LinePattern.None,
-          fillColor={0,0,0},
-          fillPattern=FillPattern.Solid,
-          origin={-120,47},
-          rotation=90),
-        Rectangle(
-          extent={{-44,4},{44,-4}},
-          lineColor={0,0,255},
-          pattern=LinePattern.None,
-          fillColor={0,0,0},
-          fillPattern=FillPattern.Solid,
-          origin={120,56},
-          rotation=90),
-        Rectangle(
-          extent={{-6,-200},{6,200}},
-          lineColor={0,0,255},
-          pattern=LinePattern.None,
-          fillColor={0,0,0},
-          fillPattern=FillPattern.Solid,
-          origin={0,-60},
-          rotation=90),
-        Rectangle(
-          extent={{-27,4},{27,-4}},
-          lineColor={0,0,255},
-          pattern=LinePattern.None,
-          fillColor={0,0,0},
-          fillPattern=FillPattern.Solid,
-          origin={120,-39},
-          rotation=90)}),
-    Diagram( coordinateSystem(preserveAspectRatio=false)));
+</html>"), Icon(coordinateSystem(preserveAspectRatio=false), graphics={Rectangle(extent={{-6,-200}, {6, 200}}, lineColor={0, 0, 255}, pattern=LinePattern.None, fillColor={0, 0, 0}, fillPattern=FillPattern.Solid, origin={0, 0}, rotation=90), Rectangle(extent={{-53, 4}, {53,-4}}, lineColor={0, 0, 255}, pattern=LinePattern.None, fillColor={0, 0, 0}, fillPattern=FillPattern.Solid, origin={-120, 47}, rotation=90), Rectangle(extent={{-44, 4}, {44,-4}}, lineColor={0, 0, 255}, pattern=LinePattern.None, fillColor={0, 0, 0}, fillPattern=FillPattern.Solid, origin={120, 56}, rotation=90), Rectangle(extent={{-6,-200}, {6, 200}}, lineColor={0, 0, 255}, pattern=LinePattern.None, fillColor={0, 0, 0}, fillPattern=FillPattern.Solid, origin={0,-60}, rotation=90), Rectangle(extent={{-27, 4}, {27,-4}}, lineColor={0, 0, 255}, pattern=LinePattern.None, fillColor={0, 0, 0}, fillPattern=FillPattern.Solid, origin={120,-39}, rotation=90)}), Diagram(coordinateSystem(preserveAspectRatio=false)));
 end PartialDistribution2Pipe;

--- a/geojson_modelica_translator/model_connectors/templates/PipeConnection.mo
+++ b/geojson_modelica_translator/model_connectors/templates/PipeConnection.mo
@@ -1,19 +1,14 @@
 //within Buildings.Applications.DHC.Examples.Combined.Generation5.Unidirectional.Networks;
-model PipeConnection "Building service connection pipe"
+model PipeConnection
+  "Building service connection pipe"
   extends Buildings.Fluid.FixedResistances.HydraulicDiameter(
-    dp(nominal=1E5),
+    dp(
+      nominal=1E5),
     dh=0,
     final ReC=6000,
     final linearized=false,
-    final v_nominal=m_flow_nominal * 4 / (rho_default * dh^2 * Modelica.Constants.pi));
-   // final fac=1.1,
-    // Steel straight pipe
-    annotation (
-    DefaultComponentName="pipCon",
-    Icon(graphics={
-        Rectangle(
-          extent={{-100,22},{100,-24}},
-          lineColor={0,0,0},
-          fillPattern=FillPattern.HorizontalCylinder,
-          fillColor={0,140,72})}));
+    final v_nominal=m_flow_nominal*4/(rho_default*dh^2*Modelica.Constants.pi));
+  // final fac=1.1,
+  // Steel straight pipe
+  annotation (DefaultComponentName="pipCon", Icon(graphics={Rectangle(extent={{-100, 22}, {100,-24}}, lineColor={0, 0, 0}, fillPattern=FillPattern.HorizontalCylinder, fillColor={0, 140, 72})}));
 end PipeConnection;

--- a/geojson_modelica_translator/model_connectors/templates/PipeDistribution.mo
+++ b/geojson_modelica_translator/model_connectors/templates/PipeDistribution.mo
@@ -1,32 +1,28 @@
 //within Buildings.Applications.DHC.Examples.Combined.Generation5.Unidirectional.Networks;
-model PipeDistribution "DHC distribution pipe"
+model PipeDistribution
+  "DHC distribution pipe"
   extends Buildings.Fluid.FixedResistances.HydraulicDiameter(
-    dp(nominal=1E5),
+    dp(
+      nominal=1E5),
     dh=0,
     final ReC=6000,
     final roughness=7E-6,
     final linearized=false,
-    final v_nominal=m_flow_nominal * 4 / (rho_default * dh^2 * Modelica.Constants.pi));
-   // fac=1.1,
-    // PE100 straight pipe
+    final v_nominal=m_flow_nominal*4/(rho_default*dh^2*Modelica.Constants.pi));
+// fac=1.1,
+// PE100 straight pipe
 equation
   when terminal() then
     if length > Modelica.Constants.eps then
       Modelica.Utilities.Streams.print(
-         "Pipe nominal pressure drop per meter for '" + getInstanceName() + "' is " +
-          String(integer( floor( dp_nominal / length + 0.5)))   + " Pa/m.");
+        "Pipe nominal pressure drop per meter for '" + getInstanceName() + "' is " + String(
+          integer(
+            floor(
+              dp_nominal/length + 0.5))) + " Pa/m.");
     else
       Modelica.Utilities.Streams.print(
-         "Zero pipe pressure drop for '" + getInstanceName() +
-         "' as the pipe length is set to zero.");
+        "Zero pipe pressure drop for '" + getInstanceName() + "' as the pipe length is set to zero.");
     end if;
   end when;
-  annotation (
-  DefaultComponentName="pipDis",
-  Icon(graphics={
-        Rectangle(
-          extent={{-100,22},{100,-24}},
-          lineColor={0,0,0},
-          fillPattern=FillPattern.HorizontalCylinder,
-          fillColor={0,140,72})}));
+  annotation (DefaultComponentName="pipDis", Icon(graphics={Rectangle(extent={{-100, 22}, {100,-24}}, lineColor={0, 0, 0}, fillPattern=FillPattern.HorizontalCylinder, fillColor={0, 140, 72})}));
 end PipeDistribution;

--- a/geojson_modelica_translator/model_connectors/templates/UnidirectionalParallel.mo
+++ b/geojson_modelica_translator/model_connectors/templates/UnidirectionalParallel.mo
@@ -3,9 +3,13 @@ model UnidirectionalParallel
   "Hydraulic network for unidirectional parallel DHC system"
   extends PartialDistribution2Pipe(
     redeclare ConnectionParallel con[nCon](
-      final lDis=lDis, final lCon=lCon, final dhDis=dhDis, final dhCon=dhCon),
-    redeclare model Model_pipDis = PipeDistribution (
-      final dh=dhEnd, final length=2*lEnd));
+      final lDis=lDis,
+      final lCon=lCon,
+      final dhDis=dhDis,
+      final dhCon=dhCon),
+    redeclare model Model_pipDis=PipeDistribution(
+      final dh=dhEnd,
+      final length=2*lEnd));
   parameter Modelica.SIunits.Length lDis[nCon]
     "Length of the distribution pipe before each connection (supply only, not counting return line)";
   parameter Modelica.SIunits.Length lCon[nCon]
@@ -16,6 +20,6 @@ model UnidirectionalParallel
     "Hydraulic diameter of the distribution pipe before each connection";
   parameter Modelica.SIunits.Length dhCon[nCon]
     "Hydraulic diameter of each connection pipe";
-  parameter Modelica.SIunits.Length dhEnd = dhDis[nCon]
+  parameter Modelica.SIunits.Length dhEnd=dhDis[nCon]
     "Hydraulic diameter of the end of the distribution line";
 end UnidirectionalParallel;


### PR DESCRIPTION
#### What does this PR accomplish? 
- Format all .mo files in the /templates directory using modelicafmt.
- See screenshots below for some possibly unexpected/undesired formatting results. We should probably have a discussion about these
#### Screenshots (if appropriate)
The unary `+` operator has a space after it
<img width="756" alt="Screen Shot 2020-07-02 at 10 59 59 AM" src="https://user-images.githubusercontent.com/18518728/86390229-eeecea00-bc54-11ea-92be-e78580db98a1.png">
String comments inside of annotations are put on new lines
<img width="996" alt="Screen Shot 2020-07-02 at 10 58 22 AM" src="https://user-images.githubusercontent.com/18518728/86390234-f1e7da80-bc54-11ea-9f48-33f1d274b376.png">
For loop expressions have place colon with space between logical expressions
<img width="964" alt="Screen Shot 2020-07-02 at 10 57 12 AM" src="https://user-images.githubusercontent.com/18518728/86390238-f3b19e00-bc54-11ea-982c-09fcba48a7b8.png">
