### PR TITLE
Add building in base

### DIFF
--- a/geojson_modelica_translator/model_connectors/base.py
+++ b/geojson_modelica_translator/model_connectors/base.py
@@ -83,11 +83,11 @@ class Base(object):
 
             try:
                 urbanopt_building.feature.properties["year_built"]
+                # UO SDK defaults to current year, however TEASER only supports up to Year 2015
+                # https://github.com/urbanopt/TEASER/blob/master/teaser/data/input/inputdata/TypeBuildingElements.json#L818
                 if urbanopt_building.feature.properties["year_built"] > 2015:
                     urbanopt_building.feature.properties["year_built"] = 2015
             except KeyError:
-                # UO SDK defaults to current year, however TEASER only supports up to Year 2015
-                # https://github.com/urbanopt/TEASER/blob/0614a11be16a8a95ef99fc8e763b737ec986013c/teaser/data/input/inputdata/TypeBuildingElements.json#L818  # noqa
                 urbanopt_building.feature.properties["year_built"] = 2015
 
             self.buildings.append(

--- a/geojson_modelica_translator/model_connectors/base.py
+++ b/geojson_modelica_translator/model_connectors/base.py
@@ -83,11 +83,11 @@ class Base(object):
 
             try:
                 urbanopt_building.feature.properties["year_built"]
+                if urbanopt_building.feature.properties["year_built"] > 2015:
+                    urbanopt_building.feature.properties["year_built"] = 2015
             except KeyError:
                 # UO SDK defaults to current year, however TEASER only supports up to Year 2015
                 # https://github.com/urbanopt/TEASER/blob/0614a11be16a8a95ef99fc8e763b737ec986013c/teaser/data/input/inputdata/TypeBuildingElements.json#L818  # noqa
-                urbanopt_building.feature.properties["year_built"] = 2015
-            if urbanopt_building.feature.properties["year_built"] > 2015:
                 urbanopt_building.feature.properties["year_built"] = 2015
 
             self.buildings.append(

--- a/geojson_modelica_translator/model_connectors/base.py
+++ b/geojson_modelica_translator/model_connectors/base.py
@@ -60,6 +60,48 @@ class Base(object):
         self.required_mo_files = []
         # extract data out of the urbanopt_building object and store into the base object
 
+    def add_building(self, urbanopt_building, mapper=None):
+        """
+        Add building to the translator.
+
+        :param urbanopt_building: an urbanopt_building
+        """
+        pass
+        # TODO: Need to convert units, these should exist on the urbanopt_building object
+        # TODO: Abstract out the GeoJSON functionality
+        if mapper is None:
+            number_stories = urbanopt_building.feature.properties["number_of_stories"]
+            try:
+                number_stories_above_ground = urbanopt_building.feature.properties["number_of_stories_above_ground"]
+            except KeyError:
+                number_stories_above_ground = urbanopt_building.feature.properties["number_of_stories"]
+
+            try:
+                urbanopt_building.feature.properties["floor_height"]
+            except KeyError:
+                urbanopt_building.feature.properties["floor_height"] = 3  # Default height in meters from sdk
+
+            try:
+                urbanopt_building.feature.properties["year_built"]
+            except KeyError:
+                # UO SDK defaults to current year, however TEASER only supports up to Year 2015
+                # https://github.com/urbanopt/TEASER/blob/0614a11be16a8a95ef99fc8e763b737ec986013c/teaser/data/input/inputdata/TypeBuildingElements.json#L818  # noqa
+                urbanopt_building.feature.properties["year_built"] = 2015
+            if urbanopt_building.feature.properties["year_built"] > 2015:
+                urbanopt_building.feature.properties["year_built"] = 2015
+
+            self.buildings.append(
+                {
+                    "area": float(urbanopt_building.feature.properties["floor_area"]) * 0.092936,  # ft2 -> m2
+                    "building_id": urbanopt_building.feature.properties["id"],
+                    "building_type": urbanopt_building.feature.properties["building_type"],
+                    "floor_height": urbanopt_building.feature.properties["floor_height"],  # Already converted to metric
+                    "num_stories": urbanopt_building.feature.properties["number_of_stories"],
+                    "num_stories_below_grade": number_stories - number_stories_above_ground,
+                    "year_built": urbanopt_building.feature.properties["year_built"],
+                }
+            )
+
     def copy_required_mo_files(self, dest_folder, within=None):
         """Copy any required_mo_files to the destination and update the within clause if defined
 

--- a/geojson_modelica_translator/model_connectors/spawn.py
+++ b/geojson_modelica_translator/model_connectors/spawn.py
@@ -43,48 +43,6 @@ class SpawnConnector(model_connector_base):
     def __init__(self, system_parameters):
         super().__init__(system_parameters)
 
-    def add_building(self, urbanopt_building, mapper=None):
-        """
-        Add building to the translator.
-
-        :param urbanopt_building: an urbanopt_building
-        """
-
-        # TODO: Need to convert units, these should exist on the urbanopt_building object
-        # TODO: Abstract out the GeoJSON functionality
-        if mapper is None:
-            number_stories = urbanopt_building.feature.properties["number_of_stories"]
-            try:
-                number_stories_above_ground = urbanopt_building.feature.properties["number_of_stories_above_ground"]
-            except KeyError:
-                number_stories_above_ground = urbanopt_building.feature.properties["number_of_stories"]
-
-            try:
-                urbanopt_building.feature.properties["floor_height"]
-            except KeyError:
-                urbanopt_building.feature.properties["floor_height"] = 3  # Default height in meters from sdk
-
-            try:
-                urbanopt_building.feature.properties["year_built"]
-            except KeyError:
-                # UO SDK defaults to current year, however TEASER only supports up to Year 2015
-                # https://github.com/urbanopt/TEASER/blob/0614a11be16a8a95ef99fc8e763b737ec986013c/teaser/data/input/inputdata/TypeBuildingElements.json#L818  # noqa
-                urbanopt_building.feature.properties["year_built"] = 2015
-            if urbanopt_building.feature.properties["year_built"] > 2015:
-                urbanopt_building.feature.properties["year_built"] = 2015
-
-            self.buildings.append(
-                {
-                    "area": urbanopt_building.feature.properties["floor_area"] * 0.092936,  # ft2 -> m2
-                    "building_id": urbanopt_building.feature.properties["id"],
-                    "building_type": urbanopt_building.feature.properties["building_type"],
-                    "floor_height": urbanopt_building.feature.properties["floor_height"],  # Already converted to metric in sdk  # noqa
-                    "num_stories": urbanopt_building.feature.properties["number_of_stories"],
-                    "num_stories_below_grade": number_stories - number_stories_above_ground,
-                    "year_built": urbanopt_building.feature.properties["year_built"],
-                }
-            )
-
     def to_modelica(self, scaffold, keep_original_models=False):
         """
         Create spawn models based on the data in the buildings and geojsons

--- a/geojson_modelica_translator/model_connectors/spawn_ets_coupling.py
+++ b/geojson_modelica_translator/model_connectors/spawn_ets_coupling.py
@@ -42,48 +42,6 @@ class SpawnConnectorETS(model_connector_base):
         super().__init__(system_parameters)
         self.required_mo_files.append(os.path.join(self.template_dir, 'HydraulicHeader.mo'))
 
-    def add_building(self, urbanopt_building, mapper=None):
-        """
-        Add building to the translator.
-
-        :param urbanopt_building: an urbanopt_building
-        """
-
-        # TODO: Need to convert units, these should exist on the urbanopt_building object
-        # TODO: Abstract out the GeoJSON functionality
-        if mapper is None:
-            number_stories = urbanopt_building.feature.properties["number_of_stories"]
-            try:
-                number_stories_above_ground = urbanopt_building.feature.properties["number_of_stories_above_ground"]
-            except KeyError:
-                number_stories_above_ground = urbanopt_building.feature.properties["number_of_stories"]
-
-            try:
-                urbanopt_building.feature.properties["floor_height"]
-            except KeyError:
-                urbanopt_building.feature.properties["floor_height"] = 3  # Default height in meters from sdk
-
-            try:
-                urbanopt_building.feature.properties["year_built"]
-            except KeyError:
-                # UO SDK defaults to current year, however TEASER only supports up to Year 2015
-                # https://github.com/urbanopt/TEASER/blob/0614a11be16a8a95ef99fc8e763b737ec986013c/teaser/data/input/inputdata/TypeBuildingElements.json#L818  # noqa
-                urbanopt_building.feature.properties["year_built"] = 2015
-            if urbanopt_building.feature.properties["year_built"] > 2015:
-                urbanopt_building.feature.properties["year_built"] = 2015
-
-            self.buildings.append(
-                {
-                    "area": urbanopt_building.feature.properties["floor_area"] * 0.092936,  # ft2 -> m2
-                    "building_id": urbanopt_building.feature.properties["id"],
-                    "building_type": urbanopt_building.feature.properties["building_type"],
-                    "floor_height": urbanopt_building.feature.properties["floor_height"],  # Already converted to metric in sdk  # noqa
-                    "num_stories": urbanopt_building.feature.properties["number_of_stories"],
-                    "num_stories_below_grade": number_stories - number_stories_above_ground,
-                    "year_built": urbanopt_building.feature.properties["year_built"],
-                }
-            )
-
     def to_modelica(self, scaffold, keep_original_models=False):
         """
         Create spawn models based on the data in the buildings and geojsons

--- a/geojson_modelica_translator/model_connectors/teaser.py
+++ b/geojson_modelica_translator/model_connectors/teaser.py
@@ -47,53 +47,6 @@ class TeaserConnector(model_connector_base):
     def __init__(self, system_parameters):
         super().__init__(system_parameters)
 
-    def add_building(self, urbanopt_building, mapper=None):
-        """
-        Add building to the translator.
-
-        :param urbanopt_building: an urbanopt_building
-        """
-        # TODO: Need to convert units, these should exist on the urbanopt_building object
-        # Units are ugly: https://docs.urbanopt.net/urbanopt-geojson-gem/schemas/building-properties.html shows most
-        # units are in feet, while https://github.com/urbanopt/urbanopt-geojson-gem/blob/develop/lib/urbanopt/geojson/building.rb#L114-L117  # noqa
-        # shows some things get changed to metric. Perhaps user-facing values are in feet while inside it is in metric?
-        # TODO: Abstract out the GeoJSON functionality
-        # note-1(Yanfei): any building/district geojson file needs to have the following properties.
-        # note-2(Yanfei): there is a need to clean the building/district geojson file, before making into modelica
-        if mapper is None:
-            number_stories = urbanopt_building.feature.properties["number_of_stories"]
-            try:
-                number_stories_above_ground = urbanopt_building.feature.properties["number_of_stories_above_ground"]
-            except KeyError:
-                number_stories_above_ground = urbanopt_building.feature.properties["number_of_stories"]
-
-            try:
-                urbanopt_building.feature.properties["floor_height"]
-            except KeyError:
-                urbanopt_building.feature.properties["floor_height"] = 3  # Default height in meters from sdk
-
-            try:
-                urbanopt_building.feature.properties["year_built"]
-            except KeyError:
-                # UO SDK defaults to current year, however TEASER only supports up to Year 2015
-                # https://github.com/urbanopt/TEASER/blob/0614a11be16a8a95ef99fc8e763b737ec986013c/teaser/data/input/inputdata/TypeBuildingElements.json#L818  # noqa
-                urbanopt_building.feature.properties["year_built"] = 2015
-            if urbanopt_building.feature.properties["year_built"] > 2015:
-                urbanopt_building.feature.properties["year_built"] = 2015
-
-            self.buildings.append(
-                {
-                    "area": float(urbanopt_building.feature.properties["floor_area"]) * 0.092936,  # ft2 -> m2
-                    "building_id": urbanopt_building.feature.properties["id"],
-                    "building_type": urbanopt_building.feature.properties["building_type"],
-                    "floor_height": urbanopt_building.feature.properties["floor_height"],  # Already converted to metric
-                    "num_stories": urbanopt_building.feature.properties["number_of_stories"],
-                    "num_stories_below_grade": number_stories - number_stories_above_ground,
-                    "year_built": urbanopt_building.feature.properties["year_built"],
-
-                }
-            )
-
     def lookup_building_type(self, building_type):
         """Look up the building type from the Enumerations in the building_properties.json schema. TEASER
         documentation on building types is here (look into the python files):

--- a/geojson_modelica_translator/model_connectors/teaser_ets_coupling.py
+++ b/geojson_modelica_translator/model_connectors/teaser_ets_coupling.py
@@ -47,53 +47,6 @@ class TeaserConnectorETS(model_connector_base):
     def __init__(self, system_parameters):
         super().__init__(system_parameters)
 
-    def add_building(self, urbanopt_building, mapper=None):
-        """
-        Add building to the translator.
-
-        :param urbanopt_building: an urbanopt_building
-        """
-        # TODO: Need to convert units, these should exist on the urbanopt_building object
-        # Units are ugly: https://docs.urbanopt.net/urbanopt-geojson-gem/schemas/building-properties.html shows most
-        # units are in feet, while https://github.com/urbanopt/urbanopt-geojson-gem/blob/develop/lib/urbanopt/geojson/building.rb#L114-L117  # noqa
-        # shows some things get changed to metric. Perhaps user-facing values are in feet while inside it is in metric?
-        # TODO: Abstract out the GeoJSON functionality
-        # note-1(Yanfei): any building/district geojson file needs to have the following properties.
-        # note-2(Yanfei): there is a need to clean the building/district geojson file, before making into modelica
-        if mapper is None:
-            number_stories = urbanopt_building.feature.properties["number_of_stories"]
-            try:
-                number_stories_above_ground = urbanopt_building.feature.properties["number_of_stories_above_ground"]
-            except KeyError:
-                number_stories_above_ground = urbanopt_building.feature.properties["number_of_stories"]
-
-            try:
-                urbanopt_building.feature.properties["floor_height"]
-            except KeyError:
-                urbanopt_building.feature.properties["floor_height"] = 3  # Default height in meters from sdk
-
-            try:
-                urbanopt_building.feature.properties["year_built"]
-            except KeyError:
-                # UO SDK defaults to current year, however TEASER only supports up to Year 2015
-                # https://github.com/urbanopt/TEASER/blob/0614a11be16a8a95ef99fc8e763b737ec986013c/teaser/data/input/inputdata/TypeBuildingElements.json#L818  # noqa
-                urbanopt_building.feature.properties["year_built"] = 2015
-            if urbanopt_building.feature.properties["year_built"] > 2015:
-                urbanopt_building.feature.properties["year_built"] = 2015
-
-            self.buildings.append(
-                {
-                    "area": float(urbanopt_building.feature.properties["floor_area"]) * 0.092936,  # ft2 -> m2
-                    "building_id": urbanopt_building.feature.properties["id"],
-                    "building_type": urbanopt_building.feature.properties["building_type"],
-                    "floor_height": urbanopt_building.feature.properties["floor_height"],  # Already converted to metric
-                    "num_stories": urbanopt_building.feature.properties["number_of_stories"],
-                    "num_stories_below_grade": number_stories - number_stories_above_ground,
-                    "year_built": urbanopt_building.feature.properties["year_built"],
-
-                }
-            )
-
     def lookup_building_type(self, building_type):
         """Look up the building type from the Enumerations in the building_properties.json schema. TEASER
         documentation on building types is here (look into the python files):

--- a/geojson_modelica_translator/model_connectors/time_series.py
+++ b/geojson_modelica_translator/model_connectors/time_series.py
@@ -41,30 +41,6 @@ class TimeSeriesConnector(model_connector_base):
     def __init__(self, system_parameters):
         super().__init__(system_parameters)
 
-    def add_building(self, urbanopt_building, mapper=None):
-        """
-        Add building to the translator.
-
-        :param urbanopt_building: an urbanopt_building
-        """
-        # TODO: Need to convert units, these should exist on the urbanopt_building object
-        # TODO: Abstract out the GeoJSON functionality
-
-        if mapper is None:
-            number_stories = urbanopt_building.feature.properties["number_of_stories"]
-            number_stories_above_ground = urbanopt_building.feature.properties["number_of_stories_above_ground"]
-            self.buildings.append(
-                {
-                    "area": urbanopt_building.feature.properties["floor_area"] * 0.092936,  # ft2 -> m2
-                    "building_id": urbanopt_building.feature.properties["id"],
-                    "building_type": urbanopt_building.feature.properties["building_type"],
-                    "floor_height": urbanopt_building.feature.properties["height"] * 0.3048,  # ft -> m
-                    "num_stories": urbanopt_building.feature.properties["number_of_stories_above_ground"],
-                    "num_stories_below_grade": number_stories - number_stories_above_ground,
-                    "year_built": urbanopt_building.feature.properties["year_built"],
-                }
-            )
-
     def to_modelica(self, scaffold):
         """
         Create timeSeries models based on the data in the buildings and geojsons

--- a/geojson_modelica_translator/model_connectors/time_series_ets_coupling.py
+++ b/geojson_modelica_translator/model_connectors/time_series_ets_coupling.py
@@ -41,30 +41,6 @@ class TimeSeriesConnectorETS(model_connector_base):
     def __init__(self, system_parameters):
         super().__init__(system_parameters)
 
-    def add_building(self, urbanopt_building, mapper=None):
-        """
-        Add building to the translator.
-
-        :param urbanopt_building: an urbanopt_building
-        """
-
-        # TODO: Need to convert units, these should exist on the urbanopt_building object
-        # TODO: Abstract out the GeoJSON functionality
-        if mapper is None:
-            number_stories = urbanopt_building.feature.properties["number_of_stories"]
-            number_stories_above_ground = urbanopt_building.feature.properties["number_of_stories_above_ground"]
-            self.buildings.append(
-                {
-                    "area": urbanopt_building.feature.properties["floor_area"] * 0.092936,  # ft2 -> m2
-                    "building_id": urbanopt_building.feature.properties["id"],
-                    "building_type": urbanopt_building.feature.properties["building_type"],
-                    "floor_height": urbanopt_building.feature.properties["height"] * 0.3048,  # ft -> m
-                    "num_stories": urbanopt_building.feature.properties["number_of_stories_above_ground"],
-                    "num_stories_below_grade": number_stories - number_stories_above_ground,
-                    "year_built": urbanopt_building.feature.properties["year_built"],
-                }
-            )
-
     def to_modelica(self, scaffold):
         """
         Create TimeSeries models based on the data in the buildings and geojsons


### PR DESCRIPTION
#### Any background context you want to provide?
First step in refactoring gmt
#### What does this PR accomplish?
Removes `add_building` method from the spawn, teaser, & time_series model connectors, and consolidates into the base class. Base class is already the super of each of those model connectors, so this was a very simple non-breaking DRY-up.
#### How should this be manually tested?
`py.test tests/model_connectors/test_spawn.py` (or any of the model connector tests, or just py.test for everything)
#### What are the relevant tickets?
#170 