### PR TITLE
Feat/level 1 cooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
         name: Coveralls
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.test_env == 'python' }}
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.test_env == 'python' && matrix.mbl_branch == 'issue2204_gmt_mbl' }}
         run: |
           poetry run coveralls
       -

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
               MARKERS="${MARKERS} -m 'not simulation'"
             fi
             if [ '${{ matrix.mbl_branch }}' == 'v8.0.0' ]; then
-              MARKERS="${MARKERS} -m 'mbl_v8'"
+              MARKERS="${MARKERS} -m mbl_v8"
             else
               MARKERS="${MARKERS} -m 'not mbl_v8'"
             fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ defaults:
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
         # 3.9 does not work as of 2020-02-01

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,22 +84,19 @@ jobs:
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         run: |
-          POSARGS=""
           if [ '${{ matrix.test_env }}' == 'python' ]; then
-            MARKERS=""
+            # !! Ugh, this is ugly but necessary (poetry + tox were not passing our args correctly to pytest)
             if [ '${{ matrix.os }}' == 'windows-latest' ]; then
               # for windows, skip python tests that require simulation (currently broken)
-              MARKERS="${MARKERS} -m 'not simulation'"
-            fi
-            if [ '${{ matrix.mbl_branch }}' == 'v8.0.0' ]; then
-              MARKERS="${MARKERS} -m mbl_v8"
+              poetry run tox -e ${{ matrix.test_env }} -- -m 'not simulation' ./tests
+            elif [ '${{ matrix.mbl_branch }}' == 'v8.0.0' ]; then
+              poetry run tox -e ${{ matrix.test_env }} -- -m mbl_v8 ./tests
             else
-              MARKERS="${MARKERS} -m 'not mbl_v8'"
+              poetry run tox -e ${{ matrix.test_env }} -- -m 'not mbl_v8' ./tests
             fi
-            POSARGS="-- ${MARKERS}"
+          else
+            poetry run tox -e ${{ matrix.test_env }}
           fi
-
-          poetry run tox -e ${{ matrix.test_env }} ${POSARGS}
       -
         name: Coveralls
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           - os: ubuntu-latest
             python-version: 3.7
             test_env: python
-            mbl_branch: v8.0.0
+            mbl_branch: v8.1.0
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -89,7 +89,7 @@ jobs:
             if [ '${{ matrix.os }}' == 'windows-latest' ]; then
               # for windows, skip python tests that require simulation (currently broken)
               poetry run tox -e ${{ matrix.test_env }} -- -m 'not simulation' ./tests
-            elif [ '${{ matrix.mbl_branch }}' == 'v8.0.0' ]; then
+            elif [ '${{ matrix.mbl_branch }}' == 'v8.1.0' ]; then
               poetry run tox -e ${{ matrix.test_env }} -- -m mbl_v8 ./tests
             else
               poetry run tox -e ${{ matrix.test_env }} -- -m 'not mbl_v8' ./tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,12 @@ jobs:
         # 3.9 does not work as of 2020-02-01
         python-version: [3.7]
         test_env: [python, precommit, docs]
+        mbl_branch: [issue2204_gmt_mbl]
+        include:
+          - os: ubuntu-latest
+            python-version: 3.7
+            test_env: python
+            mbl_branch: v8.0.0
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -59,6 +65,7 @@ jobs:
         name: Install MBL
         env:
           MATRIX_OS: ${{ matrix.os }}
+          MBL_BRANCH: ${{ matrix.mbl_branch }}
         run: |
           if [[ "${MATRIX_OS}" == 'ubuntu-latest' ]]; then
             MODELICAPATH='/home/runner/work/modelica-buildings'
@@ -66,7 +73,7 @@ jobs:
             echo $GITHUB_WORKSPACE
             MODELICAPATH='/c/Program Files/modelica-buildings'
           fi
