### PR TITLE
Alert user that Modelica doesn't support spaces in project name

### DIFF
--- a/geojson_modelica_translator/model_connectors/districts/district.py
+++ b/geojson_modelica_translator/model_connectors/districts/district.py
@@ -72,6 +72,12 @@ class District:
         self.system_parameters = system_parameters
         self._coupling_graph = coupling_graph
         self.district_model_filepath = None
+        # Modelica can't handle spaces in project name or path
+        if (len(str(root_dir).split()) > 1) or (len(str(project_name).split()) > 1):
+            raise SystemExit(
+                f"\nModelica does not support spaces in project names or paths. "
+                f"You used '{root_dir}' for run path and {project_name} for model project name. "
+                "Please update your directory path or model name to not include spaces anywhere.")
 
     def to_modelica(self):
         """Generate modelica files for the models as well as the modelica file for

--- a/geojson_modelica_translator/model_connectors/load_connectors/load_base.py
+++ b/geojson_modelica_translator/model_connectors/load_connectors/load_base.py
@@ -176,7 +176,7 @@ class LoadBase(ModelBase):
                         except KeyError:
                             floor_height = 3  # Default height in meters from sdk
                             print(
-                                f"\nNo floor_height found in geojson feature file for building {self.building_id}. "
+                                f"No floor_height found in geojson feature file for building {self.building_id}. "
                                 f"Using default value of {floor_height}.")
 
                         # UO SDK defaults to current year, however TEASER only supports up to Year 2015

--- a/geojson_modelica_translator/modelica/modelica_runner.py
+++ b/geojson_modelica_translator/modelica/modelica_runner.py
@@ -88,13 +88,13 @@ class ModelicaRunner(object):
         :return: tuple(bool, str), success status and path to the results directory
         """
         if not self.docker_configured:
-            raise Exception('Docker not configured on host computer, unable to run')
+            raise SystemExit('Docker not configured on host computer, unable to run')
 
         if not os.path.exists(file_to_run):
-            raise Exception(f'File not found to run {file_to_run}')
+            raise SystemExit(f'File not found to run {file_to_run}')
 
         if not os.path.isfile(file_to_run):
-            raise Exception(f'Expecting to run a file, not a folder in {file_to_run}')
+            raise SystemExit(f'Expecting to run a file, not a folder in {file_to_run}')
 
         if not run_path:
             # if there is no run_path, then run it in the same directory as the file being run. This works fine for
@@ -102,6 +102,13 @@ class ModelicaRunner(object):
             # to include other project dependencies (e.g., multiple mo files).
             run_path = os.path.dirname(file_to_run)
         run_path = Path(run_path)
+
+        # Modelica can't handle spaces in project name or path
+        if (len(str(run_path).split()) > 1) or (len(str(file_to_run).split()) > 1):
+            raise SystemExit(
+                f"\nModelica does not support spaces in project names or paths. "
+                f"You used '{run_path}' for run path and {file_to_run} for model project name. "
+                "Please update your directory path or model name to not include spaces anywhere.")
 
         if not project_name:
             project_name = os.path.splitext(os.path.basename(file_to_run))[0]

--- a/management/uo_des.py
+++ b/management/uo_des.py
@@ -166,7 +166,8 @@ def create_model(sys_param_file, geojson_feature_file, project_path, overwrite):
             raise SystemExit(f"Output dir '{project_path}' already exists and overwrite flag is not given")
     if len(project_path.name.split()) > 1:  # Modelica can't handle spaces in project name
         raise SystemExit(
-            f"\n'{project_path}' failed. Modelica does not support spaces in project names. Please choose a different 'project_path'")
+            f"\n'{project_path}' failed. Modelica does not support spaces in project names or paths. "
+            "Please choose a different 'project_path'")
 
     gmt = GeoJsonModelicaTranslator(
         geojson_feature_file,
@@ -202,6 +203,11 @@ def run_model(modelica_project):
     run_path = Path(modelica_project).resolve()
     project_name = run_path.stem
     file_to_run = run_path / 'Districts' / 'DistrictEnergySystem.mo'
+
+    if len(str(run_path).split()) > 1:  # Modelica can't handle spaces in project name or path
+        raise SystemExit(
+            f"\n'{run_path}' failed. Modelica does not support spaces in project names or paths. "
+            "Please update your directory tree to not include spaces in any name")
 
     # setup modelica runner
     mr = ModelicaRunner()

--- a/management/uo_des.py
+++ b/management/uo_des.py
@@ -81,7 +81,7 @@ def cli():
     help="Delete and replace any existing file of the same name & location",
     default=False
 )
-def build_sys_param(model_type, sys_param_filename, scenario_file, feature_file, overwrite):
+def build_sys_param(model_type: str, sys_param_filename: Path, scenario_file: Path, feature_file: Path, overwrite: bool):
     """
     Create system parameters file using uo_sdk output
 
@@ -142,7 +142,7 @@ def build_sys_param(model_type, sys_param_filename, scenario_file, feature_file,
     help="Delete and replace any existing folder of the same name & location",
     default=False
 )
-def create_model(sys_param_file, geojson_feature_file, project_path, overwrite):
+def create_model(sys_param_file: Path, geojson_feature_file: Path, project_path: Path, overwrite: bool):
     """Build Modelica model from user data
 
     SYS_PARAM_FILE: Path/name to sys-param file, possibly created with this CLI.
