### PR TITLE
Feat/add back ts mft

### DIFF
--- a/geojson_modelica_translator/model_connectors/couplings/templates/TimeSeriesMFT_CoolingIndirect/ComponentDefinitions.mopt
+++ b/geojson_modelica_translator/model_connectors/couplings/templates/TimeSeriesMFT_CoolingIndirect/ComponentDefinitions.mopt
@@ -1,0 +1,5 @@
+  Buildings.Controls.OBC.UnitConversions.From_degC TChWSET_{{ coupling.id }}
+    {% raw %}annotation (Placement(transformation(extent={{0,60},{-20,80}}))){% endraw %};
+  parameter Modelica.SIunits.MassFlowRate mDis_flow_nominal_{{ coupling.id }} = {{ coupling.load.id }}.mChW_flow_nominal;
+  parameter Modelica.SIunits.MassFlowRate mBui_flow_nominal_{{ coupling.id }} = {{ coupling.load.id }}.mChW_flow_nominal;
+  parameter Modelica.SIunits.HeatFlowRate Q_flow_nominal_{{ coupling.id }} = {{ coupling.load.id }}.mChW_flow_nominal*4187*{{ globals.delChiWatTemBui }};

--- a/geojson_modelica_translator/model_connectors/couplings/templates/TimeSeriesMFT_CoolingIndirect/ConnectStatements.mopt
+++ b/geojson_modelica_translator/model_connectors/couplings/templates/TimeSeriesMFT_CoolingIndirect/ConnectStatements.mopt
@@ -1,7 +1,6 @@
   connect(TChWSET_{{ coupling.id }}.y,{{ coupling.ets.id }}.TSetBuiSup)
     {% raw %}annotation (Line(points={{-22,70},{-28,70},{-28,28},{-24,28}},color={0,0,127})){% endraw %};
-  connect({{ coupling.load.id }}.buiMasTem.y[4],TChWSET_{{ coupling.id }}.u)
-    {% raw %}annotation (Line(points={{99,-10},{90,-10},{90,70},{2,70}},color={0,0,127})){% endraw %};
+  connect({{ coupling.load.id }}.buiMasTem.y[4],TChWSET_{{ coupling.id }}.u);
   connect({{ coupling.load.id }}.ports_aChiWat[1],{{ coupling.ets.id }}.port_b2)
     {% raw %}annotation (Line(points={{-60,10},{-36,10},{-36,22},{-22,22}},color={0,127,255})){% endraw %};
   connect({{ coupling.ets.id }}.port_a2,{{ coupling.load.id }}.ports_bChiWat[1])

--- a/geojson_modelica_translator/model_connectors/couplings/templates/TimeSeriesMFT_CoolingIndirect/ConnectStatements.mopt
+++ b/geojson_modelica_translator/model_connectors/couplings/templates/TimeSeriesMFT_CoolingIndirect/ConnectStatements.mopt
@@ -2,7 +2,7 @@
     {% raw %}annotation (Line(points={{-22,70},{-28,70},{-28,28},{-24,28}},color={0,0,127})){% endraw %};
   connect({{ coupling.load.id }}.buiMasTem.y[4],TChWSET_{{ coupling.id }}.u)
     {% raw %}annotation (Line(points={{99,-10},{90,-10},{90,70},{2,70}},color={0,0,127})){% endraw %};
-  connect({{ coupling.load.id }}.port_aChiWat,{{ coupling.ets.id }}.port_b2)
+  connect({{ coupling.load.id }}.ports_aChiWat[1],{{ coupling.ets.id }}.port_b2)
     {% raw %}annotation (Line(points={{-60,10},{-36,10},{-36,22},{-22,22}},color={0,127,255})){% endraw %};
-  connect({{ coupling.ets.id }}.port_a2,{{ coupling.load.id }}.port_bChiWat)
+  connect({{ coupling.ets.id }}.port_a2,{{ coupling.load.id }}.ports_bChiWat[1])
     {% raw %}annotation (Line(points={{-2,22},{8,22},{8,10},{20,10}},color={0,127,255})){% endraw %};

--- a/geojson_modelica_translator/model_connectors/couplings/templates/TimeSeriesMFT_CoolingIndirect/ConnectStatements.mopt
+++ b/geojson_modelica_translator/model_connectors/couplings/templates/TimeSeriesMFT_CoolingIndirect/ConnectStatements.mopt
@@ -1,0 +1,8 @@
+  connect(TChWSET_{{ coupling.id }}.y,{{ coupling.ets.id }}.TSetBuiSup)
+    {% raw %}annotation (Line(points={{-22,70},{-28,70},{-28,28},{-24,28}},color={0,0,127})){% endraw %};
+  connect({{ coupling.load.id }}.buiMasTem.y[4],TChWSET_{{ coupling.id }}.u)
+    {% raw %}annotation (Line(points={{99,-10},{90,-10},{90,70},{2,70}},color={0,0,127})){% endraw %};
+  connect({{ coupling.load.id }}.buiCooSin.ports[1],{{ coupling.ets.id }}.port_b2)
+    {% raw %}annotation (Line(points={{-60,10},{-36,10},{-36,22},{-22,22}},color={0,127,255})){% endraw %};
+  connect({{ coupling.ets.id }}.port_a2,{{ coupling.load.id }}.supChiWat.ports[1])
+    {% raw %}annotation (Line(points={{-2,22},{8,22},{8,10},{20,10}},color={0,127,255})){% endraw %};

--- a/geojson_modelica_translator/model_connectors/couplings/templates/TimeSeriesMFT_CoolingIndirect/ConnectStatements.mopt
+++ b/geojson_modelica_translator/model_connectors/couplings/templates/TimeSeriesMFT_CoolingIndirect/ConnectStatements.mopt
@@ -2,7 +2,7 @@
     {% raw %}annotation (Line(points={{-22,70},{-28,70},{-28,28},{-24,28}},color={0,0,127})){% endraw %};
   connect({{ coupling.load.id }}.buiMasTem.y[4],TChWSET_{{ coupling.id }}.u)
     {% raw %}annotation (Line(points={{99,-10},{90,-10},{90,70},{2,70}},color={0,0,127})){% endraw %};
-  connect({{ coupling.load.id }}.buiCooSin.ports[1],{{ coupling.ets.id }}.port_b2)
+  connect({{ coupling.load.id }}.port_aChiWat,{{ coupling.ets.id }}.port_b2)
     {% raw %}annotation (Line(points={{-60,10},{-36,10},{-36,22},{-22,22}},color={0,127,255})){% endraw %};
-  connect({{ coupling.ets.id }}.port_a2,{{ coupling.load.id }}.supChiWat.ports[1])
+  connect({{ coupling.ets.id }}.port_a2,{{ coupling.load.id }}.port_bChiWat)
     {% raw %}annotation (Line(points={{-2,22},{8,22},{8,10},{20,10}},color={0,127,255})){% endraw %};

--- a/geojson_modelica_translator/model_connectors/couplings/templates/TimeSeriesMFT_HeatingIndirect/ComponentDefinitions.mopt
+++ b/geojson_modelica_translator/model_connectors/couplings/templates/TimeSeriesMFT_HeatingIndirect/ComponentDefinitions.mopt
@@ -1,0 +1,5 @@
+  Buildings.Controls.OBC.UnitConversions.From_degC THWSET_{{ coupling.id }}
+    {% raw %}annotation (Placement(transformation(extent={{0,-100},{-20,-80}}))){% endraw %};
+  parameter Modelica.SIunits.MassFlowRate mDis_flow_nominal_{{ coupling.id }}={{ coupling.load.id }}.mHW_flow_nominal*{{ globals.delHeaWatTemBui }}/{{ globals.delHeaWatTemDis }};
+  parameter Modelica.SIunits.MassFlowRate mBui_flow_nominal_{{ coupling.id }}={{ coupling.load.id }}.mHW_flow_nominal;
+  parameter Modelica.SIunits.HeatFlowRate Q_flow_nominal_{{ coupling.id }}={{ coupling.load.id }}.mHW_flow_nominal*4187*{{ globals.delHeaWatTemBui }};

