### PR TITLE
Use modelica builder from pypi

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -161,15 +161,38 @@ Templating Diagram
 Release Instructions
 --------------------
 
-* Bump version in setup.cfg (use semantic versioning as much as possible).
+* Bump version to <NEW_VERSION> in setup.cfg (use semantic versioning as much as possible).
 * Run `autopep8` to nicely format the code (or run `pre-commit --all-files`).
 * Create a PR against develop into main.
-* After main branch passes, then merge and run the release command from the main branch.
+* After main branch passes, then merge and checkout the main branch. Build the distribution using the following code:
+
+.. code-block:: bash
+
+    # Remove old dist packages
+    rm -rf dist/*
+    python setup.py sdist
+
+* Run `git tag <NEW_VERSION>`. (Note that `python setup.py --version` pulls from the latest tag`.)
+* Verify that the files in the dist/* folder have the correct version (no dirty, no sha)
+* Run the following to release
 
 .. code-block:: bash
 
     pip install twine
-    python setup.py sdist
     twine upload dist/*
 
-* Tag the release on GitHub and add in the CHANGELOG.rst notes into the tagged release.
+* Build and release the documentation
+
+.. code-block:: bash
+
+    # Build and verify with the following
+    python setup.py build_sphinx
+
+    # release using
+    ./docs/publish_docs.sh
+
+* Push the tag to GitHub after everything is published to PyPi, then go to GitHub and add in the CHANGELOG.rst notes into the tagged release and officially release.
+
+.. code-block:: bash
+
+    git push origin <NEW_VERSION>

--- a/README.rst
+++ b/README.rst
@@ -155,12 +155,21 @@ To apply the copyright/license to all the files, run the following managed task
 
 Templating Diagram
 ------------------
+
 .. image:: ./ConnectionTemplate.png
 
+Release Instructions
+--------------------
 
-Todos
------
+* Bump version in setup.cfg (use semantic versioning as much as possible).
+* Run `autopep8` to nicely format the code (or run `pre-commit --all-files`).
+* Create a PR against develop into main.
+* After main branch passes, then merge and run the release command from the main branch.
 
-* handle weather in Teaser
-* Validate remaining schema objects
-* AHU example
+.. code-block:: bash
+
+    pip install twine
+    python setup.py sdist
+    twine upload dist/*
+
+* Tag the release on GitHub and add in the CHANGELOG.rst notes into the tagged release.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,15 +4,16 @@
 # core libraries
 geojson==2.5.0
 jsonschema==3.2.0
-requests==2.22.0
-jsonpath-ng==1.5.1
+requests==2.24.0
+jsonpath-ng==1.5.2
 
 # dependent projects
 BuildingsPy==2.0.0
 
 # Modelica Builder package (use the local [file:] version if needed for debugging)
--e git+https://github.com/urbanopt/modelica-builder.git@develop#egg=modelica_builder
+# -e git+https://github.com/urbanopt/modelica-builder.git@develop#egg=modelica_builder
 #-e file:../modelica-builder#egg=modelica-builder
+modelica-builder==0.1.0
 
 # Use the core teaser library.
 #teaser==0.7.2
@@ -21,16 +22,16 @@ BuildingsPy==2.0.0
 #-e file:../TEASER-UO#egg=teaser
 
 # Test and documentation
-autopep8==1.5
-flake8==3.7.9
+autopep8==1.5.4
+flake8==3.8.3
 nose==1.3.7
-pre-commit==2.6.0
-pytest==5.3.5
-pytest-cov==2.8.1
+pre-commit==2.7.1
+pytest==6.1.0
+pytest-cov==2.10.1
 python-coveralls==2.9.3
-sphinx==2.4.2
-sphinx_rtd_theme==0.4.3
-tox==3.14.5
+sphinx==3.2.1
+sphinx_rtd_theme==0.5.0
+tox==3.20.0
 
 # debugging and testing, not used at the moment in the main portion of the code (i.e. not needed in setup.cfg)
 scipy

--- a/setup.py
+++ b/setup.py
@@ -70,10 +70,11 @@ setup(
     install_requires=[
         "geojson==2.5.0",
         "jsonschema==3.2.0",
-        "jsonpath-ng==1.5.1",
-        "requests==2.22.0",
+        "jsonpath-ng==1.5.2",
+        "requests==2.24.0",
         'teaser @ git+https://github.com/urbanopt/TEASER.git@rc-argument-names#egg=teaser',
-        'modelica_builder @ git+https://github.com/urbanopt/modelica-builder.git@develop#egg=modelica_builder',
+        "modelica-builder==0.1.0",
+        # 'modelica_builder @ git+https://github.com/urbanopt/modelica-builder.git@develop#egg=modelica_builder',
     ],
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
#### Any background context you want to provide?
We just released the first version of Modelica Builder and should use that version instead of the git version.

#### What does this PR accomplish?
* Use Modelica-Builder from PyPI (0.1.0)
* Upgrade testing dependencies, requests, and jsonpath-ng. Others can be upgraded but they seemed too risky before release.

#### How should this be manually tested?
* `pip install -r requirements.txt`
* Verify that tests still run and pass with new dependency.

#### What are the relevant tickets?
n/a

#### Screenshots (if appropriate)