@@ -186,7 +186,7 @@ def create_model(sys_param_file, geojson_feature_file, project_path, overwrite):
     required=True,
     type=click.Path(exists=True, file_okay=False, dir_okay=True),
 )
-def run_model(modelica_project):
+def run_model(modelica_project: Path):
     """
     \b
     Run the Modelica project in a docker-based environment.

--- a/management/uo_des.py
+++ b/management/uo_des.py
@@ -118,7 +118,7 @@ def build_sys_param(model_type, sys_param_filename, scenario_file, feature_file,
     if Path(sys_param_filename).exists():
         print(f"\nSystem parameters file {sys_param_filename} successfully created.")
     else:
-        raise Exception(f"{sys_param_filename} failed. Please check your inputs and try again.")
+        raise SystemExit(f"{sys_param_filename} failed. Please check your inputs and try again.")
 
 
 @cli.command(short_help="Create Modelica model")
@@ -163,7 +163,10 @@ def create_model(sys_param_file, geojson_feature_file, project_path, overwrite):
         if overwrite:
             rmtree(project_path, ignore_errors=True)
         else:
-            raise Exception(f"Output dir '{project_path}' already exists and overwrite flag is not given")
+            raise SystemExit(f"Output dir '{project_path}' already exists and overwrite flag is not given")
+    if len(project_path.name.split()) > 1:  # Modelica can't handle spaces in project name
+        raise SystemExit(
+            f"\n'{project_path}' failed. Modelica does not support spaces in project names. Please choose a different 'project_path'")
 
     gmt = GeoJsonModelicaTranslator(
         geojson_feature_file,
@@ -207,4 +210,4 @@ def run_model(modelica_project):
     if (run_path.parent / f'{project_name}_results' / f'{project_name}_Districts_DistrictEnergySystem_result.mat').exists():
         print(f"\nModelica model {project_name} ran successfully")
     else:
-        raise Exception(f"{project_name} failed. Please check your inputs and try again.")
+        raise SystemExit(f"{project_name} failed. Please check your inputs and try again.")

--- a/tests/management/test_uo_des.py
+++ b/tests/management/test_uo_des.py
@@ -117,6 +117,23 @@ class CLIIntegrationTest(TestCase):
         # If this file exists, the cli command ran successfully
         assert (self.output_dir / 'modelica_project' / 'Districts' / 'DistrictEnergySystem.mo').exists()
 
+    def test_cli_returns_graceful_error_on_space(self):
+        bad_project_name = 'modelica project'
+        # (self.output_dir / bad_project_name).mkdir(exist_ok=True)
+
+        expected_failure = self.runner.invoke(
+            cli,
+            [
+                'create-model',
+                str(self.output_dir / 'test_sys_param.json'),
+                str(self.feature_file_path),
+                str(self.output_dir / bad_project_name)
+            ]
+        )
+
+        assert expected_failure.exit_code != 0
+        self.assertIn("Modelica does not support spaces in project names.", str(expected_failure.exception))
+
     @pytest.mark.simulation
     def test_cli_runs_model(self):
         if (self.output_dir / 'modelica_project_results').exists():

--- a/tests/management/test_uo_des.py
+++ b/tests/management/test_uo_des.py
@@ -132,7 +132,7 @@ class CLIIntegrationTest(TestCase):
         )
 
         assert expected_failure.exit_code != 0
-        self.assertIn("Modelica does not support spaces in project names.", str(expected_failure.exception))
+        self.assertIn("Modelica does not support spaces in project names or paths.", str(expected_failure.exception))
 
     @pytest.mark.simulation
     def test_cli_runs_model(self):

--- a/tests/modelica/test_modelica_runner.py
+++ b/tests/modelica/test_modelica_runner.py
@@ -81,12 +81,12 @@ class ModelicaRunnerTest(unittest.TestCase):
     def test_run_in_docker_errors(self):
         mr = ModelicaRunner()
         file_to_run = os.path.join(self.run_path, 'no_file.mo')
-        with self.assertRaises(Exception) as exc:
+        with self.assertRaises(SystemExit) as exc:
             mr.run_in_docker(file_to_run)
         self.assertEqual(f'File not found to run {file_to_run}', str(exc.exception))
 
         file_to_run = os.path.join(self.run_path)
-        with self.assertRaises(Exception) as exc:
+        with self.assertRaises(SystemExit) as exc:
             mr.run_in_docker(file_to_run)
         self.assertEqual(f'Expecting to run a file, not a folder in {file_to_run}', str(exc.exception))
 


### PR DESCRIPTION
#### Any background context you want to provide?
If a user has a space in their project name or directory tree, Modelica chokes and dies.
#### What does this PR accomplish?
Adds graceful error message to user requiring them to remove spaces from name and path.
#### How should this be manually tested?
Project name gets tested for a space in automated testing now. `poetry run py.test tests/management/test_uo_des.py`
To test the tree, change something in your dir tree to include a space and try running `uo_des run-model`
#### What are the relevant tickets?
Resolves #375 