### PR TITLE
better error message if modelica timeseries files from sdk are not found

### DIFF
--- a/geojson_modelica_translator/system_parameters/system_parameters.py
+++ b/geojson_modelica_translator/system_parameters/system_parameters.py
@@ -832,7 +832,10 @@ class SystemParameters(object):
         building_list = [x for x in building_list if not x['load_model_parameters']
                          ['time_series']['filepath'].endswith("populated")]
         if len(building_list) == 0:
-            raise Exception("No Modelica files found. The UO SDK simulations may not have been successful")
+            raise SystemExit("No Modelica files found. Modelica files are expected to be found within each feature in folders "
+                             "with names that include '_modelica'\n"
+                             f"For instance: {scenario_dir / '2' / '016_export_modelica_loads'}\n"
+                             "If these files don't exist the UO SDK simulations may not have been successful")
 
         # Update specific sys-param settings for each building
         for building in building_list:


### PR DESCRIPTION
#### Any background context you want to provide?
A user ran into this error and requested more information about where the files are expected to be.
#### What does this PR accomplish?
Adds more detail to error message when building a sys-param file and modelica files from UO SDK are not found. We now share where the files are expected to be so the user can manually check.
#### How should this be manually tested?
Change [this line](https://github.com/urbanopt/geojson-modelica-translator/blob/better-error-messages/geojson_modelica_translator/system_parameters/system_parameters.py#L834) from `==` to `!=` and run the `uo_des build-sys-param` command, pointing to default output from the sdk. This will ensure the error gets raised, and the new text shown.
#### What are the relevant tickets?
https://github.com/urbanopt/urbanopt-cli/issues/329
#### Screenshots (if appropriate)
<img width="928" alt="Screen Shot 2022-05-04 at 11 12 48 AM" src="https://user-images.githubusercontent.com/19916206/166724792-29c4f14f-2590-49ed-94aa-b8b84b05428d.png">

