### PR TITLE
fix: use correct value for secMasFloRat

### DIFF
--- a/geojson_modelica_translator/model_connectors/couplings/templates/CoolingIndirect_NetworkChilledWaterStub/ComponentDefinitions.mopt
+++ b/geojson_modelica_translator/model_connectors/couplings/templates/CoolingIndirect_NetworkChilledWaterStub/ComponentDefinitions.mopt
@@ -1,6 +1,6 @@
   Modelica.Blocks.Sources.RealExpression secMasFloRat_{{ coupling.id }}(
     // TODO: avoid reaching into other coupling!
-    // TODO: verify this is the correct value for `y`, copied from the 
+    // TODO: verify this is the correct value for `y`
     // Warning: the value here is multiplied by 5/7.5 for unknown (undocumented) reasons and needs to be reevaluated in the future.
 HeatingIndirect_NetworkHeatedWaterStub/ComponentDefinitions.mopt
     y=mDis_flow_nominal_{{ graph.couplings_by_type(coupling.ets.id).load_couplings[0].id }}*5/7.5)

--- a/geojson_modelica_translator/model_connectors/couplings/templates/CoolingIndirect_NetworkChilledWaterStub/ComponentDefinitions.mopt
+++ b/geojson_modelica_translator/model_connectors/couplings/templates/CoolingIndirect_NetworkChilledWaterStub/ComponentDefinitions.mopt
@@ -1,4 +1,6 @@
   Modelica.Blocks.Sources.RealExpression secMasFloRat_{{ coupling.id }}(
-    y={{ graph.get_coupled_load(coupling.ets.id).id }}.disFloCoo.mReqTot_flow)
+    // TODO: avoid reaching into other coupling!
+    // TODO: verify this is the correct value for `y`, copied from the HeatingIndirect_NetworkHeatedWaterStub/ComponentDefinitions.mopt
+    y=mDis_flow_nominal_{{ graph.couplings_by_type(coupling.ets.id).load_couplings[0].id }}*5/7.5)
     "Secondary loop chilled water flow rate."
     {% raw %}annotation (Placement(transformation(extent={{-74,-20},{-54,0}})));{% endraw %}

--- a/geojson_modelica_translator/model_connectors/couplings/templates/CoolingIndirect_NetworkChilledWaterStub/ComponentDefinitions.mopt
+++ b/geojson_modelica_translator/model_connectors/couplings/templates/CoolingIndirect_NetworkChilledWaterStub/ComponentDefinitions.mopt
@@ -1,6 +1,8 @@
   Modelica.Blocks.Sources.RealExpression secMasFloRat_{{ coupling.id }}(
     // TODO: avoid reaching into other coupling!
-    // TODO: verify this is the correct value for `y`, copied from the HeatingIndirect_NetworkHeatedWaterStub/ComponentDefinitions.mopt
+    // TODO: verify this is the correct value for `y`, copied from the 
+    // Warning: the value here is multiplied by 5/7.5 for unknown (undocumented) reasons and needs to be reevaluated in the future.
+HeatingIndirect_NetworkHeatedWaterStub/ComponentDefinitions.mopt
     y=mDis_flow_nominal_{{ graph.couplings_by_type(coupling.ets.id).load_couplings[0].id }}*5/7.5)
     "Secondary loop chilled water flow rate."
     {% raw %}annotation (Placement(transformation(extent={{-74,-20},{-54,0}})));{% endraw %}

--- a/geojson_modelica_translator/model_connectors/couplings/templates/HeatingIndirect_NetworkHeatedWaterStub/ComponentDefinitions.mopt
+++ b/geojson_modelica_translator/model_connectors/couplings/templates/HeatingIndirect_NetworkHeatedWaterStub/ComponentDefinitions.mopt
@@ -1,5 +1,5 @@
   Modelica.Blocks.Sources.RealExpression secMasFloRat_{{ coupling.id }}(
     // TODO: avoid reaching into other coupling!
     y=mDis_flow_nominal_{{ graph.couplings_by_type(coupling.ets.id).load_couplings[0].id }}*5/7.5)
-    "Secondary loop chilled water flow rate."
+    "Secondary loop heated water flow rate."
     {% raw %}annotation (Placement(transformation(extent={{-74,-20},{-54,0}}))){% endraw %};

--- a/geojson_modelica_translator/model_connectors/couplings/templates/HeatingIndirect_NetworkHeatedWaterStub/ComponentDefinitions.mopt
+++ b/geojson_modelica_translator/model_connectors/couplings/templates/HeatingIndirect_NetworkHeatedWaterStub/ComponentDefinitions.mopt
@@ -1,5 +1,6 @@
   Modelica.Blocks.Sources.RealExpression secMasFloRat_{{ coupling.id }}(
     // TODO: avoid reaching into other coupling!
+    // Warning: the value here is multiplied by 5/7.5 for unknown (undocumented) reasons and needs to be reevaluated in the future.
     y=mDis_flow_nominal_{{ graph.couplings_by_type(coupling.ets.id).load_couplings[0].id }}*5/7.5)
     "Secondary loop heated water flow rate."
     {% raw %}annotation (Placement(transformation(extent={{-74,-20},{-54,0}}))){% endraw %};


### PR DESCRIPTION
#### Any background context you want to provide?
We recently switched to a different timeseries load model. This broke some of our tests.

#### What does this PR accomplish?
Fixes issue where some tests generated models where we are trying to grab values of conditional parameter (disFloCoo), which Modelica doesn't allow.

Specifically, this fixes the test_district_system_new.py test. The test would fail with the following error:
```
Error at line 96, column 27, in file ‘.../geojson-modelica-translator/tests/model_connectors/output/district_system_new/Districts/DistrictEnergySystem.mo’:
  The component disFloCoo is conditional: Access of conditional components is only valid in connect statements
```
Example of failing test here:
https://github.com/urbanopt/geojson-modelica-translator/runs/1602675927#step:6:420

#### How should this be manually tested?
Run test_district_system_new.py successfully.
