### PR TITLE
Refactor/model connector organization

### DIFF
--- a/geojson_modelica_translator/geojson_modelica_translator.py
+++ b/geojson_modelica_translator/geojson_modelica_translator.py
@@ -34,11 +34,11 @@ import os
 from geojson_modelica_translator.geojson.urbanopt_geojson import (
     UrbanOptGeoJson
 )
-from geojson_modelica_translator.model_connectors.spawn import \
+from geojson_modelica_translator.model_connectors.load_connectors.spawn import \
     SpawnConnector as spawn_load
-from geojson_modelica_translator.model_connectors.teaser import \
+from geojson_modelica_translator.model_connectors.load_connectors.teaser import \
     TeaserConnector as teaser_load
-from geojson_modelica_translator.model_connectors.time_series import \
+from geojson_modelica_translator.model_connectors.load_connectors.time_series import \
     TimeSeriesConnector as timeseries_load
 from geojson_modelica_translator.scaffold import Scaffold
 
@@ -153,7 +153,7 @@ class GeoJsonModelicaTranslator(object):
         for load in self.loads:
             load.to_modelica(self.scaffold)  # , keep_original_models=False)
 
-        # import geojson_modelica_translator.model_connectors.ets_template as ets_template
+        # import geojson_modelica_translator.model_connectors.load_connectors.ets_template as ets_template
         # ets_class = getattr(ets_template, "ETSConnector")
         # ets_connector = ets_class(self.system_parameters)
 

