### PR TITLE
fix: use correct value for iConDpSen which is number of connected ETSes

### DIFF
--- a/geojson_modelica_translator/model_connectors/templates/Network2Pipe_Instance.mopt
+++ b/geojson_modelica_translator/model_connectors/templates/Network2Pipe_Instance.mopt
@@ -25,7 +25,7 @@
   {{ model.modelica_type }} {{ model.id }}(
     redeclare final package Medium={{ globals.medium_w }},
     final nCon=nBui_{{ model.id }},
-    iConDpSen=2,
+    iConDpSen=nBui_{{ model.id }},
     final mDis_flow_nominal=mDis_flow_nominal_{{ model.id }},
     final mCon_flow_nominal=mCon_flow_nominal_{{ model.id }},
     final allowFlowReversal=false,


### PR DESCRIPTION
#### Any background context you want to provide?
Previous instance of our network pipe had a hardcoded value of 2 for `iConDpSen` which would result in an out of bounds exception in the model compilation/simulation when only connecting a single ETS.

#### What does this PR accomplish?
Uses the correct number based on number of connected ETSes

#### How should this be manually tested?
Dymola process if you feel its necessary

#### What are the relevant tickets?
#### Screenshots (if appropriate)