-          git clone --single-branch --branch issue2204_gmt_mbl https://github.com/lbl-srg/modelica-buildings.git "${MODELICAPATH}"
+          git clone --single-branch --branch ${MBL_BRANCH} https://github.com/lbl-srg/modelica-buildings.git "${MODELICAPATH}"
           cd "${MODELICAPATH}"
           echo "Git branch is $(git branch)"
           # export MODELICAPATH for subsequent steps
@@ -77,10 +84,20 @@ jobs:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         run: |
           POSARGS=""
-          if [ '${{ matrix.test_env }}' == 'python' ] && [ '${{ matrix.os }}' == 'windows-latest' ]; then
-            # for windows, skip python tests that require simulation (currently broken)
-            POSARGS="-- -m 'not simulation' ./tests"
+          if [ '${{ matrix.test_env }}' == 'python' ]; then
+            MARKERS=""
+            if [ '${{ matrix.os }}' == 'windows-latest' ]; then
+              # for windows, skip python tests that require simulation (currently broken)
+              MARKERS="${MARKERS} -m 'not simulation'"
+            fi
+            if [ '${{ matrix.mbl_branch }}' == 'v8.0.0' ]; then
+              MARKERS="${MARKERS} -m 'mbl_v8'"
+            else
+              MARKERS="${MARKERS} -m 'not mbl_v8'"
+            fi
+            POSARGS="-- ${MARKERS}"
           fi
+
           poetry run tox -e ${{ matrix.test_env }} ${POSARGS}
       -
         name: Coveralls

--- a/docs/developer_resources.rst
+++ b/docs/developer_resources.rst
@@ -9,6 +9,28 @@
 Developer Resources
 ===================
 
+Tests
+-----
+
+Tests are run with pytest, e.g.
+
+.. code-block:: bash
+
+    poetry run pytest
+
+
+Snapshot Testing
+****************
+
+Some tests use `syrupy <https://github.com/tophat/syrupy>`_ to compare generated modelica models to saved "snapshots" of the models (saved as .ambr files).
+
+Snapshots should only be updated if we have changed how a model is generated, and we *know* the new version of the model is the correct version. To update all snapshots, you can run the following and commit the new snapshot files.
+
+.. code-block:: bash
+
+    poetry run pytest --snapshot-update
+
+
 Design Overview
 ---------------
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -67,6 +67,10 @@ Once the MBL is installed, then the CLI can be used to create the model with the
 The resulting Modelica package will be created and can be opened in a Modelica editor. Open the :code:`package.mo` file in the root directory of the generated package. You will also need to
 load the MBL into your Modelica editor.
 
+
+NOTE: The developers of the GMT are currently working on updating the MBL version used. If you are also a developer and need to run the unit tests in this repo, you can instruct pytest to ignore the v8 tests with :code:`poetry run pytest -m 'not mbl_v8'`, which assumes you have the MBL version documented above. To run the MBL v8 tests, you need to checkout :code:`v8.1.0` and run :code:`poetry run pytest -m mbl_v8`.
+
+
 Docker Installation
 -------------------
 