--- a/geojson_modelica_translator/model_connectors/couplings/templates/TimeSeriesMFT_HeatingIndirect/ConnectStatements.mopt
+++ b/geojson_modelica_translator/model_connectors/couplings/templates/TimeSeriesMFT_HeatingIndirect/ConnectStatements.mopt
@@ -2,7 +2,7 @@
     {% raw %}annotation (Line(points={{-22,-90},{-36,-90},{-36,-38},{-24,-38}},color={0,0,127})){% endraw %};
   connect({{ coupling.load.id }}.buiMasTem.y[2],THWSET_{{ coupling.id }}.u)
     {% raw %}annotation (Line(points={{99,-10},{90,-10},{90,-90},{2,-90}},color={0,0,127})){% endraw %};
-  connect({{ coupling.load.id }}.port_aHeaWat,{{ coupling.ets.id }}.port_b2)
+  connect({{ coupling.load.id }}.ports_aHeaWat[1],{{ coupling.ets.id }}.port_b2)
     {% raw %}annotation (Line(points={{-60,-70},{-44,-70},{-44,-44},{-22,-44}},color={0,127,255})){% endraw %};
-  connect({{ coupling.load.id }}.port_bHeaWat,{{ coupling.ets.id }}.port_a2)
+  connect({{ coupling.load.id }}.ports_bHeaWat[1],{{ coupling.ets.id }}.port_a2)
     {% raw %}annotation (Line(points={{20,-70},{4,-70},{4,-44},{-2,-44}},color={0,127,255})){% endraw %};

--- a/geojson_modelica_translator/model_connectors/couplings/templates/TimeSeriesMFT_HeatingIndirect/ConnectStatements.mopt
+++ b/geojson_modelica_translator/model_connectors/couplings/templates/TimeSeriesMFT_HeatingIndirect/ConnectStatements.mopt
@@ -2,7 +2,7 @@
     {% raw %}annotation (Line(points={{-22,-90},{-36,-90},{-36,-38},{-24,-38}},color={0,0,127})){% endraw %};
   connect({{ coupling.load.id }}.buiMasTem.y[2],THWSET_{{ coupling.id }}.u)
     {% raw %}annotation (Line(points={{99,-10},{90,-10},{90,-90},{2,-90}},color={0,0,127})){% endraw %};
-  connect({{ coupling.load.id }}.buiHeaSin.ports[1],{{ coupling.ets.id }}.port_b2)
+  connect({{ coupling.load.id }}.port_aHeaWat,{{ coupling.ets.id }}.port_b2)
     {% raw %}annotation (Line(points={{-60,-70},{-44,-70},{-44,-44},{-22,-44}},color={0,127,255})){% endraw %};
-  connect({{ coupling.load.id }}.supHeaWat.ports[1],{{ coupling.ets.id }}.port_a2)
+  connect({{ coupling.load.id }}.port_bHeaWat,{{ coupling.ets.id }}.port_a2)
     {% raw %}annotation (Line(points={{20,-70},{4,-70},{4,-44},{-2,-44}},color={0,127,255})){% endraw %};

--- a/geojson_modelica_translator/model_connectors/couplings/templates/TimeSeriesMFT_HeatingIndirect/ConnectStatements.mopt
+++ b/geojson_modelica_translator/model_connectors/couplings/templates/TimeSeriesMFT_HeatingIndirect/ConnectStatements.mopt
@@ -1,7 +1,6 @@
   connect(THWSET_{{ coupling.id }}.y,{{ coupling.ets.id }}.TSetBuiSup)
     {% raw %}annotation (Line(points={{-22,-90},{-36,-90},{-36,-38},{-24,-38}},color={0,0,127})){% endraw %};
-  connect({{ coupling.load.id }}.buiMasTem.y[2],THWSET_{{ coupling.id }}.u)
-    {% raw %}annotation (Line(points={{99,-10},{90,-10},{90,-90},{2,-90}},color={0,0,127})){% endraw %};
+  connect({{ coupling.load.id }}.buiMasTem.y[2],THWSET_{{ coupling.id }}.u);
   connect({{ coupling.load.id }}.ports_aHeaWat[1],{{ coupling.ets.id }}.port_b2)
     {% raw %}annotation (Line(points={{-60,-70},{-44,-70},{-44,-44},{-22,-44}},color={0,127,255})){% endraw %};
   connect({{ coupling.load.id }}.ports_bHeaWat[1],{{ coupling.ets.id }}.port_a2)

--- a/geojson_modelica_translator/model_connectors/couplings/templates/TimeSeriesMFT_HeatingIndirect/ConnectStatements.mopt
+++ b/geojson_modelica_translator/model_connectors/couplings/templates/TimeSeriesMFT_HeatingIndirect/ConnectStatements.mopt
@@ -1,0 +1,8 @@
+  connect(THWSET_{{ coupling.id }}.y,{{ coupling.ets.id }}.TSetBuiSup)
+    {% raw %}annotation (Line(points={{-22,-90},{-36,-90},{-36,-38},{-24,-38}},color={0,0,127})){% endraw %};
+  connect({{ coupling.load.id }}.buiMasTem.y[2],THWSET_{{ coupling.id }}.u)
+    {% raw %}annotation (Line(points={{99,-10},{90,-10},{90,-90},{2,-90}},color={0,0,127})){% endraw %};
+  connect({{ coupling.load.id }}.buiHeaSin.ports[1],{{ coupling.ets.id }}.port_b2)
+    {% raw %}annotation (Line(points={{-60,-70},{-44,-70},{-44,-44},{-22,-44}},color={0,127,255})){% endraw %};
+  connect({{ coupling.load.id }}.supHeaWat.ports[1],{{ coupling.ets.id }}.port_a2)
+    {% raw %}annotation (Line(points={{20,-70},{4,-70},{4,-44},{-2,-44}},color={0,127,255})){% endraw %};

--- a/geojson_modelica_translator/model_connectors/load_connectors/templates/TimeSeriesMFT_Instance.mopt
+++ b/geojson_modelica_translator/model_connectors/load_connectors/templates/TimeSeriesMFT_Instance.mopt
@@ -1,1 +1,2 @@
-  {{ model.modelica_type }} {{ model.id }};
+  {{ model.modelica_type }} {{ model.id }}
+  {% raw %}annotation (Placement(transformation(extent={{0,60},{20,80}}))){% endraw %};

--- a/geojson_modelica_translator/model_connectors/load_connectors/templates/TimeSeriesMFT_Instance.mopt
+++ b/geojson_modelica_translator/model_connectors/load_connectors/templates/TimeSeriesMFT_Instance.mopt
@@ -1,0 +1,1 @@
+  {{ model.modelica_type }} {{ model.id }};

--- a/geojson_modelica_translator/model_connectors/load_connectors/templates/TimeSeriesMassFlowTemperatures.mot
+++ b/geojson_modelica_translator/model_connectors/load_connectors/templates/TimeSeriesMassFlowTemperatures.mot
@@ -1,5 +1,5 @@
-within {{project_name}}.Districts;
-model TimeSeriesMassFlowTemperatures
+within {{project_name}}.Loads.{{ model_name }};
+model building
   "Time series water mass flow rates and temperatures for a building thermal
   loads generated from Energy PLus."
   extends Modelica.Icons.Example;
@@ -15,18 +15,6 @@ model TimeSeriesMassFlowTemperatures
     filNam=Modelica.Utilities.Files.loadResource(filNam))
     "Nominal heating water flow rate"
     annotation (Dialog(group="Design parameter"));
-  parameter Modelica.SIunits.TemperatureDifference delTBuiChW(
-    displayUnit="degC")=7
-    "Nominal chilled water temperature differnce(building side)";
-  parameter Modelica.SIunits.TemperatureDifference delTBuiHW(
-    displayUnit="degC")=15
-    "Nominal heating water temperature difference(building side) ";
-  parameter Modelica.SIunits.TemperatureDifference delTDisChW(
-    displayUnit="degC")=9
-    "Nominal chilled water temperature differnce(district side)";
-  parameter Modelica.SIunits.TemperatureDifference delTDisHW(
-    displayUnit="degC")=20
-    "Nominal heating water temperature difference(district side) ";
   Modelica.Blocks.Sources.CombiTimeTable buiMasTem(
     tableOnFile=true,
     tableName="modelica",
@@ -43,52 +31,12 @@ model TimeSeriesMassFlowTemperatures
     nPorts=1)
     "Chilled water supply"
     annotation (Placement(transformation(extent={{10,-10},{-10,10}},rotation=0,origin={30,10})));
