### PR TITLE
Update TimeSeriesCouplingETS.mot

### DIFF
--- a/geojson_modelica_translator/model_connectors/templates/TimeSeriesCouplingETS.mot
+++ b/geojson_modelica_translator/model_connectors/templates/TimeSeriesCouplingETS.mot
@@ -108,7 +108,7 @@ model TimeSeriesCouplingETS
       file="modelica://{{project_name}}/Loads/Resources/Scripts/{{model_name}}/Dymola/RunTeaserCouplingETS.mos" "Simulate and plot"),
     experiment(
       StopTime=86400,
-      Interval=3600,
+      outputInterval=3600,
       Tolerance=1e-06),
     Documentation(
       info="<html>


### PR DESCRIPTION
assign the time series's distance between output points "output intervals" to 3600 seconds.