--- a/geojson_modelica_translator/model_connectors/district_connectors/base.py
+++ b/geojson_modelica_translator/model_connectors/district_connectors/base.py
@@ -1,0 +1,168 @@
+"""
+****************************************************************************************************
+:copyright (c) 2019-2020 URBANopt, Alliance for Sustainable Energy, LLC, and other contributors.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted
+provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions
+and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions
+and the following disclaimer in the documentation and/or other materials provided with the
+distribution.
+
+Neither the name of the copyright holder nor the names of its contributors may be used to endorse
+or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+****************************************************************************************************
+"""
+
+import os
+import shutil
+from pathlib import Path
+
+from jinja2 import Environment, FileSystemLoader
+from modelica_builder.model import Model
+
+
+class Base(object):
+    """
+    Base class of the district connectors. The connectors can utilize various methods to create a building (or other
+    feature) to a detailed Modelica connection.
+    """
+
+    def __init__(self, system_parameters):
+        """
+        Base initializer
+
+        :param system_parameters: SystemParameters object
+        """
+        self.buildings = []
+        self.system_parameters = system_parameters
+
+        # initialize the templating framework (Jinja2)
+        self.template_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "templates")
+        self.template_env = Environment(loader=FileSystemLoader(searchpath=self.template_dir))
+
+        # store a list of the templated files to include when building the package
+        self.template_files_to_include = []
+
+        # Note that the order of the required MO files is important as it will be the order that
+        # the "package.order" will be in.
+        self.required_mo_files = []
+        # extract data out of the urbanopt_building object and store into the base object
+
+    def add_building(self, urbanopt_building, mapper=None):
+        """
+        Add building to the translator.
+
+        :param urbanopt_building: an urbanopt_building
+        """
+        # TODO: Need to convert units, these should exist on the urbanopt_building object
+        # TODO: Abstract out the GeoJSON functionality
+        if mapper is None:
+            number_stories = urbanopt_building.feature.properties["number_of_stories"]
+            try:
+                number_stories_above_ground = urbanopt_building.feature.properties["number_of_stories_above_ground"]
+            except KeyError:
+                number_stories_above_ground = urbanopt_building.feature.properties["number_of_stories"]
+
+            try:
+                urbanopt_building.feature.properties["floor_height"]
+            except KeyError:
+                urbanopt_building.feature.properties["floor_height"] = 3  # Default height in meters from sdk
+
+            try:
+                # UO SDK defaults to current year, however TEASER only supports up to Year 2015
+                # https://github.com/urbanopt/TEASER/blob/master/teaser/data/input/inputdata/TypeBuildingElements.json#L818
+                if urbanopt_building.feature.properties["year_built"] > 2015:
+                    urbanopt_building.feature.properties["year_built"] = 2015
+            except KeyError:
+                urbanopt_building.feature.properties["year_built"] = 2015
+
+            self.buildings.append(
+                {
+                    "area": float(urbanopt_building.feature.properties["floor_area"]) * 0.092936,  # ft2 -> m2
+                    "building_id": urbanopt_building.feature.properties["id"],
+                    "building_type": urbanopt_building.feature.properties["building_type"],
+                    "floor_height": urbanopt_building.feature.properties["floor_height"],  # Already converted to metric
+                    "num_stories": urbanopt_building.feature.properties["number_of_stories"],
+                    "num_stories_below_grade": number_stories - number_stories_above_ground,
+                    "year_built": urbanopt_building.feature.properties["year_built"],
+                }
+            )
+
+    def copy_required_mo_files(self, dest_folder, within=None):
+        """Copy any required_mo_files to the destination and update the within clause if defined. The required mo
+        files need to be added as full paths to the required_mo_files member variable in the connectors derived
+        classes.
+
+        :param dest_folder: String, folder to copy the resulting MO files into.
+        :param within: String, within clause to be replaced in the .mo file. Note that the original MO file needs to
+        have a within clause defined to be replaced.
+        """
+        result = []
+        for f in self.required_mo_files:
+            if not os.path.exists(f):
+                raise Exception(f"Required MO file not found: {f}")
+
+            new_filename = os.path.join(dest_folder, os.path.basename(f))
+            if within:
+                mofile = Model(f)
+                mofile.set_within_statement(within)
+                mofile.save_as(new_filename)
+                result.append(os.path.join(dest_folder, os.path.basename(f)))
+            else:
+                # simply copy the file over if no need to update within
+                result.append(shutil.copy(f, new_filename))
+
+        return result
+
+    def run_template(self, template, save_file_name, do_not_add_to_list=False, **kwargs):
+        """
+        Helper method to create the file from Jinja2's templating framework.
+
+        :param template: object, Jinja template from the `template_env.get_template()` command.
+        :param save_file_name: string, fully qualified path to save the rendered template to.
+        :param do_not_add_to_list: boolean, set to true if you do not want the file to be added to the package.order
+        :param kwargs: These are the arguments that need to be passed to the template.
+
+        :return: None
+        """
+        file_data = template.render(**kwargs)
+
+        os.makedirs(os.path.dirname(save_file_name), exist_ok=True)
+        with open(save_file_name, "w") as f:
+            f.write(file_data)
+
+        # add to the list of files to include in the package
+        if not do_not_add_to_list:
+            self.template_files_to_include.append(Path(save_file_name).stem)
+
+    def modelica_path(self, filename):
+        """Write a modelica path string for a given filename"""
+        p = Path(filename)
+        if p.suffix == ".idf":
+            # TODO: The output path is awfully brittle.
+            # FIXME: The string is hideous, but without it Pathlib thinks double slashes are "spurious"
+            # https://docs.python.org/3/library/pathlib.html#pathlib.PurePath
+            outputname = "modelica://" + str(Path("Buildings") / "Resources" / "Data"
+                                             / "ThermalZones" / "EnergyPlus" / "Validation" / "RefBldgSmallOffice"
+                                             / p.name)
+        elif p.suffix == ".epw" or p.suffix == ".mos":
+            outputname = "modelica://" + str(Path("Buildings") / "Resources" / "weatherdata" / p.name)
+        return outputname
+
+    # These methods need to be defined in each of the derived model connectors
+    # def to_modelica(self):

--- a/geojson_modelica_translator/model_connectors/district_connectors/district_system.py
+++ b/geojson_modelica_translator/model_connectors/district_connectors/district_system.py
@@ -32,13 +32,13 @@ import os
 import shutil
 from pathlib import Path
 
-from geojson_modelica_translator.model_connectors.load_connectors.base import \
-    Base as model_connector_base
+from geojson_modelica_translator.model_connectors.district_connectors.base import \
+    Base as district_connector_base
 from geojson_modelica_translator.modelica.input_parser import PackageParser
 from modelica_builder.model import Model
 
 
-class DistrictSystemConnector(model_connector_base):
+class DistrictSystemConnector(district_connector_base):
     def __init__(self, system_parameters):
         super().__init__(system_parameters)
         # Note that the order of the required MO files is important as it will be the order that