-  Buildings.Fluid.Sources.Boundary_pT disCooSin(
-    redeclare package Medium=MediumW,
-    use_T_in=false,
-    T=288.15,
-    nPorts=1)
-    "District cooling sink."
-    annotation (Placement(transformation(extent={{10,-10},{-10,10}},rotation=0,origin={30,50})));
-  CoolingIndirect cooETS(
-    allowFlowReversal1=false,
-    allowFlowReversal2=false,
-    redeclare package Medium=MediumW,
-    mBui_flow_nominal=mChW_flow_nominal,
-    mDis_flow_nominal=mChW_flow_nominal,
-    dpValve_nominal=6000,
-    dp1_nominal=500,
-    dp2_nominal=500,
-    use_Q_flow_nominal=true,
-    Q_flow_nominal=mChW_flow_nominal*4187*delTBuiChW,
-    T_a1_nominal(
-      displayUnit="degC")=278.15,
-    T_a2_nominal(
-      displayUnit="degC")=289.15,
-    eta=0.8)
-    annotation (Placement(transformation(extent={{-22,18},{-2,38}})));
   Buildings.Fluid.Sources.Boundary_pT buiCooSin(
     redeclare package Medium=MediumW,
     use_T_in=false,
     nPorts=1)
     "Building cooling sink."
     annotation (Placement(transformation(extent={{-10,-10},{10,10}},rotation=0,origin={-70,10})));
-  HeatingIndirect heaETS(
-    allowFlowReversal1=false,
-    allowFlowReversal2=false,
-    redeclare package Medium=MediumW,
-    mBui_flow_nominal=mHW_flow_nominal,
-    mDis_flow_nominal=mHW_flow_nominal*delTBuiHW/delTDisHW,
-    dpValve_nominal=6000,
-    dp1_nominal=500,
-    dp2_nominal=500,
-    use_Q_flow_nominal=true,
-    Q_flow_nominal=mHW_flow_nominal*4187*delTBuiHW,
-    T_a1_nominal=338.15,
-    T_a2_nominal=315.15,
-    xi_start=0,
-    reverseActing=true)
-    annotation (Placement(transformation(extent={{-22,-48},{-2,-28}})));
   Buildings.Fluid.Sources.MassFlowSource_T supHeaWat(
     redeclare package Medium=MediumW,
     use_m_flow_in=true,
@@ -102,89 +50,28 @@ model TimeSeriesMassFlowTemperatures
     nPorts=1)
     "Building heating sink."
     annotation (Placement(transformation(extent={{-10,-10},{10,10}},rotation=0,origin={-70,-70})));
-  Buildings.Fluid.Sources.Boundary_pT disHeaSou(
-    redeclare package Medium=MediumW,
-    use_T_in=false,
-    T=313.15,
-    nPorts=1)
-    "Heating water supply"
-    annotation (Placement(transformation(extent={{10,-10},{-10,10}},rotation=0,origin={30,-30})));
   Buildings.Controls.OBC.UnitConversions.From_degC TChWR
     annotation (Placement(transformation(extent={{80,20},{60,40}})));
   Buildings.Controls.OBC.UnitConversions.From_degC THWR
     "Heating water temperature."
     annotation (Placement(transformation(extent={{80,-60},{60,-40}})));
-  Buildings.Controls.OBC.UnitConversions.From_degC TChWSET
-    annotation (Placement(transformation(extent={{0,60},{-20,80}})));
-  Buildings.Controls.OBC.UnitConversions.From_degC THWSET
-    annotation (Placement(transformation(extent={{0,-100},{-20,-80}})));
-  Buildings.Fluid.Sources.MassFlowSource_T supDisChWat(
-    redeclare package Medium=MediumW,
-    use_m_flow_in=true,
-    use_T_in=false,
-    T=278.15,
-    nPorts=1)
-    "Chilled water supply district side."
-    annotation (Placement(transformation(extent={{-10,-10},{10,10}},rotation=0,origin={-70,50})));
-  Modelica.Blocks.Sources.RealExpression mDisChW(
-    y=buiMasTem.y[6]*(delTBuiChW/delTDisChW))
-    annotation (Placement(transformation(extent={{-36,70},{-56,90}})));
-  Modelica.Blocks.Sources.RealExpression mDisHW(
-    y=buiMasTem.y[5]*delTDisHW/delTBuiHW)
-    annotation (Placement(transformation(extent={{-40,-20},{-60,0}})));
   Modelica.Blocks.Sources.RealExpression mBuiHW(
     y=buiMasTem.y[5])
     annotation (Placement(transformation(extent={{80,-20},{60,0}})));
-  Buildings.Fluid.Sources.MassFlowSource_T disHeaSin(
-    redeclare package Medium=MediumW,
-    use_m_flow_in=true,
-    use_T_in=false,
-    T=330.15,
-    nPorts=1)
-    "District heating sink."
-    annotation (Placement(transformation(extent={{-10,-10},{10,10}},rotation=0,origin={-70,-30})));
   Modelica.Blocks.Sources.RealExpression mBuiChW(
     y=buiMasTem.y[6])
     annotation (Placement(transformation(extent={{82,50},{62,70}})));
 equation
-  connect(cooETS.port_a2,supChiWat.ports[1])
-    annotation (Line(points={{-2,22},{8,22},{8,10},{20,10}},color={0,127,255}));
-  connect(cooETS.port_b1,disCooSin.ports[1])
-    annotation (Line(points={{-2,34},{4,34},{4,50},{20,50}},color={0,127,255}));
-  connect(buiCooSin.ports[1],cooETS.port_b2)
-    annotation (Line(points={{-60,10},{-36,10},{-36,22},{-22,22}},color={0,127,255}));
-  connect(THWSET.y,heaETS.TSetBuiSup)
-    annotation (Line(points={{-22,-90},{-36,-90},{-36,-38},{-24,-38}},color={0,0,127}));
-  connect(TChWSET.y,cooETS.TSetBuiSup)
-    annotation (Line(points={{-22,70},{-28,70},{-28,28},{-24,28}},color={0,0,127}));
   connect(TChWR.y,supChiWat.T_in)
     annotation (Line(points={{58,30},{46,30},{46,14},{42,14}},color={0,0,127}));
   connect(THWR.y,supHeaWat.T_in)
     annotation (Line(points={{58,-50},{58,-66},{42,-66}},color={0,0,127}));
-  connect(supDisChWat.ports[1],cooETS.port_a1)
-    annotation (Line(points={{-60,50},{-36,50},{-36,34},{-22,34}},color={0,127,255}));
-  connect(mDisChW.y,supDisChWat.m_flow_in)
-    annotation (Line(points={{-57,80},{-84,80},{-84,58},{-82,58}},color={0,0,127}));
-  connect(buiHeaSin.ports[1],heaETS.port_b2)
-    annotation (Line(points={{-60,-70},{-44,-70},{-44,-44},{-22,-44}},color={0,127,255}));
-  connect(supHeaWat.ports[1],heaETS.port_a2)
-    annotation (Line(points={{20,-70},{4,-70},{4,-44},{-2,-44}},color={0,127,255}));
-  connect(disHeaSou.ports[1],heaETS.port_b1)
-    annotation (Line(points={{20,-30},{4,-30},{4,-32},{-2,-32}},color={0,127,255}));
   connect(mBuiHW.y,supHeaWat.m_flow_in)
     annotation (Line(points={{59,-10},{50,-10},{50,-62},{42,-62}},color={0,0,127}));
-  connect(disHeaSin.ports[1],heaETS.port_a1)
-    annotation (Line(points={{-60,-30},{-38,-30},{-38,-32},{-22,-32}},color={0,127,255}));
-  connect(mDisHW.y,disHeaSin.m_flow_in)
-    annotation (Line(points={{-61,-10},{-84,-10},{-84,-22},{-82,-22}},color={0,0,127}));
   connect(buiMasTem.y[1],THWR.u)
     annotation (Line(points={{99,-10},{90,-10},{90,-50},{82,-50}},color={0,0,127}));
