### PR TITLE
Do not pass system_params

### DIFF
--- a/geojson_modelica_translator/geojson_modelica_translator.py
+++ b/geojson_modelica_translator/geojson_modelica_translator.py
@@ -99,8 +99,7 @@ class GeoJsonModelicaTranslator(object):
         with the sys_params object. Each building object contains all the data
         it needs to generate the resulting model.
 
-        :param sys_params: ...
-        :return:
+        :return: None
         """
         if self.system_parameters is None:
             raise Exception("Must set the system parameter file first. Use gj.set_system_parameters")

--- a/geojson_modelica_translator/geojson_modelica_translator.py
+++ b/geojson_modelica_translator/geojson_modelica_translator.py
@@ -93,7 +93,7 @@ class GeoJsonModelicaTranslator(object):
         else:
             raise Exception(f"GeoJSON file does not exist: {filename}")
 
-    def process_loads(self, sys_params):
+    def process_loads(self):
         """
         Process the loads of the GeoJSON file. This combines the GeoJSON object
         with the sys_params object. Each building object contains all the data
@@ -102,10 +102,13 @@ class GeoJsonModelicaTranslator(object):
         :param sys_params: ...
         :return:
         """
+        if self.system_parameters is None:
+            raise Exception("Must set the system parameter file first. Use gj.set_system_parameters")
+
         for load in self.json_loads:
             # Read in the load and determine if the model is RC, CSV, or Spawn
             _log.debug(load)
-            model_con = sys_params.get_param_by_building_id(load.id, "load_model")
+            model_con = self.system_parameters.get_param_by_building_id(load.id, "load_model")
             try:
                 # Also handle the load as if it is connected to the ETS or not
                 class_ = load_mapper[model_con]

--- a/tests/geojson_modelica_translator/test_translator.py
+++ b/tests/geojson_modelica_translator/test_translator.py
@@ -68,10 +68,9 @@ class GeoJSONTranslatorTest(TestCaseBase):
 
         gj = GeoJsonModelicaTranslator.from_geojson(filename)
         filename = os.path.join(self.data_dir, "system_parameters_mix_models.json")
-        sys_params = SystemParameters(filename)
-        gj.set_system_parameters(sys_params)
+        gj.set_system_parameters(SystemParameters(filename))
 
-        gj.process_loads(sys_params)
+        gj.process_loads()
         self.assertEqual(len(gj.loads), 3)
         gj.to_modelica(self.project_name, self.output_dir)
 


### PR DESCRIPTION
#### Any background context you want to provide?
The process_loads() method required the passing of the system parameters object.

#### What does this PR accomplish?
* Remove the system_params from the process_loads. It is not needed because the geojson object already has the system_parameters file as a member variable. It is set by calling gj.set_system_parameters(<a_file_obj>)

#### How should this be manually tested?
* `py.test` should cover the tests

#### What are the relevant tickets?
N/A

#### Screenshots (if appropriate)
