### PR TITLE
Fix simulation settings

### DIFF
--- a/geojson_modelica_translator/modelica/lib/runner/jmodelica.py
+++ b/geojson_modelica_translator/modelica/lib/runner/jmodelica.py
@@ -64,7 +64,7 @@ if opts['solver'].lower() == 'cvode':
 
     opts['CVode_options'] = {
         'external_event_detection': False,
-        'maxh': (mod.get_default_experiment_stop_time() - mod.get_default_experiment_stop_time()) / float(opts['ncp']),
+        'maxh': (mod.get_default_experiment_stop_time() - mod.get_default_experiment_start_time()) / float(opts['ncp']),
         'iter': 'Newton',
         'discr': 'BDF',
         'rtol': rtol,
@@ -74,7 +74,7 @@ if opts['solver'].lower() == 'cvode':
 
 if debug_solver:
     opts["logging"] = True  # <- Turn on solver debug logging
-mod.set("_log_level", 6)
+    mod.set("_log_level", 6)
 
 ######################################################################
 # Simulate


### PR DESCRIPTION
With the fix, the model `tests/model_connectors/output/district_cooling_system/Districts/DistrictEnergySystem.mo` now takes 15 s to simulate with JModelica.
Note that the simulation time could be lowered down to about 10 s by setting `ncp = 500` instead of `5000` currently. The latter value is only needed for year-long simulations.