-  connect(buiMasTem.y[2],THWSET.u)
-    annotation (Line(points={{99,-10},{90,-10},{90,-90},{2,-90}},color={0,0,127}));
   connect(buiMasTem.y[3],TChWR.u)
     annotation (Line(points={{99,-10},{90,-10},{90,30},{82,30}},color={0,0,127}));
-  connect(buiMasTem.y[4],TChWSET.u)
-    annotation (Line(points={{99,-10},{90,-10},{90,70},{2,70}},color={0,0,127}));
   connect(mBuiChW.y,supChiWat.m_flow_in)
     annotation (Line(points={{61,60},{42,60},{42,18}},color={0,0,127}));
   annotation (
@@ -216,5 +103,5 @@ First implementation.
 </li>
 </ul>
 </html>"));
-end TimeSeriesMassFlowTemperatures;
+end building;
 {% endraw %}

--- a/geojson_modelica_translator/model_connectors/load_connectors/templates/TimeSeriesMassFlowTemperatures.mot
+++ b/geojson_modelica_translator/model_connectors/load_connectors/templates/TimeSeriesMassFlowTemperatures.mot
@@ -172,7 +172,13 @@ equation
           lineColor={95,95,95},
           smooth=Smooth.None,
           fillPattern=FillPattern.Solid,
-          fillColor={95,95,95})}),
+          fillColor={95,95,95}),
+        Text(
+          extent={{-100,20},{100,-20}},
+          lineColor={0,0,0},
+          fillColor={0,0,0},
+          fillPattern=FillPattern.Solid,
+          textString="MFT")}),
     __Dymola_Commands(
       file="modelica://Buildings/Resources/Scripts/Dymola/Applications/DHC/Loads/Examples/TimeSeries_MassFlow_Temperature.mos" "Simulate and plot"),
     experiment(

--- a/geojson_modelica_translator/model_connectors/load_connectors/templates/TimeSeriesMassFlowTemperatures.mot
+++ b/geojson_modelica_translator/model_connectors/load_connectors/templates/TimeSeriesMassFlowTemperatures.mot
@@ -1,0 +1,220 @@
+within {{project_name}}.Districts;
+model TimeSeriesMassFlowTemperatures
+  "Time series water mass flow rates and temperatures for a building thermal
+  loads generated from Energy PLus."
+  extends Modelica.Icons.Example;
+  {% raw %}package MediumW=Buildings.Media.Water;
+  {% endraw %}parameter String filNam="modelica://{{project_name}}/Loads/{{data['load_resources_path']}}/{{data['time_series']['filename']}}";
+  {% raw %}parameter Modelica.SIunits.MassFlowRate mChW_flow_nominal=getPeakMassFlowRate(
+    string="#Nominal chilled water mass flow rate",
+    filNam=Modelica.Utilities.Files.loadResource(filNam))
+    "Nominal cooling water flow rate"
+    annotation (Dialog(group="Design parameter"));
+  parameter Modelica.SIunits.MassFlowRate mHW_flow_nominal=getPeakMassFlowRate(
+    string="#Nominal heating water mass flow rate",
+    filNam=Modelica.Utilities.Files.loadResource(filNam))
+    "Nominal heating water flow rate"
+    annotation (Dialog(group="Design parameter"));
+  parameter Modelica.SIunits.TemperatureDifference delTBuiChW(
+    displayUnit="degC")=7
+    "Nominal chilled water temperature differnce(building side)";
+  parameter Modelica.SIunits.TemperatureDifference delTBuiHW(
+    displayUnit="degC")=15
+    "Nominal heating water temperature difference(building side) ";
+  parameter Modelica.SIunits.TemperatureDifference delTDisChW(
+    displayUnit="degC")=9
+    "Nominal chilled water temperature differnce(district side)";
+  parameter Modelica.SIunits.TemperatureDifference delTDisHW(
+    displayUnit="degC")=20
+    "Nominal heating water temperature difference(district side) ";
+  Modelica.Blocks.Sources.CombiTimeTable buiMasTem(
+    tableOnFile=true,
+    tableName="modelica",
+    fileName=Modelica.Utilities.Files.loadResource(
+      filNam),
+    extrapolation=Modelica.Blocks.Types.Extrapolation.Periodic,
+    columns=2:7,
+    smoothness=Modelica.Blocks.Types.Smoothness.LinearSegments)
+    annotation (Placement(transformation(extent={{120,-20},{100,0}})));
+  Buildings.Fluid.Sources.MassFlowSource_T supChiWat(
+    redeclare package Medium=MediumW,
+    use_m_flow_in=true,
+    use_T_in=true,
+    nPorts=1)
+    "Chilled water supply"
+    annotation (Placement(transformation(extent={{10,-10},{-10,10}},rotation=0,origin={30,10})));
+  Buildings.Fluid.Sources.Boundary_pT disCooSin(
+    redeclare package Medium=MediumW,
+    use_T_in=false,
+    T=288.15,
+    nPorts=1)
+    "District cooling sink."
+    annotation (Placement(transformation(extent={{10,-10},{-10,10}},rotation=0,origin={30,50})));
+  CoolingIndirect cooETS(
+    allowFlowReversal1=false,
+    allowFlowReversal2=false,
+    redeclare package Medium=MediumW,
+    mBui_flow_nominal=mChW_flow_nominal,
+    mDis_flow_nominal=mChW_flow_nominal,
+    dpValve_nominal=6000,
+    dp1_nominal=500,
+    dp2_nominal=500,
+    use_Q_flow_nominal=true,
+    Q_flow_nominal=mChW_flow_nominal*4187*delTBuiChW,
+    T_a1_nominal(
+      displayUnit="degC")=278.15,
+    T_a2_nominal(
+      displayUnit="degC")=289.15,
+    eta=0.8)
+    annotation (Placement(transformation(extent={{-22,18},{-2,38}})));
+  Buildings.Fluid.Sources.Boundary_pT buiCooSin(
+    redeclare package Medium=MediumW,
+    use_T_in=false,
+    nPorts=1)
+    "Building cooling sink."
+    annotation (Placement(transformation(extent={{-10,-10},{10,10}},rotation=0,origin={-70,10})));
+  HeatingIndirect heaETS(
+    allowFlowReversal1=false,
+    allowFlowReversal2=false,
+    redeclare package Medium=MediumW,
+    mBui_flow_nominal=mHW_flow_nominal,
+    mDis_flow_nominal=mHW_flow_nominal*delTBuiHW/delTDisHW,
+    dpValve_nominal=6000,
+    dp1_nominal=500,
+    dp2_nominal=500,
+    use_Q_flow_nominal=true,
+    Q_flow_nominal=mHW_flow_nominal*4187*delTBuiHW,
+    T_a1_nominal=338.15,
+    T_a2_nominal=315.15,
+    xi_start=0,
+    reverseActing=true)
+    annotation (Placement(transformation(extent={{-22,-48},{-2,-28}})));
+  Buildings.Fluid.Sources.MassFlowSource_T supHeaWat(
+    redeclare package Medium=MediumW,
+    use_m_flow_in=true,
+    use_T_in=true,
+    nPorts=1)
+    "Heating water supply"
+    annotation (Placement(transformation(extent={{10,-10},{-10,10}},rotation=0,origin={30,-70})));
+  Buildings.Fluid.Sources.Boundary_pT buiHeaSin(
+    redeclare package Medium=MediumW,
+    use_T_in=false,
+    nPorts=1)
+    "Building heating sink."
+    annotation (Placement(transformation(extent={{-10,-10},{10,10}},rotation=0,origin={-70,-70})));
+  Buildings.Fluid.Sources.Boundary_pT disHeaSou(
+    redeclare package Medium=MediumW,
+    use_T_in=false,
+    T=313.15,
+    nPorts=1)
+    "Heating water supply"
+    annotation (Placement(transformation(extent={{10,-10},{-10,10}},rotation=0,origin={30,-30})));
+  Buildings.Controls.OBC.UnitConversions.From_degC TChWR
+    annotation (Placement(transformation(extent={{80,20},{60,40}})));
+  Buildings.Controls.OBC.UnitConversions.From_degC THWR
+    "Heating water temperature."
+    annotation (Placement(transformation(extent={{80,-60},{60,-40}})));
+  Buildings.Controls.OBC.UnitConversions.From_degC TChWSET
+    annotation (Placement(transformation(extent={{0,60},{-20,80}})));
+  Buildings.Controls.OBC.UnitConversions.From_degC THWSET
+    annotation (Placement(transformation(extent={{0,-100},{-20,-80}})));
+  Buildings.Fluid.Sources.MassFlowSource_T supDisChWat(
+    redeclare package Medium=MediumW,
+    use_m_flow_in=true,
+    use_T_in=false,
+    T=278.15,
+    nPorts=1)
+    "Chilled water supply district side."
+    annotation (Placement(transformation(extent={{-10,-10},{10,10}},rotation=0,origin={-70,50})));
+  Modelica.Blocks.Sources.RealExpression mDisChW(
+    y=buiMasTem.y[6]*(delTBuiChW/delTDisChW))
+    annotation (Placement(transformation(extent={{-36,70},{-56,90}})));
+  Modelica.Blocks.Sources.RealExpression mDisHW(
+    y=buiMasTem.y[5]*delTDisHW/delTBuiHW)
+    annotation (Placement(transformation(extent={{-40,-20},{-60,0}})));
+  Modelica.Blocks.Sources.RealExpression mBuiHW(
+    y=buiMasTem.y[5])
+    annotation (Placement(transformation(extent={{80,-20},{60,0}})));
+  Buildings.Fluid.Sources.MassFlowSource_T disHeaSin(
+    redeclare package Medium=MediumW,
+    use_m_flow_in=true,
+    use_T_in=false,
+    T=330.15,
+    nPorts=1)
+    "District heating sink."
+    annotation (Placement(transformation(extent={{-10,-10},{10,10}},rotation=0,origin={-70,-30})));
+  Modelica.Blocks.Sources.RealExpression mBuiChW(
+    y=buiMasTem.y[6])
+    annotation (Placement(transformation(extent={{82,50},{62,70}})));
+equation
+  connect(cooETS.port_a2,supChiWat.ports[1])
+    annotation (Line(points={{-2,22},{8,22},{8,10},{20,10}},color={0,127,255}));
+  connect(cooETS.port_b1,disCooSin.ports[1])
+    annotation (Line(points={{-2,34},{4,34},{4,50},{20,50}},color={0,127,255}));
+  connect(buiCooSin.ports[1],cooETS.port_b2)
+    annotation (Line(points={{-60,10},{-36,10},{-36,22},{-22,22}},color={0,127,255}));
+  connect(THWSET.y,heaETS.TSetBuiSup)
+    annotation (Line(points={{-22,-90},{-36,-90},{-36,-38},{-24,-38}},color={0,0,127}));
+  connect(TChWSET.y,cooETS.TSetBuiSup)
+    annotation (Line(points={{-22,70},{-28,70},{-28,28},{-24,28}},color={0,0,127}));
+  connect(TChWR.y,supChiWat.T_in)
+    annotation (Line(points={{58,30},{46,30},{46,14},{42,14}},color={0,0,127}));
+  connect(THWR.y,supHeaWat.T_in)
+    annotation (Line(points={{58,-50},{58,-66},{42,-66}},color={0,0,127}));
+  connect(supDisChWat.ports[1],cooETS.port_a1)
+    annotation (Line(points={{-60,50},{-36,50},{-36,34},{-22,34}},color={0,127,255}));
+  connect(mDisChW.y,supDisChWat.m_flow_in)
+    annotation (Line(points={{-57,80},{-84,80},{-84,58},{-82,58}},color={0,0,127}));
+  connect(buiHeaSin.ports[1],heaETS.port_b2)
+    annotation (Line(points={{-60,-70},{-44,-70},{-44,-44},{-22,-44}},color={0,127,255}));
+  connect(supHeaWat.ports[1],heaETS.port_a2)
+    annotation (Line(points={{20,-70},{4,-70},{4,-44},{-2,-44}},color={0,127,255}));
+  connect(disHeaSou.ports[1],heaETS.port_b1)
+    annotation (Line(points={{20,-30},{4,-30},{4,-32},{-2,-32}},color={0,127,255}));
+  connect(mBuiHW.y,supHeaWat.m_flow_in)
+    annotation (Line(points={{59,-10},{50,-10},{50,-62},{42,-62}},color={0,0,127}));
+  connect(disHeaSin.ports[1],heaETS.port_a1)
+    annotation (Line(points={{-60,-30},{-38,-30},{-38,-32},{-22,-32}},color={0,127,255}));
+  connect(mDisHW.y,disHeaSin.m_flow_in)
+    annotation (Line(points={{-61,-10},{-84,-10},{-84,-22},{-82,-22}},color={0,0,127}));
+  connect(buiMasTem.y[1],THWR.u)
+    annotation (Line(points={{99,-10},{90,-10},{90,-50},{82,-50}},color={0,0,127}));
+  connect(buiMasTem.y[2],THWSET.u)
+    annotation (Line(points={{99,-10},{90,-10},{90,-90},{2,-90}},color={0,0,127}));
+  connect(buiMasTem.y[3],TChWR.u)
+    annotation (Line(points={{99,-10},{90,-10},{90,30},{82,30}},color={0,0,127}));
+  connect(buiMasTem.y[4],TChWSET.u)
+    annotation (Line(points={{99,-10},{90,-10},{90,70},{2,70}},color={0,0,127}));
+  connect(mBuiChW.y,supChiWat.m_flow_in)
+    annotation (Line(points={{61,60},{42,60},{42,18}},color={0,0,127}));
+  annotation (
+    Diagram(
+      coordinateSystem(
+        extent={{-100,-100},{120,100}})),
+    Icon(
+      coordinateSystem(
+        extent={{-100,-100},{120,100}})),
+    __Dymola_Commands(
+      file="modelica://Buildings/Resources/Scripts/Dymola/Applications/DHC/Loads/Examples/TimeSeries_MassFlow_Temperature.mos" "Simulate and plot"),
+    experiment(
+      Tolerance=1e-6,
+      StopTime=31534200),
+    Documentation(
+      info="<html>
+<p>
+This example connects the building side (time series CSV file generated from
+energyPlus of heating/cooling water mass flow rate and temperature's)
+with the district side (infinite sources of cooling and heating) through
+an indirect heating and cooling energy transfer station (ETS, a heat exchanger).
+</p>
+</html>",
+      revisions="<html>
+<ul>
+<li>
+August 25, 2020, by Hagar Elarga:<br/>
+First implementation.
+</li>
+</ul>
+</html>"));
+end TimeSeriesMassFlowTemperatures;
+{% endraw %}

--- a/geojson_modelica_translator/model_connectors/load_connectors/templates/TimeSeriesMassFlowTemperatures.mot
+++ b/geojson_modelica_translator/model_connectors/load_connectors/templates/TimeSeriesMassFlowTemperatures.mot
@@ -61,7 +61,27 @@ model building
   Modelica.Blocks.Sources.RealExpression mBuiChW(
     y=buiMasTem.y[6])
     annotation (Placement(transformation(extent={{82,50},{62,70}})));
+  Modelica.Fluid.Interfaces.FluidPort_a port_aHeaWat
+    "Heating water inlet port"
+    annotation (Placement(transformation(extent={{-310,-100},{-290,-80}}),iconTransformation(extent={{-310,-100},{-290,-80}})));
+  Modelica.Fluid.Interfaces.FluidPort_a port_aChiWat
+    "Chilled water inlet port"
+    annotation (Placement(transformation(extent={{-310,-300},{-290,-280}}),iconTransformation(extent={{-310,-220},{-290,-200}})));
+  Modelica.Fluid.Interfaces.FluidPort_b port_bHeaWat
+    "Heating water outlet port"
+    annotation (Placement(transformation(extent={{290,-100},{310,-80}}),iconTransformation(extent={{290,-100},{310,-80}})));
+  Modelica.Fluid.Interfaces.FluidPort_b port_bChiWat
+    "Chilled water outlet port"
+    annotation (Placement(transformation(extent={{290,-300},{310,-280}}),iconTransformation(extent={{290,-220},{310,-200}})));
 equation
+  connect(buiCooSin.ports[1],port_aChiWat)
+    annotation (Line(points={{-60,10},{-60,-46},{-118,-46},{-118,-290},{-300,-290}},color={0,0,127}));
+  connect(buiHeaSin.ports[1],port_aHeaWat)
+    annotation (Line(points={{-60,-70},{-180,-70},{-180,-90},{-300,-90}},color={0,0,127}));
+  connect(supChiWat.ports[1],port_bChiWat)
+    annotation (Line(points={{20,10},{160,10},{160,-290},{300,-290}},color={0,0,127}));
+  connect(supHeaWat.ports[1],port_bHeaWat)
+    annotation (Line(points={{20,-70},{190,-70},{190,-90},{300,-90}},color={0,0,127}));
   connect(TChWR.y,supChiWat.T_in)
     annotation (Line(points={{58,30},{46,30},{46,14},{42,14}},color={0,0,127}));
   connect(THWR.y,supHeaWat.T_in)
@@ -77,10 +97,82 @@ equation
   annotation (
     Diagram(
       coordinateSystem(
-        extent={{-100,-100},{120,100}})),
+        preserveAspectRatio=false,
+        extent={{-300,-300},{300,300}})),
     Icon(
       coordinateSystem(
-        extent={{-100,-100},{120,100}})),
+        extent={{-300,-300},{300,300}},
+        preserveAspectRatio=false),
+      graphics={
+        Rectangle(
+          extent={{-300,-300},{300,300}},
+          lineColor={0,0,127},
+          fillColor={255,255,255},
+          fillPattern=FillPattern.Solid),
+        Rectangle(
+          extent={{20,-188},{300,-172}},
+          lineColor={0,0,255},
+          pattern=LinePattern.None,
+          fillColor={255,0,0},
+          fillPattern=FillPattern.Solid),
+        Rectangle(
+          extent={{-300,-172},{-20,-188}},
+          lineColor={0,0,255},
+          pattern=LinePattern.None,
+          fillColor={0,0,255},
+          fillPattern=FillPattern.Solid),
+        Rectangle(
+          extent={{18,-38},{46,-10}},
+          lineColor={255,255,255},
+          fillColor={255,255,255},
+          fillPattern=FillPattern.Solid),
+        Text(
+          extent={{-150,-328},{150,-368}},
+          lineColor={0,0,255},
+          textString="%name"),
+        Rectangle(
+          extent={{20,-52},{300,-68}},
+          lineColor={0,0,255},
+          pattern=LinePattern.None,
+          fillColor={0,0,255},
+          fillPattern=FillPattern.Solid),
+        Rectangle(
+          extent={{-300,-68},{-20,-52}},
+          lineColor={0,0,255},
+          pattern=LinePattern.None,
+          fillColor={255,0,0},
+          fillPattern=FillPattern.Solid),
+        Rectangle(
+          extent={{-180,180},{174,-220}},
+          lineColor={150,150,150},
+          fillPattern=FillPattern.Sphere,
+          fillColor={255,255,255}),
+        Rectangle(
+          extent={{36,42},{108,114}},
+          lineColor={255,255,255},
+          fillColor={255,255,255},
+          fillPattern=FillPattern.Solid),
+        Rectangle(
+          extent={{-124,42},{-52,114}},
+          lineColor={255,255,255},
+          fillColor={255,255,255},
+          fillPattern=FillPattern.Solid),
+        Rectangle(
+          extent={{-126,-122},{-54,-50}},
+          lineColor={255,255,255},
+          fillColor={255,255,255},
+          fillPattern=FillPattern.Solid),
+        Rectangle(
+          extent={{40,-122},{112,-50}},
+          lineColor={255,255,255},
+          fillColor={255,255,255},
+          fillPattern=FillPattern.Solid),
+        Polygon(
+          points={{0,264},{-218,164},{220,164},{0,264}},
+          lineColor={95,95,95},
+          smooth=Smooth.None,
+          fillPattern=FillPattern.Solid,
+          fillColor={95,95,95})}),
     __Dymola_Commands(
       file="modelica://Buildings/Resources/Scripts/Dymola/Applications/DHC/Loads/Examples/TimeSeries_MassFlow_Temperature.mos" "Simulate and plot"),
     experiment(

--- a/geojson_modelica_translator/model_connectors/load_connectors/templates/TimeSeriesMassFlowTemperatures.mot
+++ b/geojson_modelica_translator/model_connectors/load_connectors/templates/TimeSeriesMassFlowTemperatures.mot
@@ -61,26 +61,26 @@ model building
   Modelica.Blocks.Sources.RealExpression mBuiChW(
     y=buiMasTem.y[6])
     annotation (Placement(transformation(extent={{82,50},{62,70}})));
-  Modelica.Fluid.Interfaces.FluidPort_a port_aHeaWat
+  Modelica.Fluid.Interfaces.FluidPorts_a ports_aHeaWat[1]
     "Heating water inlet port"
-    annotation (Placement(transformation(extent={{-310,-100},{-290,-80}}),iconTransformation(extent={{-310,-100},{-290,-80}})));
-  Modelica.Fluid.Interfaces.FluidPort_a port_aChiWat
+    annotation (Placement(transformation(extent={{-310,-100},{-290,-20}}),iconTransformation(extent={{-310,-100},{-290,-20}})));
+  Modelica.Fluid.Interfaces.FluidPorts_a ports_aChiWat[1]
     "Chilled water inlet port"
-    annotation (Placement(transformation(extent={{-310,-300},{-290,-280}}),iconTransformation(extent={{-310,-220},{-290,-200}})));
-  Modelica.Fluid.Interfaces.FluidPort_b port_bHeaWat
+    annotation (Placement(transformation(extent={{-310,-300},{-290,-220}}),iconTransformation(extent={{-310,-220},{-290,-140}})));
+  Modelica.Fluid.Interfaces.FluidPorts_b ports_bHeaWat[1]
     "Heating water outlet port"
-    annotation (Placement(transformation(extent={{290,-100},{310,-80}}),iconTransformation(extent={{290,-100},{310,-80}})));
-  Modelica.Fluid.Interfaces.FluidPort_b port_bChiWat
+    annotation (Placement(transformation(extent={{290,-100},{310,-20}}),iconTransformation(extent={{290,-100},{310,-20}})));
+  Modelica.Fluid.Interfaces.FluidPorts_b ports_bChiWat[1]
     "Chilled water outlet port"
-    annotation (Placement(transformation(extent={{290,-300},{310,-280}}),iconTransformation(extent={{290,-220},{310,-200}})));
+    annotation (Placement(transformation(extent={{290,-300},{310,-220}}),iconTransformation(extent={{290,-220},{310,-140}})));
 equation
-  connect(buiCooSin.ports[1],port_aChiWat)
+  connect(buiCooSin.ports[1],ports_aChiWat[1])
     annotation (Line(points={{-60,10},{-60,-46},{-118,-46},{-118,-290},{-300,-290}},color={0,0,127}));
-  connect(buiHeaSin.ports[1],port_aHeaWat)
+  connect(buiHeaSin.ports[1],ports_aHeaWat[1])
     annotation (Line(points={{-60,-70},{-180,-70},{-180,-90},{-300,-90}},color={0,0,127}));
-  connect(supChiWat.ports[1],port_bChiWat)
+  connect(supChiWat.ports[1],ports_bChiWat[1])
     annotation (Line(points={{20,10},{160,10},{160,-290},{300,-290}},color={0,0,127}));
-  connect(supHeaWat.ports[1],port_bHeaWat)
+  connect(supHeaWat.ports[1],ports_bHeaWat[1])
     annotation (Line(points={{20,-70},{190,-70},{190,-90},{300,-90}},color={0,0,127}));
   connect(TChWR.y,supChiWat.T_in)
     annotation (Line(points={{58,30},{46,30},{46,14},{42,14}},color={0,0,127}));

--- a/geojson_modelica_translator/model_connectors/load_connectors/templates/getPeakMassFlowRate.mo
+++ b/geojson_modelica_translator/model_connectors/load_connectors/templates/getPeakMassFlowRate.mo
@@ -1,0 +1,100 @@
+function getPeakMassFlowRate
+  "Function that reads the peak mass flow Rate from the load profile"
+  input String string
+    "String that is written before the '=' sign";
+  input String filNam
+    "Name of data file with heating and cooling  water mass flow rate"
+    annotation (Dialog(loadSelector(filter="Load file (*.mos)",caption="Select load file")));
+  output Real number
+    "Number that is read from the file";
+protected
+  String lin
+    "Line that is used in parser";
+  Integer iLin
+    "Line number";
+  Integer index=0
+    "Index of string 'string'";
+  Integer staInd
+    "Start index used when parsing a real number";
+  Integer nexInd
+    "Next index used when parsing a real number";
+  Boolean found
+    "Flag, true if 'string' has been found";
+  Boolean EOF
+    "Flag, true if EOF has been reached";
+  String del
+    "Found delimiter";
+algorithm
+  // Get line that contains 'string'
+  iLin := 0;
+  EOF := false;
+  while(not EOF) and(index == 0) loop
+    iLin := iLin+1;
+    (lin,EOF) := Modelica.Utilities.Streams.readLine(
+      fileName=filNam,
+      lineNumber=iLin);
+    index := Modelica.Utilities.Strings.find(
+      string=lin,
+      searchString=string,
+      startIndex=1,
+      caseSensitive=true);
+  end while;
+  assert(
+    not EOF,
+    "Error: Did not find '"+string+"' when scanning '"+filNam+"'."+"\n   Check for correct file syntax.");
+  // Search for the equality sign
+  (del,nexInd) := Modelica.Utilities.Strings.scanDelimiter(
+    string=lin,
+    startIndex=Modelica.Utilities.Strings.length(string)+1,
+    requiredDelimiters={"="},
+    message="Failed to find '=' when reading water mass flow rate in '"+filNam+"'.");
+  // Read the value behind it.
+  number := Modelica.Utilities.Strings.scanReal(
+    string=lin,
+    startIndex=nexInd,
+    message="Failed to read double value when reading water mass flow rate in '"+filNam+"'.");
+  annotation (
+    Documentation(
+      info="<html>
+<p>
+This Function that reads a double value from a text file.
+</p>
+<p>
+This function scans a file that has a format such as
+</p>
+<pre>
+#1
+#Some other text
+#Nominal chilled water mass flow rate = 17.41  kg/s
+#Nominal heating water mass flow rate = 52.83  kg/s
+double tab1(35041,7)
+0,42.63,55.0,15.74,6.67,9.98,0.15
+900,42.63,55.0,15.74,6.67,9.98,0.15
+...
+</pre>
+<p>
+The parameter <code>string</code> is a string that the function
+searches for, starting at the first line.
+If it finds the string, it expects an equality sign, and
+returns the double value after this equality sign.
+If the function encounters the end of the file, it
+terminates the simulation with an assertion.
+</p>
+<p>
+See
+<a href=\"modelica://Buildings.Experimental.DHC.Loads.BaseClasses.Validation.GetPeakMassFlowRate\">
+Buildings.Experimental.DHC.Loads.BaseClasses.Validation.GetPeakMassFlowRate</a>
+for how to invoke this function.
+</p>
+</html>",
+      revisions="<html>
+<ul>
+<li>
+August 20, 2020, by Hagar Elarga:<br/>
+First implementation based on the implementation of
+<a href=\"modelica://Buildings.Experimental.DHC.Loads.BaseClasses.Validation.GetPeakLoad\">
+Buildings.Experimental.DHC.Loads.BaseClasses.Validation.GetPeakLoad</a> function.
+</li>
+</ul>
+</html>"));
+end getPeakMassFlowRate;

--- a/geojson_modelica_translator/model_connectors/load_connectors/time_series_mft_ets_coupling.py
+++ b/geojson_modelica_translator/model_connectors/load_connectors/time_series_mft_ets_coupling.py
@@ -1,0 +1,195 @@
+"""
+****************************************************************************************************
+:copyright (c) 2019-2020 URBANopt, Alliance for Sustainable Energy, LLC, and other contributors.
+All rights reserved.
+Redistribution and use in source and binary forms, with or without modification, are permitted
+provided that the following conditions are met:
+Redistributions of source code must retain the above copyright notice, this list of conditions
+and the following disclaimer.
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions
+and the following disclaimer in the documentation and/or other materials provided with the
+distribution.
+Neither the name of the copyright holder nor the names of its contributors may be used to endorse
+or promote products derived from this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+****************************************************************************************************
+"""
+
+import os
+import shutil
+from pathlib import Path
+
+from geojson_modelica_translator.model_connectors.load_connectors.load_base import (
+    LoadBase
+)
+from geojson_modelica_translator.modelica.input_parser import PackageParser
+from geojson_modelica_translator.utils import ModelicaPath
+
+
+class TimeSeriesConnectorMFTETS(LoadBase):
+    def __init__(self, system_parameters):
+        super().__init__(system_parameters)
+
+        # Note that the order of the required MO files is important as it will be the order that
+        # the "package.order" will be in.
+        self.required_mo_files.append(os.path.join(self.template_dir, 'getPeakMassFlowRate.mo'))
+
+    def to_modelica(self, scaffold):
+        """
+        Create TimeSeries models based on the data in the buildings and geojsons
+        :param scaffold: Scaffold object, Scaffold of the entire directory of the project.
+        """
+
+        # MassFlowrate Temperature models
+        cooling_indirect_template = self.template_env.get_template("CoolingIndirect.mot")
+        heating_indirect_template = self.template_env.get_template("HeatingIndirect.mot")
+        time_series_mft_template = self.template_env.get_template("TimeSeriesMassFlowTemperatures.mot")
+        time_series_ets_mft_mos_template = self.template_env.get_template("RunTimeSeries_MassFlow_Temperature.most")
+        time_series_mft_central_plant = self.template_env.get_template(
+            "TimeSeriesMassFlowTemperaturesCentralPlants.mot")
+
+        building_names = []
+        for building in self.buildings:
+            building_names.append(f"B{building['building_id']}")
+            b_modelica_path = ModelicaPath(
+                f"B{building['building_id']}", scaffold.loads_path.files_dir, True
+            )
+
+            # grab the data from the system_parameter file for this building id
+            # TODO: create method in system_parameter class to make this easier and respect the defaults
+            time_series_filename = self.system_parameters.get_param_by_building_id(
+                building["building_id"], "load_model_parameters.time_series.filepath"
+            )
+
+            template_data = {
+                "load_resources_path": b_modelica_path.resources_relative_dir,
+                "time_series": {
+                    "filepath": time_series_filename,
+                    "filename": os.path.basename(time_series_filename),
+                    "path": os.path.dirname(time_series_filename),
+                },
+                "nominal_values": {
+                    "delTDisCoo": self.system_parameters.get_param_by_building_id(
+                        building["building_id"], "load_model_parameters.time_series.delTDisCoo"
+                    )
+                }
+            }
+
+            if os.path.exists(template_data["time_series"]["filepath"]):
+                new_file = os.path.join(b_modelica_path.resources_dir, template_data["time_series"]["filename"])
+                os.makedirs(os.path.dirname(new_file), exist_ok=True)
+                shutil.copy(template_data["time_series"]["filepath"], new_file)
+            else:
+                raise Exception(f"Missing MOS file for time series: {template_data['time_series']['filepath']}")
+
+            # Run templates to write actual Modelica models
+            ets_model_type = self.system_parameters.get_param_by_building_id(building["building_id"], "ets_model")
+
+            ets_data = None
+            if ets_model_type == "Indirect Heating and Cooling":
+                ets_data = self.system_parameters.get_param_by_building_id(
+                    building["building_id"],
+                    "ets_model_parameters.indirect"
+                )
+            else:
+                raise Exception("Only ETS Model of type 'Indirect Heating and Cooling' type enabled currently")
+
+            self.run_template(
+                template=cooling_indirect_template,
+                save_file_name=Path(b_modelica_path.files_dir) / "CoolingIndirect.mo",
+                project_name=scaffold.project_name,
+                model_name=f"B{building['building_id']}",
+                data=template_data,
+                ets_data=ets_data,
+            )
+
+            self.run_template(
+                template=heating_indirect_template,
+                save_file_name=Path(b_modelica_path.files_dir) / "HeatingIndirect.mo",
+                project_name=scaffold.project_name,
+                model_name=f"B{building['building_id']}",
+                data=template_data,
+                ets_data=ets_data,
+            )
+
+            self.run_template(
+                template=time_series_mft_template,
+                save_file_name=Path(b_modelica_path.files_dir) / "TimeSeriesMassFlowTemperatures.mo",
+                project_name=scaffold.project_name,
+                model_name=f"B{building['building_id']}",
+                data=template_data,
+                ets_data=ets_data,
+            )
+
+            self.run_template(
+                template=time_series_ets_mft_mos_template,
+                save_file_name=Path(b_modelica_path.files_dir) / "RunTimeSeries_MassFlow_Temperature.mos",
+                do_not_add_to_list=True,
+                project_name=scaffold.project_name,
+                model_name=f"B{building['building_id']}",
+                data=template_data,
+                ets_data=ets_data,
+            )
+
+            self.run_template(
+                template=time_series_mft_central_plant,
+                save_file_name=os.path.join(
+                    b_modelica_path.files_dir,
+                    "TimeSeriesMassFlowTemperaturesCentralPlants.mo"),
+                project_name=scaffold.project_name,
+                model_name=f"B{building['building_id']}",
+                data=template_data,
+                ets_data=ets_data,
+            )
+
+            self.copy_required_mo_files(b_modelica_path.files_dir, within=f'{scaffold.project_name}.Loads')
+
+        # Run post process to create the remaining project files for this building
+        self.post_process(scaffold, building_names)
+
+    def post_process(self, scaffold, building_names):
+        """
+        Cleanup the export of TimeSeries files into a format suitable for the district-based analysis. This includes
+        the following:
+            * Add a Loads project
+            * Add a project level project
+        :param scaffold: Scaffold object, Scaffold of the entire directory of the project.
+        :param building_names: list, names of the buildings that need to be cleaned up after export
+        :return: None
+        """
+        for b in building_names:
+            order_files = [Path(mo).stem for mo in self.required_mo_files]
+            order_files += self.template_files_to_include
+            b_modelica_path = Path(scaffold.loads_path.files_dir) / b
+            new_package = PackageParser.new_from_template(
+                path=b_modelica_path,
+                name=b,
+                order=order_files,
+                within=f"{scaffold.project_name}"
+            )
+            new_package.save()
+
+        # now create the Loads level package. This (for now) will create the package without considering any existing
+        # files in the Loads directory.
+
+        package = PackageParser.new_from_template(
+            path=scaffold.loads_path.files_dir,
+            name="Loads",
+            order=building_names,
+            within=f"{scaffold.project_name}"
+        )
+        package.save()
+
+        # now create the Package level package. This really needs to happen at the GeoJSON to modelica stage, but
+        # do it here for now to aid in testing.
+        pp = PackageParser.new_from_template(
+            scaffold.project_path, scaffold.project_name, ["Loads"]
+        )
+        pp.save()

--- a/tests/model_connectors/data/ts_mft_ets_example_data.mos
+++ b/tests/model_connectors/data/ts_mft_ets_example_data.mos
@@ -2,7 +2,7 @@
 #Nominal heating water mass flow rate=67.82
 #Nominal chilled water mass flow rate=52.15
 #time,NODE 62:System Node Temperature[C],NODE 67:System Node Temperature[C],NODE 70:System Node Temperature[C],NODE 98:System Node Temperature[C],massFlowRateHeating,massFlowRateCooling
-double modelica(35041,7)
+double modelica(35040,7)
 0,55,55,6.7,6.7,0,0
 900,55,55,6.7,6.7,0,0
 1800,55,55,6.7,6.7,0,0

--- a/tests/model_connectors/test_time_series_mft_ets.py
+++ b/tests/model_connectors/test_time_series_mft_ets.py
@@ -1,0 +1,83 @@
+"""
+****************************************************************************************************
+:copyright (c) 2019-2020 URBANopt, Alliance for Sustainable Energy, LLC, and other contributors.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted
+provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions
+and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions
+and the following disclaimer in the documentation and/or other materials provided with the
+distribution.
+
+Neither the name of the copyright holder nor the names of its contributors may be used to endorse
+or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+****************************************************************************************************
+"""
+
+import os
+
+from geojson_modelica_translator.geojson_modelica_translator import (
+    GeoJsonModelicaTranslator
+)
+from geojson_modelica_translator.model_connectors.load_connectors.time_series_mft_ets_coupling import (
+    TimeSeriesConnectorMFTETS
+)
+from geojson_modelica_translator.system_parameters.system_parameters import (
+    SystemParameters
+)
+
+from ..base_test_case import TestCaseBase
+
+
+class TimeSeriesModelConnectorSingleBuildingMFTETSTest(TestCaseBase):
+    def setUp(self):
+        project_name = "time_series_massflow"
+        self.data_dir, self.output_dir = self.set_up(os.path.dirname(__file__), project_name)
+
+        # load in the example geojson with a single office building
+        filename = os.path.join(self.data_dir, "time_series_ex1.json")
+        self.gj = GeoJsonModelicaTranslator.from_geojson(filename)
+        # use the GeoJson translator to scaffold out the directory
+        self.gj.scaffold_directory(self.output_dir, project_name)
+
+        # load system parameter data
+        filename = os.path.join(self.data_dir, "time_series_system_params_massflow_ex1.json")
+        sys_params = SystemParameters(filename)
+
+        # now test the spawn connector (independent of the larger geojson translator
+        self.time_series = TimeSeriesConnectorMFTETS(sys_params)
+        for b in self.gj.json_loads:
+            self.time_series.add_building(b)
+
+    def test_mft_time_series_to_modelica_and_run(self):
+        self.time_series.to_modelica(self.gj.scaffold)
+
+        root_path = os.path.abspath(os.path.join(self.gj.scaffold.loads_path.files_dir, 'B5a6b99ec37f4de7f94020090'))
+        files = [
+            os.path.join(root_path, 'CoolingIndirect.mo'),
+            os.path.join(root_path, 'HeatingIndirect.mo'),
+            os.path.join(root_path, 'TimeSeriesMassFlowTemperatures.mo'),
+            os.path.join(root_path, 'TimeSeriesMassFlowTemperaturesCentralPlants.mo'),
+        ]
+
+        # verify that there are only 2 files that matter (coupling and building)
+        for file in files:
+            self.assertTrue(os.path.exists(file), f"File does not exist: {file}")
+
+        self.run_and_assert_in_docker(os.path.join(root_path, 'TimeSeriesMassFlowTemperatures.mo'),
+                                      project_path=self.gj.scaffold.project_path,
+                                      project_name=self.gj.scaffold.project_name)

--- a/tests/model_connectors/test_time_series_mft_ets.py
+++ b/tests/model_connectors/test_time_series_mft_ets.py
@@ -62,7 +62,7 @@ from ..base_test_case import TestCaseBase
 
 class TimeSeriesModelConnectorSingleBuildingMFTETSTest(TestCaseBase):
     def test_mft_time_series_to_modelica_and_run(self):
-        project_name = "time_series_massflow_tmp"
+        project_name = "time_series_massflow"
         self.data_dir, self.output_dir = self.set_up(os.path.dirname(__file__), project_name)
 
         # load in the example geojson with a single office building


### PR DESCRIPTION
#### Any background context you want to provide?
Before the "flexibility" refactoring of the GMT, we had the TimeSeriesMassFlowTemperatures.mot and [time_series_mft_ets_coupling.py](https://github.com/urbanopt/geojson-modelica-translator/blob/old-design/geojson_modelica_translator/model_connectors/load_connectors/time_series_mft_ets_coupling.py). When refactoring these files were removed and not added back.

#### What does this PR accomplish?
Creates a new load, TimeSeriesMFT, and its couplings to heating and cooling ETSes. Also adds a test which uses a .mos file for the MFT data with stubbed network sources (ie infinite heating and cooling sources into ETSes). The graphical representation of this model at the district level is slightly broken. We have connections between the load's `buiMasTem` and TChi and THea set for the ETSes, but no `RealOutput`s for them.

#### How should this be manually tested?
#### What are the relevant tickets?
Resolves #287 
#### Screenshots (if appropriate)
Generated District System:
<img width="499" alt="Screen Shot 2021-02-02 at 10 31 03 AM" src="https://user-images.githubusercontent.com/18518728/106639148-e689c400-6541-11eb-92b3-c15b5aa510db.png">



Generated load:
<img width="615" alt="Screen Shot 2021-02-02 at 10 19 34 AM" src="https://user-images.githubusercontent.com/18518728/106637631-310a4100-6540-11eb-956e-abffca252659.png">