@@ -69,7 +69,7 @@ class DistrictSystemConnector(model_connector_base):
         self.required_mo_files.append(os.path.join(self.template_dir, 'UnidirectionalParallel.mo'))
         self.required_mo_files.append(os.path.join(self.template_dir, 'ValveParameters.mo'))
 
-    def to_modelica(self, scaffold, model_connector_base):
+    def to_modelica(self, scaffold, district_connector_base):
         """
         # TODO: Need to pass in list of buildings to connect to network.
 
@@ -109,26 +109,26 @@ class DistrictSystemConnector(model_connector_base):
                     "idf_filename": idf_filename,
                     "filename": os.path.basename(idf_filename),
                     "path": os.path.dirname(idf_filename),
-                    "modelica_path": model_connector_base.modelica_path(self, idf_filename),
+                    "modelica_path": district_connector_base.modelica_path(self, idf_filename),
                 },
                 "epw": {
                     "epw_filename": epw_filename,
                     "filename": os.path.basename(epw_filename),
                     "path": os.path.dirname(epw_filename),
-                    "modelica_path": model_connector_base.modelica_path(self, epw_filename),
+                    "modelica_path": district_connector_base.modelica_path(self, epw_filename),
                 },
                 "mos_weather": {
                     "mos_weather_filename": mos_weather_filename,
                     "filename": os.path.basename(mos_weather_filename),
                     "path": os.path.dirname(mos_weather_filename),
-                    # TODO: Should/How/Can we remove "model_connector_base" here? Compare line 112 with line 220
-                    "modelica_path": model_connector_base.modelica_path(self, mos_weather_filename),
+                    # TODO: Should/How/Can we remove "district_connector_base" here? Compare line 112 with line 220
+                    "modelica_path": district_connector_base.modelica_path(self, mos_weather_filename),
                 },
                 "wet_bulb_calc": {
                     "mos_wet_bulb_filename": mos_wet_bulb_filename,
                     "filename": Path(mos_wet_bulb_filename).name,
                     "path": Path(mos_wet_bulb_filename).parent,
-                    "modelica_path": model_connector_base.modelica_path(self, mos_wet_bulb_filename),
+                    "modelica_path": district_connector_base.modelica_path(self, mos_wet_bulb_filename),
                 },
                 "nominal_values": {
                     "delta_temp": self.system_parameters.get_param(

--- a/geojson_modelica_translator/model_connectors/district_system.py
+++ b/geojson_modelica_translator/model_connectors/district_system.py
@@ -32,7 +32,7 @@ import os
 import shutil
 from pathlib import Path
 
-from geojson_modelica_translator.model_connectors.base import \
+from geojson_modelica_translator.model_connectors.load_connectors.base import \
     Base as model_connector_base
 from geojson_modelica_translator.modelica.input_parser import PackageParser
 from modelica_builder.model import Model

--- a/geojson_modelica_translator/model_connectors/load_connectors/base.py
+++ b/geojson_modelica_translator/model_connectors/load_connectors/base.py
@@ -52,7 +52,7 @@ class Base(object):
         self.system_parameters = system_parameters
 
         # initialize the templating framework (Jinja2)
-        self.template_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "templates")
+        self.template_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "templates")
         self.template_env = Environment(loader=FileSystemLoader(searchpath=self.template_dir))
 
         # store a list of the templated files to include when building the package

--- a/geojson_modelica_translator/model_connectors/load_connectors/spawn_ets_coupling.py
+++ b/geojson_modelica_translator/model_connectors/load_connectors/spawn_ets_coupling.py
@@ -21,9 +21,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
 FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
 CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUR
-
-EMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
 DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
 IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
 OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
@@ -33,15 +31,16 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import os
 import shutil
 
-from geojson_modelica_translator.model_connectors.base import \
+from geojson_modelica_translator.model_connectors.load_connectors.base import \
     Base as model_connector_base
 from geojson_modelica_translator.modelica.input_parser import PackageParser
 from geojson_modelica_translator.utils import ModelicaPath
 
 
-class SpawnConnector(model_connector_base):
+class SpawnConnectorETS(model_connector_base):
     def __init__(self, system_parameters):
         super().__init__(system_parameters)
+        self.required_mo_files.append(os.path.join(self.template_dir, 'HydraulicHeader.mo'))
 
     def to_modelica(self, scaffold, keep_original_models=False):
         """
