### PR TITLE
Addressing Michael Wetter's suggestion for TAir

### DIFF
--- a/geojson_modelica_translator/model_connectors/load_connectors/teaser.py
+++ b/geojson_modelica_translator/model_connectors/load_connectors/teaser.py
@@ -518,10 +518,7 @@ class Teaser(LoadBase):
         # now create the Loads level package and package.order.
         if not os.path.exists(os.path.join(scaffold.loads_path.files_dir, 'package.mo')):
             load_package = PackageParser.new_from_template(
-                scaffold.loads_path.files_dir,
-                "Loads",
-                ["B" + b for b in building_names],
-                within=f"{scaffold.project_name}"
+                scaffold.loads_path.files_dir, "Loads", ["B" + b for b in building_names], within=f"{scaffold.project_name}"
             )
             load_package.save()
         else:

--- a/geojson_modelica_translator/model_connectors/load_connectors/teaser.py
+++ b/geojson_modelica_translator/model_connectors/load_connectors/teaser.py
@@ -312,17 +312,6 @@ class Teaser(LoadBase):
                     annotations=['Placement(transformation(extent={{-80,-60},{-60,-40}}))']
                 )
 
-                # add TAir output
-                mofile.insert_component(
-                    'Buildings.Controls.OBC.CDL.Interfaces.RealOutput', 'TAir',
-                    modifications={
-                        'quantity': '"ThermodynamicTemperature"',
-                        'unit': '"K"',
-                        'displayUnit': '"degC"',
-                    },
-                    string_comment='Room air temperature',
-                    annotations=['Placement(transformation(extent={{100,38},{120,58}}))']
-                )
                 # add TRad output
                 mofile.insert_component(
                     'Buildings.Controls.OBC.CDL.Interfaces.RealOutput', 'TRad',
@@ -361,6 +350,19 @@ class Teaser(LoadBase):
                     thermal_zone_name = 'thermalZoneFourElements'
 
                 if thermal_zone_name is not None and thermal_zone_type is not None:
+                    # add TAir output
+                    # This has been moved away from the other insert_component blocks to use thermal_zone_name
+                    mofile.insert_component(
+                        'Buildings.Controls.OBC.CDL.Interfaces.RealOutput', 'TAir',
+                        modifications={
+                            'quantity': '"ThermodynamicTemperature"',
+                            'unit': '"K"',
+                            'displayUnit': '"degC"',
+                        },
+                        conditional=f'if {thermal_zone_name}.ATot > 0 or {thermal_zone_name}.VAir > 0',
+                        string_comment='Room air temperature',
+                        annotations=['Placement(transformation(extent={{100,38},{120,58}}))']
+                    )
                     mofile.update_component_modifications(
                         f"Buildings.ThermalZones.ReducedOrder.RC.{thermal_zone_type}",
                         thermal_zone_name,
@@ -516,7 +518,10 @@ class Teaser(LoadBase):
         # now create the Loads level package and package.order.
         if not os.path.exists(os.path.join(scaffold.loads_path.files_dir, 'package.mo')):
             load_package = PackageParser.new_from_template(
-                scaffold.loads_path.files_dir, "Loads", ["B" + b for b in building_names], within=f"{scaffold.project_name}"
+                scaffold.loads_path.files_dir,
+                "Loads",
+                ["B" + b for b in building_names],
+                within=f"{scaffold.project_name}"
             )
             load_package.save()
         else:

--- a/geojson_modelica_translator/model_connectors/model_base.py
+++ b/geojson_modelica_translator/model_connectors/model_base.py
@@ -90,20 +90,19 @@ class ModelBase(object):
                 number_stories = urbanopt_building.feature.properties["number_of_stories"]
                 building_floor_area_m2 = self.ft2_to_m2(urbanopt_building.feature.properties["floor_area"])
             except KeyError as ke:
-                raise SystemExit(f'Missing property {ke} in geojson feature file')
+                raise SystemExit(f'\nMissing property {ke} in geojson feature file')
 
             try:
                 number_stories_above_ground = urbanopt_building.feature.properties["number_of_stories_above_ground"]
             except KeyError:
                 number_stories_above_ground = number_stories
-                print("Assuming all building levels are above ground for building_id: {building_id}")
+                print(f"\nAssuming all building levels are above ground for building_id: {building_id}")
 
             try:
                 floor_height = urbanopt_building.feature.properties["floor_height"]
             except KeyError:
                 floor_height = 3  # Default height in meters from sdk
-                print(
-                    "No floor_height found in geojson feature file for building {building_id}. Using default value of {floor_height}")
+                print(f"\nNo floor_height found in geojson feature file for building {building_id}. Using default value of {floor_height}")
 
             # UO SDK defaults to current year, however TEASER only supports up to Year 2015
             # https://github.com/urbanopt/TEASER/blob/master/teaser/data/input/inputdata/TypeBuildingElements.json#L818
@@ -113,8 +112,7 @@ class ModelBase(object):
                     year_built = 2015
             except KeyError:
                 year_built = 2015
-                print(
-                    "No year_built found in geojson feature file for building {building_id}. Using default value of {year_built}")
+                print(f"No 'year_built' found in geojson feature file for building {building_id}. Using default value of {year_built}")
 
             self.buildings.append(
                 {


### PR DESCRIPTION
#### Any background context you want to provide?
This is a response to Michael Wetter's suggestion for improving the teaser modelica file
#### What does this PR accomplish?
- Adds a conditional statement when adding `TAir` so it has the same instantiation rules as the upstream connector (otherwise if a user sets VAir and ATot to 0, the model is singular).
- Moves adding the TAir component a little lower in the code, to use the `thermal_zone_name` variable.
- Fixes a typo I left in model_base.py, unrelated to the rest of this PR.
#### How should this be manually tested?
`py.test tests/model_connectors/test_teaser.py`
- Confirm that tests/model_connectors/output/teaser_single/Loads/B5.../Floor.mo (or any of the *.mo files in there) contains an `if` statement on line 189
- And that the test passes, of course.
#### What are the relevant tickets?
Resolves #300 