--- a/geojson_modelica_translator/modelica/GMT_Lib/DHC/Components/CentralPlant/Cooling/CoolingPlant.mo
+++ b/geojson_modelica_translator/modelica/GMT_Lib/DHC/Components/CentralPlant/Cooling/CoolingPlant.mo
@@ -1,0 +1,39 @@
+within GMT_Lib.DHC.Components.CentralPlant.Cooling;
+model CoolingPlant
+  "This example is to validate template Central Cooling Plant component model."
+    extends Buildings.Experimental.DHC.CentralPlants.Cooling.Examples.Plant(
+    redeclare Buildings.Fluid.Chillers.Data.ElectricEIR.ElectricEIRChiller_York_YT_1055kW_5_96COP_Vanes perChi(
+      mEva_flow_nominal=mCHW_flow_nominal,
+      mCon_flow_nominal=mCW_flow_nominal,
+      QEva_flow_nominal=QChi_nominal),
+    redeclare Buildings.Experimental.DHC.CentralPlants.Cooling.Plant pla,
+    dTApp=3,
+    mCHW_flow_nominal=18.3,
+    dpCHW_nominal=44.8*1000,
+    mMin_flow=0.03,
+    mCW_flow_nominal=34.7,
+    dpCW_nominal=46.2*1000,
+    PFan_nominal=4999,
+    TCHWSet=273.15 + 7,
+    dpCooTowVal_nominal=5999,
+    dpCHWPumVal_nominal=5999,
+    dpCWPumVal_nominal=5999);
+  annotation (
+    Icon(coordinateSystem(preserveAspectRatio=false)),
+    Diagram(coordinateSystem(preserveAspectRatio=false)),
+    experiment(StopTime=86400, Tolerance=1e-06),
+    Documentation(info="<html>
+      <p>This model validates the district central cooling plant template model
+GMT_Lib.DHC.Components.CentralPlants.Cooling.Cooling.mot</a>.
+</p>
+</html>", revisions="<html>
+<ul>
+<li>
+October 20, 2021 by Chengnan Shi:<br/>
+First implementation.
+</li>
+</ul>
+</html>"),
+    __Dymola_Commands(file="CoolingPlant.mos"
+                                             "Simulate and Plot"));
+end CoolingPlant;

--- a/geojson_modelica_translator/modelica/GMT_Lib/DHC/Components/CentralPlant/Cooling/CoolingPlant.mos
+++ b/geojson_modelica_translator/modelica/GMT_Lib/DHC/Components/CentralPlant/Cooling/CoolingPlant.mos
@@ -1,0 +1,69 @@
+// Simulate
+simulateModel("GMT_Lib.DHC.Components.CentralPlant.Cooling.CoolingPlant",
+    stopTime=86400,
+    method="cvode",
+    tolerance=1e-06,
+    resultFile="CoolingPlant");
+// Plot commands
+removePlots(false);
+createPlot(
+    id=1,
+    position={24, 10, 831, 511},
+    y={"pla.PCoo", "loaVar.y"},
+    range={0.0, 90000.0, -4000000.0, 3000000.0},
+    grid=true,
+    filename="Plant.mat",
+    leftTitleType=2,
+    leftTitle="[W]",
+    colors={{28,108,200}, {238,46,47}},
+    timeUnit="h",
+    displayUnits={"W", "W"});
+createPlot(
+    id=1,
+    position={24, 10, 831, 511},
+    y={"pla.chiStaCon.plr.y"},
+    range={0.0, 90000.0, 0, 2},
+    grid=true,
+	subPlot=2,
+    leftTitle="[1]",
+    colors={{28,108,200}},
+    timeUnit="h",
+    displayUnits={"1"});
+createPlot(
+    id=1,
+    position={24, 10, 831, 511},
+    y={"pla.chiStaCon.y[1]", "pla.chiStaCon.y[2]"},
+    range={0.0, 90000.0, -1.0, 2.0},
+    grid=true,
+    subPlot=3,
+    colors={{28,108,200}, {28,108,200}},
+    timeUnit="h");
+createPlot(
+    id=2,
+    position={55, 26, 833, 515},
+    y={"pla.senMasFlo.m_flow", "pla.splCHWSup.port_1.m_flow", "pla.splCHWSup.port_2.m_flow", "pla.splCHWSup.port_3.m_flow"},
+    range={0.0, 90000.0, -60.0, 60.0},
+    grid=true,
+    colors={{28,108,200}, {238,46,47}, {0,140,72}, {217,67,180}},
+    timeUnit="h",
+    displayUnits={"kg/s", "kg/s", "kg/s", "kg/s"});
+createPlot(
+    id=2,
+    position={55, 26, 833, 515},
+    y={"pla.cooTowWitByp.TWetBul", "pla.cooTowWitByp.TLvg"},
+    range={0.0, 90000.0, 0.0, 30.0},
+    grid=true,
+    subPlot=2,
+    colors={{28,108,200}, {238,46,47}},
+    timeUnit="h",
+    displayUnits={"degC", "degC"});
+createPlot(
+    id=2,
+    position={24, 10, 831, 511},
+    y={"pla.senTCHWSup.T", "pla.senTCHWRet.T"},
+    range={0.0, 90000.0, 0.0, 60.0},
+    grid=true,
+    subPlot=3,
+    colors={{28,108,200}, {238,46,47}},
+    timeUnit="h",
+    displayUnits={"degC", "degC"});

--- a/geojson_modelica_translator/modelica/GMT_Lib/DHC/Components/CentralPlant/Cooling/CoolingPlant.mot
+++ b/geojson_modelica_translator/modelica/GMT_Lib/DHC/Components/CentralPlant/Cooling/CoolingPlant.mot
@@ -1,25 +1,23 @@
-within {{ project_name }}.CoolingPlant;
+within GMT_Lib.DHC.Components.CentralPlant.Cooling.CoolingPlant;
 model CoolingPlant
   "Isolated central cooling plant template model."
   extends Buildings.Experimental.DHC.CentralPlants.Cooling.Examples.Plant(
-  {% replace %}
-  redeclare {{ ["chiller_performance"] }} perChi(
+  redeclare {$ chiller_performance $} perChi(
     mEva_flow_nominal=mCHW_flow_nominal,
     mCon_flow_nominal=mCW_flow_nominal,
     QEva_flow_nominal=QChi_nominal),
-  redeclare {{ ["plant_type"]}} pla,
-  dTApp={{ ["delta_temp_approach"] }},
-  mCHW_flow_nominal={{ ["chw_mass_flow_nominal"] }},
-  dpCHW_nominal={{ ["chw_pressure_drop_nominal"] }},
-  mMin_flow={{ ["chiller_water_flow_minimum"] }},
-  mCW_flow_nominal={{ ["cw_mass_flow_nominal"] }},
-  dpCW_nominal={{ ["cw_pressure_drop_nominal"] }},
-  PFan_nominal={{ ["fan_power"] }},
-  TCHWSet={{["chw_temp_setpoint"] }}
-  dpCooTowVal_nominal={{ ["cooling_tower_pressure_drop_valve_nominal"] }},
-  dpCHWPumVal_nominal={{ ["chw_pressure_drop_valve_nominal"] }},
-  dpCWPumVal_nominal={{ ["cw_pressure_drop_valve_nominal"] }});
-  {% end_replace %}
+  redeclare {$ plant_type $} pla,
+  dTApp={$ delta_temp_approach $},
+  mCHW_flow_nominal={$ chw_mass_flow_nominal $},
+  dpCHW_nominal={$ chw_pressure_drop_nominal $},
+  mMin_flow={$ chiller_water_flow_minimum $},
+  mCW_flow_nominal={$ cw_mass_flow_nominal $},
+  dpCW_nominal={$ cw_pressure_drop_nominal $},
+  PFan_nominal={$ fan_power $},
+  TCHWSet={$chw_temp_setpoint $}
+  dpCooTowVal_nominal={$ cooling_tower_pressure_drop_valve_nominal $},
+  dpCHWPumVal_nominal={$ chw_pressure_drop_valve_nominal $},
+  dpCWPumVal_nominal={$ cw_pressure_drop_valve_nominal $});
   annotation (
     Icon(
       coordinateSystem(

--- a/geojson_modelica_translator/modelica/GMT_Lib/DHC/Components/CentralPlant/Cooling/CoolingPlant.mot
+++ b/geojson_modelica_translator/modelica/GMT_Lib/DHC/Components/CentralPlant/Cooling/CoolingPlant.mot
@@ -14,7 +14,7 @@ model CoolingPlant
   mCW_flow_nominal={$ cw_mass_flow_nominal $},
   dpCW_nominal={$ cw_pressure_drop_nominal $},
   PFan_nominal={$ fan_power $},
-  TCHWSet={$chw_temp_setpoint $}
+  TCHWSet={$chw_temp_setpoint $},
   dpCooTowVal_nominal={$ cooling_tower_pressure_drop_valve_nominal $},
   dpCHWPumVal_nominal={$ chw_pressure_drop_valve_nominal $},
   dpCWPumVal_nominal={$ cw_pressure_drop_valve_nominal $});

--- a/geojson_modelica_translator/modelica/GMT_Lib/DHC/Components/CentralPlant/Cooling/CoolingPlant.mot
+++ b/geojson_modelica_translator/modelica/GMT_Lib/DHC/Components/CentralPlant/Cooling/CoolingPlant.mot
@@ -1,0 +1,51 @@
+within {{ project_name }}.CoolingPlant;
+model CoolingPlant
+  "Isolated central cooling plant template model."
+  extends Buildings.Experimental.DHC.CentralPlants.Cooling.Examples.Plant(
+  {% replace %}
+  redeclare {{ ["chiller_performance"] }} perChi(
+    mEva_flow_nominal=mCHW_flow_nominal,
+    mCon_flow_nominal=mCW_flow_nominal,
+    QEva_flow_nominal=QChi_nominal),
+  redeclare {{ ["plant_type"]}} pla,
+  dTApp={{ ["delta_temp_approach"] }},
+  mCHW_flow_nominal={{ ["chw_mass_flow_nominal"] }},
+  dpCHW_nominal={{ ["chw_pressure_drop_nominal"] }},
+  mMin_flow={{ ["chiller_water_flow_minimum"] }},
+  mCW_flow_nominal={{ ["cw_mass_flow_nominal"] }},
+  dpCW_nominal={{ ["cw_pressure_drop_nominal"] }},
+  PFan_nominal={{ ["fan_power"] }},
+  TCHWSet={{["chw_temp_setpoint"] }}
+  dpCooTowVal_nominal={{ ["cooling_tower_pressure_drop_valve_nominal"] }},
+  dpCHWPumVal_nominal={{ ["chw_pressure_drop_valve_nominal"] }},
+  dpCWPumVal_nominal={{ ["cw_pressure_drop_valve_nominal"] }});
+  {% end_replace %}
+  annotation (
+    Icon(
+      coordinateSystem(
+        preserveAspectRatio=false)),
+    Diagram(
+      coordinateSystem(
+        preserveAspectRatio=false)),
+    experiment(
+      StopTime=86400,
+      Tolerance=1e-06),
+    Documentation(
+      info="<html>
+      <p>This model validates the district central cooling plant template model implemented in
+<a href=\"GMT_Lib.DHC.Components.CentralPlants.Cooling.CoolingPlant.mo\">
+GMT_Lib.DHC.Components.CentralPlants.Cooling.CoolingPlant.mot</a>.
+</p>
+</html>",
+      revisions="<html>
+<ul>
+<li>
+October 20, 2021 by Chengnan Shi:<br/>
+First implementation.
+</li>
+</ul>
+</html>"),
+    __Dymola_Commands(
+      file="CoolingPlant.mos"
+      "Simulate and Plot"));
+end CoolingPlant;

--- a/poetry.lock
+++ b/poetry.lock
@@ -128,6 +128,14 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
+name = "colored"
+version = "1.4.3"
+description = "Simple library for color and formatting to terminal"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "coverage"
 version = "5.5"
 description = "Code coverage measurement for Python"
@@ -852,6 +860,23 @@ lint = ["flake8", "mypy", "docutils-stubs"]
 test = ["pytest"]
 
 [[package]]
+name = "syrupy"
+version = "1.5.0"
+description = "PyTest Snapshot Test Utility"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+attrs = ">=18.2.0,<22.0.0"
+colored = ">=1.3.92,<2.0.0"
+pytest = ">=5.1.0,<7.0.0"
+
+[package.extras]
+dev = ["black", "flake8-bugbear", "flake8-builtins", "flake8-comprehensions", "flake8-i18n", "flake8", "isort", "mypy", "pip-tools", "py-githooks", "pygithub", "pyperf", "semver", "twine", "wheel", "codecov", "coverage", "invoke"]
+test = ["codecov", "coverage", "invoke"]
+
+[[package]]
 name = "teaser"
 version = "0.7.5"
 description = "Tool for Energy Analysis and Simulation for Efficient Retrofit"
@@ -951,7 +976,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "a4bda68372c470856c00dbfd6cebd2cea42efa035d82e0121f2e51fe48f78d66"
+content-hash = "f924aea26016436cf90433fc7b874f69c62eb929c4b7655ec46db4f45aaf4c74"
 
 [metadata.files]
 alabaster = [
@@ -1003,6 +1028,9 @@ click = [
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
+]
+colored = [
+    {file = "colored-1.4.3.tar.gz", hash = "sha256:b7b48b9f40e8a65bbb54813d5d79dd008dc8b8c5638d5bbfd30fc5a82e6def7a"},
 ]
 coverage = [
     {file = "coverage-5.5-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:b6d534e4b2ab35c9f93f46229363e17f63c53ad01330df9f2d6bd1187e5eaacf"},
@@ -1575,6 +1603,10 @@ sphinxcontrib-qthelp = [
 sphinxcontrib-serializinghtml = [
     {file = "sphinxcontrib-serializinghtml-1.1.5.tar.gz", hash = "sha256:aa5f6de5dfdf809ef505c4895e51ef5c9eac17d0f287933eb49ec495280b6952"},
     {file = "sphinxcontrib_serializinghtml-1.1.5-py2.py3-none-any.whl", hash = "sha256:352a9a00ae864471d3a7ead8d7d79f5fc0b57e8b3f95e9867eb9eb28999b92fd"},
+]
+syrupy = [
+    {file = "syrupy-1.5.0-py3-none-any.whl", hash = "sha256:4e791e12bd605c4af8ae39648093a3c665b0c4155c9dc32bcaf08a5433887732"},
+    {file = "syrupy-1.5.0.tar.gz", hash = "sha256:7c544cc167a9b85b069cc0fe735e646cf78f68fa816b39e22c2039df3c844011"},
 ]
 teaser = [
     {file = "teaser-0.7.5.tar.gz", hash = "sha256:0fa848418628431922a3dec4d876f457445cb0b479eda2cf1f306e45596ed0e3"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ sphinx_rtd_theme = "0.5.0"
 sphinx-jsonschema = "1.16.7"
 toml = "0.10.2"
 tox = "3.20.0"
+syrupy = "^1.5.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ testpaths = tests
 
 markers =
     simulation: marks tests that run a simulation with docker/jmodelica (deselect with '-m "not simulation"')
-    mbl_v8: marks tests that require Modlica Buildings Library v8.0.0 is checked out in your modelica path (deselect with '-m "not mbl_v8"')
+    mbl_v8: marks tests that require Modlica Buildings Library v8.1.0 is checked out in your modelica path (deselect with '-m "not mbl_v8"')
 
 [flake8]
 # Some sane defaults for the code style checker flake8

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ testpaths = tests
 
 markers =
     simulation: marks tests that run a simulation with docker/jmodelica (deselect with '-m "not simulation"')
+    mbl_v8: marks tests that require Modlica Buildings Library v8.0.0 is checked out in your modelica path (deselect with '-m "not mbl_v8"')
 
 [flake8]
 # Some sane defaults for the code style checker flake8

--- a/tests/GMT_Lib/__snapshots__/test_gmt_lib.ambr
+++ b/tests/GMT_Lib/__snapshots__/test_gmt_lib.ambr
@@ -1,0 +1,53 @@
+# name: test_generate_cooling_plant
+  '
+  within GMT_Lib.DHC.Components.CentralPlant.Cooling.CoolingPlant;
+  model CoolingPlant
+    "Isolated central cooling plant template model."
+    extends Buildings.Experimental.DHC.CentralPlants.Cooling.Examples.Plant(
+    redeclare Buildings.Fluid.Chillers.Data.ElectricEIR.ElectricEIRChiller_York_YT_1055kW_5_96COP_Vanes perChi(
+      mEva_flow_nominal=mCHW_flow_nominal,
+      mCon_flow_nominal=mCW_flow_nominal,
+      QEva_flow_nominal=QChi_nominal),
+    redeclare Buildings.Experimental.DHC.CentralPlants.Cooling.Plant pla,
+    dTApp=3,
+    mCHW_flow_nominal=18.3,
+    dpCHW_nominal=44800,
+    mMin_flow=0.03,
+    mCW_flow_nominal=34.7,
+    dpCW_nominal=46200,
+    PFan_nominal=4999,
+    TCHWSet=281.15
+    dpCooTowVal_nominal=5999,
+    dpCHWPumVal_nominal=5999,
+    dpCWPumVal_nominal=5999);
+    annotation (
+      Icon(
+        coordinateSystem(
+          preserveAspectRatio=false)),
+      Diagram(
+        coordinateSystem(
+          preserveAspectRatio=false)),
+      experiment(
+        StopTime=86400,
+        Tolerance=1e-06),
+      Documentation(
+        info="<html>
+        <p>This model validates the district central cooling plant template model implemented in
+  <a href=\"GMT_Lib.DHC.Components.CentralPlants.Cooling.CoolingPlant.mo\">
+  GMT_Lib.DHC.Components.CentralPlants.Cooling.CoolingPlant.mot</a>.
+  </p>
+  </html>",
+        revisions="<html>
+  <ul>
+  <li>
+  October 20, 2021 by Chengnan Shi:<br/>
+  First implementation.
+  </li>
+  </ul>
+  </html>"),
+      __Dymola_Commands(
+        file="CoolingPlant.mos"
+        "Simulate and Plot"));
+  end CoolingPlant;
+  '
+---

--- a/tests/GMT_Lib/__snapshots__/test_gmt_lib.ambr
+++ b/tests/GMT_Lib/__snapshots__/test_gmt_lib.ambr
@@ -16,7 +16,7 @@
     mCW_flow_nominal=34.7,
     dpCW_nominal=46200,
     PFan_nominal=4999,
-    TCHWSet=281.15
+    TCHWSet=281.15,
     dpCooTowVal_nominal=5999,
     dpCHWPumVal_nominal=5999,
     dpCWPumVal_nominal=5999);

--- a/tests/GMT_Lib/test_gmt_lib.py
+++ b/tests/GMT_Lib/test_gmt_lib.py
@@ -1,0 +1,74 @@
+"""
+****************************************************************************************************
+:copyright (c) 2019-2021 URBANopt, Alliance for Sustainable Energy, LLC, and other contributors.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted
+provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions
+and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions
+and the following disclaimer in the documentation and/or other materials provided with the
+distribution.
+
+Neither the name of the copyright holder nor the names of its contributors may be used to endorse
+or promote products derived from this software without specific prior written permission.
+
+Redistribution of this software, without modification, must refer to the software by the same
+designation. Redistribution of a modified version of this software (i) may not refer to the
+modified version by the same designation, or by any confusingly similar designation, and
+(ii) must refer to the underlying software originally provided by Alliance as “URBANopt”. Except
+to comply with the foregoing, the term “URBANopt”, or any confusingly similar designation may
+not be used to refer to any modified version of this software or any modified version of the
+underlying software originally provided by Alliance without the prior written consent of Alliance.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+****************************************************************************************************
+"""
+from pathlib import Path
+
+from jinja2 import Environment, FileSystemLoader, StrictUndefined
+
+GMT_LIB_PATH = Path(__file__).parent.parent.parent / 'geojson_modelica_translator' / 'modelica' / 'GMT_Lib'
+
+env = Environment(
+    loader=FileSystemLoader(GMT_LIB_PATH),
+    undefined=StrictUndefined,
+    variable_start_string='{$',
+    variable_end_string='$}'
+)
+
+
+def test_generate_cooling_plant(snapshot):
+    # -- Setup
+    params = {
+        'chiller_performance':  'Buildings.Fluid.Chillers.Data.ElectricEIR.ElectricEIRChiller_York_YT_1055kW_5_96COP_Vanes',
+        'plant_type': 'Buildings.Experimental.DHC.CentralPlants.Cooling.Plant',
+        'delta_temp_approach': 3,
+        'chw_mass_flow_nominal':  18.3,
+        'chw_pressure_drop_nominal': 44800,
+        'chiller_water_flow_minimum': 0.03,
+        'cw_mass_flow_nominal':  34.7,
+        'cw_pressure_drop_nominal': 46200,
+        'fan_power': 4999,
+        'chw_temp_setpoint': 281.15,
+        'cooling_tower_pressure_drop_valve_nominal': 5999,
+        'chw_pressure_drop_valve_nominal': 5999,
+        'cw_pressure_drop_valve_nominal': 5999
+    }
+
+    # -- Act
+    actual = env.get_template('DHC/Components/CentralPlant/Cooling/CoolingPlant.mot').render(**params)
+
+    # -- Assert
+    assert actual == snapshot

--- a/tests/GMT_Lib/test_gmt_lib.py
+++ b/tests/GMT_Lib/test_gmt_lib.py
@@ -82,6 +82,7 @@ def test_generate_cooling_plant(snapshot):
 
 
 @pytest.mark.mbl_v8
+@pytest.mark.simulation
 def test_simulate_cooling_plant():
     # -- Setup
     template_path = (COOLING_PLANT_PATH / 'CoolingPlant.mot').relative_to(GMT_LIB_PATH)

--- a/tests/GMT_Lib/test_gmt_lib.py
+++ b/tests/GMT_Lib/test_gmt_lib.py
@@ -75,7 +75,7 @@ def test_generate_cooling_plant(snapshot):
     template_path = (COOLING_PLANT_PATH / 'CoolingPlant.mot').relative_to(GMT_LIB_PATH)
 
     # -- Act
-    actual = env.get_template(str(template_path)).render(**COOLING_PLANT_PARAMS)
+    actual = env.get_template(template_path.as_posix()).render(**COOLING_PLANT_PARAMS)
 
     # -- Assert
     assert actual == snapshot
@@ -86,7 +86,7 @@ def test_generate_cooling_plant(snapshot):
 def test_simulate_cooling_plant():
     # -- Setup
     template_path = (COOLING_PLANT_PATH / 'CoolingPlant.mot').relative_to(GMT_LIB_PATH)
-    output = env.get_template(str(template_path)).render(**COOLING_PLANT_PARAMS)
+    output = env.get_template(template_path.as_posix()).render(**COOLING_PLANT_PARAMS)
     package_output_dir = PARENT_DIR / 'output' / 'Cooling'
     package_output_dir.mkdir(parents=True, exist_ok=True)
     with open(package_output_dir / 'CoolingPlant.mo', 'w') as f:


### PR DESCRIPTION
#### Any background context you want to provide?
- CU Boulder is creating a library of templates for the GMT to use. These new templates use Modelica Buildings Library v8 (GMT currently uses a fork of MBL).

#### What does this PR accomplish?
- add CoolingPlant template from CU Boulder
- add tests for cooling plant
- update CI to handle tests that require Modelica Buildings Library v8
- ⚠️  Since the CU Boulder models require MBL v8, I have created the test marker `mbl_v8` to flag tests that require that version of the MBL to be checked out (`cd $MODELICAPATH && git checkout v8.1.0`). To run the original tests that don't use v8, make sure you include the `-m 'not mbl_v8'` flag. For example:
```
poetry run pytest -m 'not mbl_v8'
```
Or if you only want to run the mbl_v8 tests you'd use
```
poetry run pytest -m mbl_v8
```

#### How should this be manually tested?
- run automated tests
```
# with v8.0.0 tag checked out in modelica-buildings repo
poetry run pytest -m mbl_v8

...

# with GMT's fork of modelica-buildings checked out, issue2204_gmt_mbl
poetry run pytest -m 'not mbl_v8'
```
#### What are the relevant tickets?
#431 
Closes #436 

#### Screenshots (if appropriate)