@@ -49,9 +48,11 @@ class SpawnConnector(model_connector_base):
 
         :param scaffold: Scaffold object, Scaffold of the entire directory of the project.
         """
-        spawn_coupling_template = self.template_env.get_template("SpawnCouplingBuilding.mot")
+        spawn_ets_coupling_template = self.template_env.get_template("SpawnCouplingETS.mot")
         spawn_building_template = self.template_env.get_template("SpawnBuilding.mot")
-        spawn_mos_template = self.template_env.get_template("RunSpawnCouplingBuilding.most")
+        cooling_indirect_template = self.template_env.get_template("CoolingIndirect.mot")
+        heating_indirect_template = self.template_env.get_template("HeatingIndirect.mot")
+        spawn_ets_mos_template = self.template_env.get_template("RunSpawnCouplingETS.most")
         building_names = []
         for building in self.buildings:
             # create each spawn building and save to the correct directory
@@ -146,19 +147,48 @@ class SpawnConnector(model_connector_base):
                 data=template_data
             )
 
+            ets_model_type = self.system_parameters.get_param_by_building_id(building["building_id"], "ets_model")
+            ets_data = None
+            if ets_model_type == "Indirect Heating and Cooling":
+                ets_data = self.system_parameters.get_param_by_building_id(
+                    building["building_id"],
+                    "ets_model_parameters.indirect"
+                )
+            else:
+                raise Exception("Only ETS Model of type 'Indirect Heating and Cooling' type enabled currently")
+
+            self.run_template(
+                cooling_indirect_template,
+                os.path.join(b_modelica_path.files_dir, "CoolingIndirect.mo"),
+                project_name=scaffold.project_name,
+                model_name=f"B{building['building_id']}",
+                ets_data=ets_data
+            )
+
+            self.run_template(
+                heating_indirect_template,
+                os.path.join(b_modelica_path.files_dir, "HeatingIndirect.mo"),
+                project_name=scaffold.project_name,
+                model_name=f"B{building['building_id']}",
+                ets_data=ets_data
+            )
+
             full_model_name = os.path.join(
                 scaffold.project_name,
                 scaffold.loads_path.files_relative_dir,
                 f"B{building['building_id']}",
-                "coupling").replace(os.path.sep, '.')
+                "SpawnCouplingETS").replace(os.path.sep, '.')
 
-            file_data = spawn_mos_template.render(full_model_name=full_model_name)
-            with open(os.path.join(b_modelica_path.scripts_dir, "RunSpawnCouplingBuilding.mos"), "w") as f:
+            file_data = spawn_ets_mos_template.render(
+                full_model_name=full_model_name, model_name="SpawnCouplingETS"
+            )
+
+            with open(os.path.join(b_modelica_path.scripts_dir, "RunSpawnCouplingETS.mos"), "w") as f:
                 f.write(file_data)
 
             self.run_template(
-                spawn_coupling_template,
-                os.path.join(b_modelica_path.files_dir, "coupling.mo"),
+                spawn_ets_coupling_template,
+                os.path.join(b_modelica_path.files_dir, "SpawnCouplingETS.mo"),
                 project_name=scaffold.project_name,
                 model_name=f"B{building['building_id']}",
                 data=template_data
@@ -180,13 +210,13 @@ class SpawnConnector(model_connector_base):
 
         :param scaffold: Scaffold object, Scaffold of the entire directory of the project.
         :param building_names: list, names of the buildings that need to be cleaned up after export
-        :param keep_original_models: boolean, # TODO
         :return: None
         """
         for b in building_names:
             b_modelica_path = os.path.join(scaffold.loads_path.files_dir, b)
             new_package = PackageParser.new_from_template(
-                b_modelica_path, b, ["building", "coupling"], within=f"{scaffold.project_name}.Loads"
+                b_modelica_path, b, ["building", "CoolingIndirect", "SpawnCouplingETS"],
+                within=f"{scaffold.project_name}.Loads"
             )
             new_package.save()
 

--- a/geojson_modelica_translator/model_connectors/load_connectors/teaser.py
+++ b/geojson_modelica_translator/model_connectors/load_connectors/teaser.py
@@ -32,7 +32,7 @@ import glob
 import os
 import shutil
 
-from geojson_modelica_translator.model_connectors.base import \
+from geojson_modelica_translator.model_connectors.load_connectors.base import \
     Base as model_connector_base
 from geojson_modelica_translator.modelica.input_parser import PackageParser
 from geojson_modelica_translator.utils import ModelicaPath, copytree

--- a/geojson_modelica_translator/model_connectors/load_connectors/teaser_ets_coupling.py
+++ b/geojson_modelica_translator/model_connectors/load_connectors/teaser_ets_coupling.py
@@ -32,7 +32,7 @@ import glob
 import os
 import shutil
 
-from geojson_modelica_translator.model_connectors.base import \
+from geojson_modelica_translator.model_connectors.load_connectors.base import \
     Base as model_connector_base
 from geojson_modelica_translator.modelica.input_parser import PackageParser
 from geojson_modelica_translator.utils import ModelicaPath, copytree

--- a/geojson_modelica_translator/model_connectors/load_connectors/time_series.py
+++ b/geojson_modelica_translator/model_connectors/load_connectors/time_series.py
@@ -31,7 +31,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import os
 import shutil
 
-from geojson_modelica_translator.model_connectors.base import \
+from geojson_modelica_translator.model_connectors.load_connectors.base import \
     Base as model_connector_base
 from geojson_modelica_translator.modelica.input_parser import PackageParser
 from geojson_modelica_translator.utils import ModelicaPath

--- a/geojson_modelica_translator/model_connectors/load_connectors/time_series_mft_ets_coupling.py
+++ b/geojson_modelica_translator/model_connectors/load_connectors/time_series_mft_ets_coupling.py
@@ -32,7 +32,7 @@ import os
 import shutil
 from pathlib import Path
 
-from geojson_modelica_translator.model_connectors.base import \
+from geojson_modelica_translator.model_connectors.load_connectors.base import \
     Base as model_connector_base
 from geojson_modelica_translator.modelica.input_parser import PackageParser
 from geojson_modelica_translator.utils import ModelicaPath

--- a/tests/geojson_modelica_translator/test_scaffold.py
+++ b/tests/geojson_modelica_translator/test_scaffold.py
@@ -34,7 +34,7 @@ import unittest
 
 from geojson_modelica_translator.scaffold import Scaffold
 
-# from geojson_modelica_translator.model_connectors.base import Base as building_base
+# from geojson_modelica_translator.model_connectors.load_connectors.base import Base as building_base
 # class FakeConnector(building_base):
 #     def to_modelica(self):
 #         pass

--- a/tests/geojson_modelica_translator/test_translator.py
+++ b/tests/geojson_modelica_translator/test_translator.py
@@ -33,11 +33,11 @@ import os
 from geojson_modelica_translator.geojson_modelica_translator import (
     GeoJsonModelicaTranslator
 )
-from geojson_modelica_translator.model_connectors.spawn import \
+from geojson_modelica_translator.model_connectors.load_connectors.spawn import \
     SpawnConnector as spawn_load
-from geojson_modelica_translator.model_connectors.teaser import \
+from geojson_modelica_translator.model_connectors.load_connectors.teaser import \
     TeaserConnector as teaser_load
-from geojson_modelica_translator.model_connectors.time_series import \
+from geojson_modelica_translator.model_connectors.load_connectors.time_series import \
     TimeSeriesConnector as timeseries_load
 from geojson_modelica_translator.system_parameters.system_parameters import (
     SystemParameters

--- a/tests/model_connectors/test_base.py
+++ b/tests/model_connectors/test_base.py
@@ -32,7 +32,7 @@ import os
 import shutil
 import unittest
 
-from geojson_modelica_translator.model_connectors.base import \
+from geojson_modelica_translator.model_connectors.load_connectors.base import \
     Base as model_connector_base
 from jinja2 import Template
 

--- a/tests/model_connectors/test_district_heating_system.py
+++ b/tests/model_connectors/test_district_heating_system.py
@@ -36,7 +36,7 @@ from pathlib import Path
 from geojson_modelica_translator.geojson_modelica_translator import (
     GeoJsonModelicaTranslator
 )
-from geojson_modelica_translator.model_connectors.base import \
+from geojson_modelica_translator.model_connectors.load_connectors.base import \
     Base as model_connector_base
 from geojson_modelica_translator.model_connectors.district_system import (
     DistrictSystemConnector

--- a/tests/model_connectors/test_district_heating_system.py
+++ b/tests/model_connectors/test_district_heating_system.py
@@ -37,8 +37,8 @@ from geojson_modelica_translator.geojson_modelica_translator import (
     GeoJsonModelicaTranslator
 )
 from geojson_modelica_translator.model_connectors.load_connectors.base import \
-    Base as model_connector_base
-from geojson_modelica_translator.model_connectors.district_system import (
+    Base as district_connector_base
+from geojson_modelica_translator.model_connectors.district_connectors.district_system import (
     DistrictSystemConnector
 )
 from geojson_modelica_translator.modelica.modelica_runner import ModelicaRunner
@@ -72,7 +72,7 @@ class SpawnModelConnectorSingleBuildingTimeSeriesHeatingTest(unittest.TestCase):
 
     def test_district_heating_to_modelica_and_run(self):
         self.assertIsNotNone(self.district)
-        self.district.to_modelica(self.gj.scaffold, model_connector_base)
+        self.district.to_modelica(self.gj.scaffold, district_connector_base)
 
         # make sure the model can run using the ModelicaRunner class
         mr = ModelicaRunner()

--- a/tests/model_connectors/test_district_heating_system.py
+++ b/tests/model_connectors/test_district_heating_system.py
@@ -36,11 +36,11 @@ from pathlib import Path
 from geojson_modelica_translator.geojson_modelica_translator import (
     GeoJsonModelicaTranslator
 )
-from geojson_modelica_translator.model_connectors.load_connectors.base import \
-    Base as district_connector_base
 from geojson_modelica_translator.model_connectors.district_connectors.district_system import (
     DistrictSystemConnector
 )
+from geojson_modelica_translator.model_connectors.load_connectors.base import \
+    Base as district_connector_base
 from geojson_modelica_translator.modelica.modelica_runner import ModelicaRunner
 from geojson_modelica_translator.system_parameters.system_parameters import (
     SystemParameters

--- a/tests/model_connectors/test_district_system.py
+++ b/tests/model_connectors/test_district_system.py
@@ -33,7 +33,7 @@ import os
 from geojson_modelica_translator.geojson_modelica_translator import (
     GeoJsonModelicaTranslator
 )
-from geojson_modelica_translator.model_connectors.base import \
+from geojson_modelica_translator.model_connectors.load_connectors.base import \
     Base as model_connector_base
 from geojson_modelica_translator.model_connectors.district_system import (
     DistrictSystemConnector

--- a/tests/model_connectors/test_district_system.py
+++ b/tests/model_connectors/test_district_system.py
@@ -33,9 +33,9 @@ import os
 from geojson_modelica_translator.geojson_modelica_translator import (
     GeoJsonModelicaTranslator
 )
-from geojson_modelica_translator.model_connectors.load_connectors.base import \
-    Base as model_connector_base
-from geojson_modelica_translator.model_connectors.district_system import (
+from geojson_modelica_translator.model_connectors.district_connectors.base import \
+    Base as district_connector_base
+from geojson_modelica_translator.model_connectors.district_connectors.district_system import (
     DistrictSystemConnector
 )
 from geojson_modelica_translator.system_parameters.system_parameters import (
@@ -66,7 +66,7 @@ class SpawnModelConnectorSingleBuildingTimeSeriesTest(TestCaseBase):
 
     def test_district_cooling_to_modelica_and_run(self):
         self.assertIsNotNone(self.district)
-        self.district.to_modelica(self.gj.scaffold, model_connector_base)
+        self.district.to_modelica(self.gj.scaffold, district_connector_base)
 
         file_to_run = os.path.abspath(
             os.path.join(self.gj.scaffold.districts_path.files_dir, 'DistrictCoolingSystem.mo'),

--- a/tests/model_connectors/test_spawn.py
+++ b/tests/model_connectors/test_spawn.py
@@ -33,7 +33,9 @@ import os
 from geojson_modelica_translator.geojson_modelica_translator import (
     GeoJsonModelicaTranslator
 )
-from geojson_modelica_translator.model_connectors.load_connectors.spawn import SpawnConnector
+from geojson_modelica_translator.model_connectors.load_connectors.spawn import (
+    SpawnConnector
+)
 from geojson_modelica_translator.system_parameters.system_parameters import (
     SystemParameters
 )

--- a/tests/model_connectors/test_spawn.py
+++ b/tests/model_connectors/test_spawn.py
@@ -33,7 +33,7 @@ import os
 from geojson_modelica_translator.geojson_modelica_translator import (
     GeoJsonModelicaTranslator
 )
-from geojson_modelica_translator.model_connectors.spawn import SpawnConnector
+from geojson_modelica_translator.model_connectors.load_connectors.spawn import SpawnConnector
 from geojson_modelica_translator.system_parameters.system_parameters import (
     SystemParameters
 )

--- a/tests/model_connectors/test_spawn_ets.py
+++ b/tests/model_connectors/test_spawn_ets.py
@@ -33,7 +33,7 @@ import os
 from geojson_modelica_translator.geojson_modelica_translator import (
     GeoJsonModelicaTranslator
 )
-from geojson_modelica_translator.model_connectors.spawn_ets_coupling import (
+from geojson_modelica_translator.model_connectors.load_connectors.spawn_ets_coupling import (
     SpawnConnectorETS
 )
 from geojson_modelica_translator.system_parameters.system_parameters import (

--- a/tests/model_connectors/test_teaser.py
+++ b/tests/model_connectors/test_teaser.py
@@ -34,7 +34,9 @@ import os
 from geojson_modelica_translator.geojson_modelica_translator import (
     GeoJsonModelicaTranslator
 )
-from geojson_modelica_translator.model_connectors.load_connectors.teaser import TeaserConnector
+from geojson_modelica_translator.model_connectors.load_connectors.teaser import (
+    TeaserConnector
+)
 from geojson_modelica_translator.system_parameters.system_parameters import (
     SystemParameters
 )

--- a/tests/model_connectors/test_teaser.py
+++ b/tests/model_connectors/test_teaser.py
@@ -34,7 +34,7 @@ import os
 from geojson_modelica_translator.geojson_modelica_translator import (
     GeoJsonModelicaTranslator
 )
-from geojson_modelica_translator.model_connectors.teaser import TeaserConnector
+from geojson_modelica_translator.model_connectors.load_connectors.teaser import TeaserConnector
 from geojson_modelica_translator.system_parameters.system_parameters import (
     SystemParameters
 )

--- a/tests/model_connectors/test_teaser_ets.py
+++ b/tests/model_connectors/test_teaser_ets.py
@@ -33,7 +33,7 @@ import os
 from geojson_modelica_translator.geojson_modelica_translator import (
     GeoJsonModelicaTranslator
 )
-from geojson_modelica_translator.model_connectors.teaser_ets_coupling import (
+from geojson_modelica_translator.model_connectors.load_connectors.teaser_ets_coupling import (
     TeaserConnectorETS
 )
 from geojson_modelica_translator.system_parameters.system_parameters import (

--- a/tests/model_connectors/test_time_series.py
+++ b/tests/model_connectors/test_time_series.py
@@ -33,7 +33,7 @@ import os
 from geojson_modelica_translator.geojson_modelica_translator import (
     GeoJsonModelicaTranslator
 )
-from geojson_modelica_translator.model_connectors.time_series import (
+from geojson_modelica_translator.model_connectors.load_connectors.time_series import (
     TimeSeriesConnector
 )
 from geojson_modelica_translator.system_parameters.system_parameters import (

--- a/tests/model_connectors/test_time_series_mft_ets.py
+++ b/tests/model_connectors/test_time_series_mft_ets.py
@@ -33,7 +33,7 @@ import os
 from geojson_modelica_translator.geojson_modelica_translator import (
     GeoJsonModelicaTranslator
 )
-from geojson_modelica_translator.model_connectors.time_series_mft_ets_coupling import (
+from geojson_modelica_translator.model_connectors.load_connectors.time_series_mft_ets_coupling import (
     TimeSeriesConnectorMFTETS
 )
 from geojson_modelica_translator.system_parameters.system_parameters import (


### PR DESCRIPTION
#### Any background context you want to provide?
Currently, the load and district models are both in the `model_connectors` directory. To begin the refactoring process, we are separating them out into their own directories.
#### What does this PR accomplish?
Separates model and district connectors as well as creates their own base classes.
#### How should this be manually tested?
<Nick ??>
#### What are the relevant tickets?
#195 