### PR TITLE
Break out build and simulate tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,10 @@ name: CI
 on:
   pull_request:
   push:
-    branches:
-      - 'develop'
-      - 'main'
+    # re-enable all branches until we start simulating again.
+    # branches:
+    #   - 'develop'
+    #   - 'main'
 
 defaults:
   run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,16 +20,12 @@ jobs:
         # 3.9 does not work as of 2020-02-01
         python-version: [3.7]
         test_env: [python, precommit, docs]
-        mbl_branch: [issue2204_gmt_mbl]
+        mbl_branch: [master]
         include:
           - os: ubuntu-latest
             python-version: 3.7
             test_env: python
             mbl_branch: master
-          - os: ubuntu-latest
-            python-version: 3.7
-            test_env: check_sys_params
-            mbl_branch: issue2204_gmt_mbl
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -95,10 +91,10 @@ jobs:
               poetry run tox -e ${{ matrix.test_env }} -- -m 'not simulation' ./tests
             elif [ '${{ matrix.mbl_branch }}' == 'master' ]; then
               # we can no longer run any msl v4 simulations with JModelica
-              poetry run tox -e ${{ matrix.test_env }} -- -m 'mbl_v9 and not msl_v4_simulation' ./tests
+              poetry run tox -e ${{ matrix.test_env }} -- -m 'not simulation' ./tests
             else
               # we can no longer run any msl v4 simulations with JModelica
-              poetry run tox -e ${{ matrix.test_env }} -- -m 'not mbl_v9 and not msl_v4_simulation' ./tests
+              poetry run tox -e ${{ matrix.test_env }} -- -m 'not simulation' ./tests
             fi
           else
             poetry run tox -e ${{ matrix.test_env }}
@@ -107,7 +103,7 @@ jobs:
         name: Coveralls
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.test_env == 'python' && matrix.mbl_branch == 'issue2204_gmt_mbl' }}
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.test_env == 'python' && matrix.mbl_branch == 'master' }}
         run: |
           poetry run coveralls
       -

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+Version 0.2.4 (unreleased)
+--------------------------
+* Use MBL v9 (current master branch) for all models. Note that JModelica no longer works with this version. User must now use either Dymola or Optimica--A new solution is forthcoming.
+* Update unit tests to break out building the tests and running the tests.
+
 Version 0.2.3
 -------------
 * Add GMT Lib methods for Level 1 translation of Modelica-templated objects (for microgrid).

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -67,7 +67,7 @@ Once the MBL is installed, then the CLI can be used to create the model with the
 The resulting Modelica package will be created and can be opened in a Modelica editor. Open the :code:`package.mo` file in the root directory of the generated package. You will also need to
 load the MBL into your Modelica editor.
 
-NOTE: The developers of the GMT are currently working on updating the MBL version used. If you are also a developer and need to run the unit tests in this repo, you can instruct pytest to ignore the v8 tests with :code:`poetry run pytest -m 'not mbl_v9'`, which assumes you have the MBL version documented above. To run the MBL v9 tests, you need to checkout :code:`master` and run :code:`poetry run pytest -m mbl_v9`, however several MBL v9 components now require MSL 4.0, which doesn't work within JModelica.
+The latest version of this repository uses MBL v9 (not yet released, but current master branch). This version does not support running JModelica due to the upgrade to Modelica Standard Library (MSL) version 4. For this reason, the unit tests no longer run the models; therefore, you will need to mark the pytest to not run the simulations with :code:`poetry run pytest -m 'not simulation'`.
 
 
 Docker Installation

--- a/geojson_modelica_translator/model_connectors/load_connectors/teaser.py
+++ b/geojson_modelica_translator/model_connectors/load_connectors/teaser.py
@@ -530,7 +530,6 @@ class Teaser(LoadBase):
         nom_cool_flow = np.array([-10000] * len(zone_list))
         for i, dic in enumerate(zone_list):
             if dic["instance_name"] == "ict":
-                print("setting coo flow")
                 nom_cool_flow[i - 1] = -50000  # Need to offset for different indexing
         nom_heat_flow = np.array([10000] * len(zone_list))
         building_template_data = {

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ description-file = README.rst
 
 [tool:pytest]
 addopts =
-    --cov geojson_modelica_translator --cov-report term-missing
+    # --cov geojson_modelica_translator --cov-report term-missing
     --verbose
     -s
 norecursedirs =
@@ -18,9 +18,8 @@ norecursedirs =
 testpaths = tests
 
 markers =
-    simulation: marks tests that run a simulation with docker/jmodelica (deselect with '-m "not simulation"')
-    mbl_v9: marks tests that require Modelica Buildings Library master branch is checked out in your modelica path (deselect with '-m "not mbl_v9"')
-    msl_v4_simulation: marks that the model requires Modelica Standard Language 4.0, ultimately meaning that JModelica will not work for the simulation.
+    simulation: marks tests that run a simulation with docker/jmodelica (deselect with '-m "not simulation"'). All simulations now require MSL v4.
+
 [flake8]
 # Some sane defaults for the code style checker flake8
 max_line_length = 120

--- a/tests/GMT_Lib/test_gmt_lib.py
+++ b/tests/GMT_Lib/test_gmt_lib.py
@@ -95,7 +95,22 @@ def test_generate_cooling_plant(snapshot):
     assert actual == snapshot
 
 
-@pytest.mark.mbl_v9
+def test_build_community_pv():
+    # -- Setup
+
+    package_output_dir = PARENT_DIR / 'output' / 'CommunityPV'
+    package_output_dir.mkdir(parents=True, exist_ok=True)
+    sys_params = SystemParameters(MICROGRID_PARAMS)
+
+    # -- Act
+    cpv = CommunityPV(sys_params)
+    cpv.build_from_template(package_output_dir)
+
+    # -- Assert
+    # Did the mofile get created?
+    assert linecount(package_output_dir / 'PVPanels1.mo') > 20
+
+
 @pytest.mark.simulation
 def test_simulate_community_pv():
     # -- Setup
@@ -108,19 +123,33 @@ def test_simulate_community_pv():
     cpv = CommunityPV(sys_params)
     cpv.build_from_template(package_output_dir)
 
-    # runner = ModelicaRunner()
-    # success, _ = runner.run_in_docker(package_output_dir / 'PVPanels0.mo')
+    runner = ModelicaRunner()
+    success, _ = runner.run_in_docker(package_output_dir / 'PVPanels0.mo')
 
     # -- Assert
     # Did the mofile get created?
     assert linecount(package_output_dir / 'PVPanels1.mo') > 20
     # Did the simulation run?
-    # assert success is True
+    assert success is True
 
 
-@pytest.mark.mbl_v9
+def test_build_cooling_plant():
+    # -- Setup
+    template_path = (COOLING_PLANT_PATH / 'CoolingPlant.mot').relative_to(GMT_LIB_PATH)
+
+    # -- Act
+    output = env.get_template(template_path.as_posix()).render(**COOLING_PLANT_PARAMS)
+    package_output_dir = PARENT_DIR / 'output' / 'Cooling'
+    package_output_dir.mkdir(parents=True, exist_ok=True)
+    with open(package_output_dir / 'CoolingPlant.mo', 'w') as f:
+        f.write(output)
+
+    # -- Assert
+    # Did the mofile get created?
+    assert linecount(package_output_dir / 'CoolingPlant.mo') > 20
+
+
 @pytest.mark.simulation
-@pytest.mark.msl_v4_simulation
 def test_simulate_cooling_plant():
     # -- Setup
     template_path = (COOLING_PLANT_PATH / 'CoolingPlant.mot').relative_to(GMT_LIB_PATH)
@@ -141,7 +170,21 @@ def test_simulate_cooling_plant():
     assert success is True
 
 
-@pytest.mark.mbl_v9
+def test_build_wind_turbine():
+    # -- Setup
+    package_output_dir = PARENT_DIR / 'output' / 'WindTurbine'
+    package_output_dir.mkdir(parents=True, exist_ok=True)
+    sys_params = SystemParameters(MICROGRID_PARAMS)
+
+    # -- Act
+    cpv = WindTurbine(sys_params)
+    cpv.build_from_template(package_output_dir)
+
+    # -- Assert
+    # Did the mofile get created?
+    assert linecount(package_output_dir / 'WindTurbine0.mo') > 20
+
+
 @pytest.mark.simulation
 def test_simulate_wind_turbine():
     # -- Setup
@@ -154,21 +197,34 @@ def test_simulate_wind_turbine():
     cpv = WindTurbine(sys_params)
     cpv.build_from_template(package_output_dir)
 
-    # runner = ModelicaRunner()
-    # success, _ = runner.run_in_docker(package_output_dir / 'WindTurbine0.mo')
+    runner = ModelicaRunner()
+    success, _ = runner.run_in_docker(package_output_dir / 'WindTurbine0.mo')
 
     # -- Assert
     # Did the mofile get created?
     assert linecount(package_output_dir / 'WindTurbine0.mo') > 20
     # Did the simulation run?
-    # assert success is True
+    assert success is True
 
 
-@pytest.mark.mbl_v9
+def test_build_distribution_lines():
+    # -- Setup
+    package_output_dir = PARENT_DIR / 'output' / 'DistributionLines'
+    package_output_dir.mkdir(parents=True, exist_ok=True)
+    sys_params = SystemParameters(MICROGRID_PARAMS)
+
+    # -- Act
+    cpv = DistributionLines(sys_params)
+    cpv.build_from_template(package_output_dir)
+
+    # -- Assert
+    # Did the mofile get created?
+    assert linecount(package_output_dir / 'ACLine0.mo') > 20
+
+
 @pytest.mark.simulation
 def test_simulate_distribution_lines():
     # -- Setup
-
     package_output_dir = PARENT_DIR / 'output' / 'DistributionLines'
     package_output_dir.mkdir(parents=True, exist_ok=True)
     sys_params = SystemParameters(MICROGRID_PARAMS)
@@ -187,9 +243,9 @@ def test_simulate_distribution_lines():
     # assert success is True
 
 
-@pytest.mark.mbl_v9
-@pytest.mark.simulation
-def test_stub_mbl_v9_with_not_msl_v4():
-    """Need to have a stub where mbl_v9 is selected that is simulatable (with
-    MSV V3.2) in order to not create a failed pytest command with exit code 5."""
-    assert False is not True
+# Keeping the code below because it may come back and this was a weird issue.
+# @pytest.mark.simulation
+# def test_stub_mbl_v9_with_not_msl_v4():
+#     """Need to have a stub where mbl_v9 is selected that is simulatable (with
+#     MSV V3.2) in order to not create a failed pytest command with exit code 5."""
+#     assert False is not True

--- a/tests/management/test_uo_des.py
+++ b/tests/management/test_uo_des.py
@@ -135,7 +135,6 @@ class CLIIntegrationTest(TestCase):
         self.assertIn("Modelica does not support spaces in project names or paths.", str(expected_failure.exception))
 
     @pytest.mark.simulation
-    @pytest.mark.msl_v4_simulation
     def test_cli_runs_model(self):
         if (self.output_dir / 'modelica_project_results').exists():
             rmtree(self.output_dir / 'modelica_project_results')

--- a/tests/model_connectors/test_chilled_water_plant.py
+++ b/tests/model_connectors/test_chilled_water_plant.py
@@ -37,6 +37,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
 import os
+from pathlib import Path
 
 import pytest
 from geojson_modelica_translator.geojson.urbanopt_geojson import (
@@ -62,10 +63,10 @@ from geojson_modelica_translator.system_parameters.system_parameters import (
 from ..base_test_case import TestCaseBase
 
 
-@pytest.mark.simulation
-@pytest.mark.msl_v4_simulation
 class DistrictSystemTest(TestCaseBase):
-    def test_district_system(self):
+    def setUp(self):
+        super().setUp()
+
         project_name = "chilled_water_plant_stub"
         self.data_dir, self.output_dir = self.set_up(os.path.dirname(__file__), project_name)
 
@@ -86,15 +87,21 @@ class DistrictSystemTest(TestCaseBase):
             cp_cw_coupling,
         ])
 
-        district = District(
+        self.district = District(
             root_dir=self.output_dir,
             project_name=project_name,
             system_parameters=sys_params,
             coupling_graph=graph
         )
-        district.to_modelica()
+        self.district.to_modelica()
 
-        root_path = os.path.abspath(os.path.join(district._scaffold.districts_path.files_dir))
-        self.run_and_assert_in_docker(os.path.join(root_path, 'DistrictEnergySystem.mo'),
-                                      project_path=district._scaffold.project_path,
-                                      project_name=district._scaffold.project_name)
+    def test_build_district_system(self):
+        root_path = Path(self.district._scaffold.districts_path.files_dir).resolve()
+        assert ((root_path) / 'DistrictEnergySystem.mo').exists()
+
+    @pytest.mark.simulation
+    def test_simulate_district_system(self):
+        root_path = Path(self.district._scaffold.districts_path.files_dir).resolve()
+        self.run_and_assert_in_docker(Path(root_path) / 'DistrictEnergySystem.mo',
+                                      project_path=self.district._scaffold.project_path,
+                                      project_name=self.district._scaffold.project_name)

--- a/tests/model_connectors/test_chilled_water_plant.py
+++ b/tests/model_connectors/test_chilled_water_plant.py
@@ -97,7 +97,7 @@ class DistrictSystemTest(TestCaseBase):
 
     def test_build_district_system(self):
         root_path = Path(self.district._scaffold.districts_path.files_dir).resolve()
-        assert ((root_path) / 'DistrictEnergySystem.mo').exists()
+        assert (root_path / 'DistrictEnergySystem.mo').exists()
 
     @pytest.mark.simulation
     def test_simulate_district_system(self):

--- a/tests/model_connectors/test_chp_system.py
+++ b/tests/model_connectors/test_chp_system.py
@@ -73,10 +73,10 @@ from geojson_modelica_translator.system_parameters.system_parameters import (
 from ..base_test_case import TestCaseBase
 
 
-@pytest.mark.simulation
-@pytest.mark.msl_v4_simulation
 class CombinedHeatingPowerTest(TestCaseBase):
-    def test_chp_system(self):
+    def setUp(self):
+        super().setUp()
+
         self.project_name = 'heat_with_chp'
         self.data_dir, self.output_dir = self.set_up(Path(__file__).parent, self.project_name)
 
@@ -108,15 +108,21 @@ class CombinedHeatingPowerTest(TestCaseBase):
         # create the couplings and graph
         graph = CouplingGraph(all_couplings)
 
-        district = District(
+        self.district = District(
             root_dir=self.output_dir,
             project_name=self.project_name,
             system_parameters=self.sys_params,
             coupling_graph=graph
         )
-        district.to_modelica()
+        self.district.to_modelica()
 
-        # root_path = Path(district._scaffold.districts_path.files_dir).resolve()
-        # self.run_and_assert_in_docker(Path(root_path) / 'DistrictEnergySystem.mo',
-        #                               project_path=district._scaffold.project_path,
-        #                               project_name=district._scaffold.project_name)
+    def test_build_chp_system(self):
+        root_path = Path(self.district._scaffold.districts_path.files_dir).resolve()
+        assert ((root_path) / 'DistrictEnergySystem.mo').exists()
+
+    @pytest.mark.simulation
+    def test_simulate_chp_system(self):
+        root_path = Path(self.district._scaffold.districts_path.files_dir).resolve()
+        self.run_and_assert_in_docker(Path(root_path) / 'DistrictEnergySystem.mo',
+                                      project_path=self.district._scaffold.project_path,
+                                      project_name=self.district._scaffold.project_name)

--- a/tests/model_connectors/test_chp_system.py
+++ b/tests/model_connectors/test_chp_system.py
@@ -118,7 +118,7 @@ class CombinedHeatingPowerTest(TestCaseBase):
 
     def test_build_chp_system(self):
         root_path = Path(self.district._scaffold.districts_path.files_dir).resolve()
-        assert ((root_path) / 'DistrictEnergySystem.mo').exists()
+        assert (root_path / 'DistrictEnergySystem.mo').exists()
 
     @pytest.mark.simulation
     def test_simulate_chp_system(self):

--- a/tests/model_connectors/test_district_cooling_system.py
+++ b/tests/model_connectors/test_district_cooling_system.py
@@ -37,6 +37,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
 import os
+from pathlib import Path
 
 import pytest
 from geojson_modelica_translator.geojson.urbanopt_geojson import (
@@ -74,9 +75,10 @@ from ..base_test_case import TestCaseBase
 
 
 @pytest.mark.simulation
-@pytest.mark.msl_v4_simulation
 class DistrictCoolingSystemTest(TestCaseBase):
-    def test_district_cooling_system(self):
+    def setUp(self):
+        super().setUp()
+
         project_name = 'district_cooling_system'
         self.data_dir, self.output_dir = self.set_up(os.path.dirname(__file__), project_name)
 
@@ -108,15 +110,21 @@ class DistrictCoolingSystemTest(TestCaseBase):
         # create the couplings and graph
         graph = CouplingGraph(all_couplings)
 
-        district = District(
+        self.district = District(
             root_dir=self.output_dir,
             project_name=project_name,
             system_parameters=sys_params,
             coupling_graph=graph
         )
-        district.to_modelica()
+        self.district.to_modelica()
 
-        root_path = os.path.abspath(os.path.join(district._scaffold.districts_path.files_dir))
-        self.run_and_assert_in_docker(os.path.join(root_path, 'DistrictEnergySystem.mo'),
-                                      project_path=district._scaffold.project_path,
-                                      project_name=district._scaffold.project_name)
+    def test_build_district_cooling_system(self):
+        root_path = Path(self.district._scaffold.districts_path.files_dir).resolve()
+        assert ((root_path) / 'DistrictEnergySystem.mo').exists()
+
+    @pytest.mark.simulation
+    def test_simulate_district_cooling_system(self):
+        root_path = Path(self.district._scaffold.districts_path.files_dir).resolve()
+        self.run_and_assert_in_docker(Path(root_path) / 'DistrictEnergySystem.mo',
+                                      project_path=self.district._scaffold.project_path,
+                                      project_name=self.district._scaffold.project_name)

--- a/tests/model_connectors/test_district_cooling_system.py
+++ b/tests/model_connectors/test_district_cooling_system.py
@@ -120,7 +120,7 @@ class DistrictCoolingSystemTest(TestCaseBase):
 
     def test_build_district_cooling_system(self):
         root_path = Path(self.district._scaffold.districts_path.files_dir).resolve()
-        assert ((root_path) / 'DistrictEnergySystem.mo').exists()
+        assert (root_path / 'DistrictEnergySystem.mo').exists()
 
     @pytest.mark.simulation
     def test_simulate_district_cooling_system(self):

--- a/tests/model_connectors/test_district_heating_and_cooling_systems.py
+++ b/tests/model_connectors/test_district_heating_and_cooling_systems.py
@@ -130,7 +130,7 @@ class DistrictHeatingAndCoolingSystemsTest(TestCaseBase):
 
     def test_build_district_heating_and_cooling_systems(self):
         root_path = Path(self.district._scaffold.districts_path.files_dir).resolve()
-        assert ((root_path) / 'DistrictEnergySystem.mo').exists()
+        assert (root_path / 'DistrictEnergySystem.mo').exists()
 
     @pytest.mark.simulation
     def test_simulate_district_heating_and_cooling_systems(self):

--- a/tests/model_connectors/test_district_heating_and_cooling_systems.py
+++ b/tests/model_connectors/test_district_heating_and_cooling_systems.py
@@ -68,10 +68,10 @@ from geojson_modelica_translator.system_parameters.system_parameters import (
 from ..base_test_case import TestCaseBase
 
 
-@pytest.mark.simulation
-@pytest.mark.msl_v4_simulation
 class DistrictHeatingAndCoolingSystemsTest(TestCaseBase):
     def setUp(self):
+        super().setUp()
+
         self.project_name = 'district_heating_and_cooling_systems'
         self.data_dir, self.output_dir = self.set_up(Path(__file__).parent, self.project_name)
 
@@ -83,7 +83,6 @@ class DistrictHeatingAndCoolingSystemsTest(TestCaseBase):
         filename = Path(self.data_dir) / "time_series_system_params_ets.json"
         self.sys_params = SystemParameters(filename)
 
-    def test_district_heating_and_cooling_systems(self):
         # create cooling network and plant
         cooling_network = Network2Pipe(self.sys_params)
         cooling_plant = CoolingPlant(self.sys_params)
@@ -100,12 +99,12 @@ class DistrictHeatingAndCoolingSystemsTest(TestCaseBase):
         ]
 
         # keep track of separate loads and etses for testing purposes
-        loads = []
+        self.loads = []
         heat_etses = []
         cool_etses = []
         for geojson_load in self.gj.buildings:
             time_series_load = TimeSeries(self.sys_params, geojson_load)
-            loads.append(time_series_load)
+            self.loads.append(time_series_load)
             geojson_load_id = geojson_load.feature.properties["id"]
 
             cooling_indirect = CoolingIndirect(self.sys_params, geojson_load_id)
@@ -121,28 +120,34 @@ class DistrictHeatingAndCoolingSystemsTest(TestCaseBase):
         # create the couplings and graph
         graph = CouplingGraph(all_couplings)
 
-        district = District(
+        self.district = District(
             root_dir=self.output_dir,
             project_name=self.project_name,
             system_parameters=self.sys_params,
             coupling_graph=graph
         )
-        district.to_modelica()
+        self.district.to_modelica()
 
-        root_path = Path(district._scaffold.districts_path.files_dir).resolve()
+    def test_build_district_heating_and_cooling_systems(self):
+        root_path = Path(self.district._scaffold.districts_path.files_dir).resolve()
+        assert ((root_path) / 'DistrictEnergySystem.mo').exists()
+
+    @pytest.mark.simulation
+    def test_simulate_district_heating_and_cooling_systems(self):
+        root_path = Path(self.district._scaffold.districts_path.files_dir).resolve()
         self.run_and_assert_in_docker(Path(root_path) / 'DistrictEnergySystem.mo',
-                                      project_path=district._scaffold.project_path,
-                                      project_name=district._scaffold.project_name)
+                                      project_path=self.district._scaffold.project_path,
+                                      project_name=self.district._scaffold.project_name)
 
         #
         # Validate model outputs
         #
-        results_dir = f'{district._scaffold.project_path}_results'
+        results_dir = f'{self.district._scaffold.project_path}_results'
         mat_file = f'{results_dir}/{self.project_name}_Districts_DistrictEnergySystem_result.mat'
         mat_results = Reader(mat_file, 'dymola')
 
         # check the mass flow rates of the first load are in the expected range
-        load = loads[0]
+        load = self.loads[0]
         (_, heat_m_flow) = mat_results.values(f'{load.id}.ports_aHeaWat[1].m_flow')
         # NL: changed the line below to be aChiWat (not repeating aHeaWat).
         (_, cool_m_flow) = mat_results.values(f'{load.id}.ports_aChiWat[1].m_flow')

--- a/tests/model_connectors/test_district_heating_system.py
+++ b/tests/model_connectors/test_district_heating_system.py
@@ -37,6 +37,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
 import os
+from pathlib import Path
 
 import pytest
 from geojson_modelica_translator.geojson.urbanopt_geojson import (
@@ -73,10 +74,10 @@ from geojson_modelica_translator.system_parameters.system_parameters import (
 from ..base_test_case import TestCaseBase
 
 
-@pytest.mark.simulation
-@pytest.mark.msl_v4_simulation
 class DistrictHeatingSystemNewTest(TestCaseBase):
-    def test_district_heating_system(self):
+    def setUp(self):
+        super().setUp()
+
         project_name = 'district_heating_system'
         self.data_dir, self.output_dir = self.set_up(os.path.dirname(__file__), project_name)
 
@@ -108,15 +109,21 @@ class DistrictHeatingSystemNewTest(TestCaseBase):
         # create the couplings and graph
         graph = CouplingGraph(all_couplings)
 
-        district = District(
+        self.district = District(
             root_dir=self.output_dir,
             project_name=project_name,
             system_parameters=sys_params,
             coupling_graph=graph
         )
-        district.to_modelica()
+        self.district.to_modelica()
 
-        root_path = os.path.abspath(os.path.join(district._scaffold.districts_path.files_dir))
-        self.run_and_assert_in_docker(os.path.join(root_path, 'DistrictEnergySystem.mo'),
-                                      project_path=district._scaffold.project_path,
-                                      project_name=district._scaffold.project_name)
+    def test_build_district_heating_system(self):
+        root_path = Path(self.district._scaffold.districts_path.files_dir).resolve()
+        assert ((root_path) / 'DistrictEnergySystem.mo').exists()
+
+    @pytest.mark.simulation
+    def test_simulate_district_heating_system(self):
+        root_path = Path(self.district._scaffold.districts_path.files_dir).resolve()
+        self.run_and_assert_in_docker(Path(root_path) / 'DistrictEnergySystem.mo',
+                                      project_path=self.district._scaffold.project_path,
+                                      project_name=self.district._scaffold.project_name)

--- a/tests/model_connectors/test_district_heating_system.py
+++ b/tests/model_connectors/test_district_heating_system.py
@@ -119,7 +119,7 @@ class DistrictHeatingSystemNewTest(TestCaseBase):
 
     def test_build_district_heating_system(self):
         root_path = Path(self.district._scaffold.districts_path.files_dir).resolve()
-        assert ((root_path) / 'DistrictEnergySystem.mo').exists()
+        assert (root_path / 'DistrictEnergySystem.mo').exists()
 
     @pytest.mark.simulation
     def test_simulate_district_heating_system(self):

--- a/tests/model_connectors/test_district_system.py
+++ b/tests/model_connectors/test_district_system.py
@@ -37,6 +37,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
 import os
+from pathlib import Path
 
 import pytest
 from geojson_modelica_translator.geojson.urbanopt_geojson import (
@@ -70,10 +71,10 @@ from geojson_modelica_translator.system_parameters.system_parameters import (
 from ..base_test_case import TestCaseBase
 
 
-@pytest.mark.simulation
-@pytest.mark.msl_v4_simulation
 class DistrictSystemTest(TestCaseBase):
-    def test_district_system(self):
+    def setUp(self):
+        super().setUp()
+
         project_name = "district_system"
         self.data_dir, self.output_dir = self.set_up(os.path.dirname(__file__), project_name)
 
@@ -105,15 +106,21 @@ class DistrictSystemTest(TestCaseBase):
             ts_hw_coupling,
         ])
 
-        district = District(
+        self.district = District(
             root_dir=self.output_dir,
             project_name=project_name,
             system_parameters=sys_params,
             coupling_graph=graph
         )
-        district.to_modelica()
+        self.district.to_modelica()
 
-        root_path = os.path.abspath(os.path.join(district._scaffold.districts_path.files_dir))
-        self.run_and_assert_in_docker(os.path.join(root_path, 'DistrictEnergySystem.mo'),
-                                      project_path=district._scaffold.project_path,
-                                      project_name=district._scaffold.project_name)
+    def test_build_district_system(self):
+        root_path = Path(self.district._scaffold.districts_path.files_dir).resolve()
+        assert ((root_path) / 'DistrictEnergySystem.mo').exists()
+
+    @pytest.mark.simulation
+    def test_simulate_district_system(self):
+        root_path = Path(self.district._scaffold.districts_path.files_dir).resolve()
+        self.run_and_assert_in_docker(Path(root_path) / 'DistrictEnergySystem.mo',
+                                      project_path=self.district._scaffold.project_path,
+                                      project_name=self.district._scaffold.project_name)

--- a/tests/model_connectors/test_district_system.py
+++ b/tests/model_connectors/test_district_system.py
@@ -116,7 +116,7 @@ class DistrictSystemTest(TestCaseBase):
 
     def test_build_district_system(self):
         root_path = Path(self.district._scaffold.districts_path.files_dir).resolve()
-        assert ((root_path) / 'DistrictEnergySystem.mo').exists()
+        assert (root_path / 'DistrictEnergySystem.mo').exists()
 
     @pytest.mark.simulation
     def test_simulate_district_system(self):

--- a/tests/model_connectors/test_heated_water_plant.py
+++ b/tests/model_connectors/test_heated_water_plant.py
@@ -98,7 +98,7 @@ class DistrictSystemTest(TestCaseBase):
 
     def test_build_district_system(self):
         root_path = Path(self.district._scaffold.districts_path.files_dir).resolve()
-        assert ((root_path) / 'DistrictEnergySystem.mo').exists()
+        assert (root_path / 'DistrictEnergySystem.mo').exists()
 
     @pytest.mark.simulation
     def test_simulate_district_system(self):

--- a/tests/model_connectors/test_heated_water_plant.py
+++ b/tests/model_connectors/test_heated_water_plant.py
@@ -37,6 +37,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
 import os
+from pathlib import Path
 
 import pytest
 from geojson_modelica_translator.geojson.urbanopt_geojson import (
@@ -64,10 +65,10 @@ from geojson_modelica_translator.system_parameters.system_parameters import (
 from ..base_test_case import TestCaseBase
 
 
-@pytest.mark.simulation
-@pytest.mark.msl_v4_simulation
 class DistrictSystemTest(TestCaseBase):
-    def test_district_system(self):
+    def setUp(self):
+        super().setUp()
+
         project_name = "heated_water_plant_stub"
         self.data_dir, self.output_dir = self.set_up(os.path.dirname(__file__), project_name)
 
@@ -87,15 +88,21 @@ class DistrictSystemTest(TestCaseBase):
             hp_hw_coupling,
         ])
 
-        district = District(
+        self.district = District(
             root_dir=self.output_dir,
             project_name=project_name,
             system_parameters=sys_params,
             coupling_graph=graph
         )
-        district.to_modelica()
+        self.district.to_modelica()
 
-        root_path = os.path.abspath(os.path.join(district._scaffold.districts_path.files_dir))
-        self.run_and_assert_in_docker(os.path.join(root_path, 'DistrictEnergySystem.mo'),
-                                      project_path=district._scaffold.project_path,
-                                      project_name=district._scaffold.project_name)
+    def test_build_district_system(self):
+        root_path = Path(self.district._scaffold.districts_path.files_dir).resolve()
+        assert ((root_path) / 'DistrictEnergySystem.mo').exists()
+
+    @pytest.mark.simulation
+    def test_simulate_district_system(self):
+        root_path = Path(self.district._scaffold.districts_path.files_dir).resolve()
+        self.run_and_assert_in_docker(Path(root_path) / 'DistrictEnergySystem.mo',
+                                      project_path=self.district._scaffold.project_path,
+                                      project_name=self.district._scaffold.project_name)

--- a/tests/model_connectors/test_mixed_loads.py
+++ b/tests/model_connectors/test_mixed_loads.py
@@ -69,9 +69,10 @@ from ..base_test_case import TestCaseBase
 
 
 @pytest.mark.simulation
-@pytest.mark.msl_v4_simulation
 class MixedLoadsTest(TestCaseBase):
     def setUp(self):
+        super().setUp()
+
         self.project_name = 'mixed_loads'
         _, self.output_dir = self.set_up(Path(__file__).parent, self.project_name)
 
@@ -82,7 +83,6 @@ class MixedLoadsTest(TestCaseBase):
         filename = self.SHARED_DATA_DIR / 'mixed_loads_district' / 'system_params.json'
         self.sys_params = SystemParameters(filename)
 
-    def test_mixed_loads_district_energy_system(self):
         # create cooling network and plant
         cooling_network = Network2Pipe(self.sys_params)
         cooling_plant = CoolingPlant(self.sys_params)
@@ -131,15 +131,21 @@ class MixedLoadsTest(TestCaseBase):
         # create the couplings and graph
         graph = CouplingGraph(all_couplings)
 
-        district = District(
+        self.district = District(
             root_dir=self.output_dir,
             project_name=self.project_name,
             system_parameters=self.sys_params,
             coupling_graph=graph
         )
-        district.to_modelica()
+        self.district.to_modelica()
 
-        root_path = Path(district._scaffold.districts_path.files_dir).resolve()
+    def test_build_mixed_loads_district_energy_system(self):
+        root_path = Path(self.district._scaffold.districts_path.files_dir).resolve()
+        assert ((root_path) / 'DistrictEnergySystem.mo').exists()
+
+    @pytest.mark.simulation
+    def test_simulate_mixed_loads_district_energy_system(self):
+        root_path = Path(self.district._scaffold.districts_path.files_dir).resolve()
         self.run_and_assert_in_docker(Path(root_path) / 'DistrictEnergySystem.mo',
-                                      project_path=district._scaffold.project_path,
-                                      project_name=district._scaffold.project_name)
+                                      project_path=self.district._scaffold.project_path,
+                                      project_name=self.district._scaffold.project_name)

--- a/tests/model_connectors/test_mixed_loads.py
+++ b/tests/model_connectors/test_mixed_loads.py
@@ -141,7 +141,7 @@ class MixedLoadsTest(TestCaseBase):
 
     def test_build_mixed_loads_district_energy_system(self):
         root_path = Path(self.district._scaffold.districts_path.files_dir).resolve()
-        assert ((root_path) / 'DistrictEnergySystem.mo').exists()
+        assert (root_path / 'DistrictEnergySystem.mo').exists()
 
     @pytest.mark.simulation
     def test_simulate_mixed_loads_district_energy_system(self):

--- a/tests/model_connectors/test_spawn.py
+++ b/tests/model_connectors/test_spawn.py
@@ -104,7 +104,7 @@ class SpawnModelConnectorSingleBuildingTest(TestCaseBase):
 
     def test_build_spawn_cooling(self):
         root_path = Path(self.district._scaffold.districts_path.files_dir).resolve()
-        assert ((root_path) / 'DistrictEnergySystem.mo').exists()
+        assert (root_path / 'DistrictEnergySystem.mo').exists()
 
     @pytest.mark.simulation
     def test_simulate_spawn_single(self):

--- a/tests/model_connectors/test_spawn.py
+++ b/tests/model_connectors/test_spawn.py
@@ -37,6 +37,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
 import os
+from pathlib import Path
 
 import pytest
 from geojson_modelica_translator.geojson.urbanopt_geojson import (
@@ -67,10 +68,10 @@ from geojson_modelica_translator.system_parameters.system_parameters import (
 from ..base_test_case import TestCaseBase
 
 
-@pytest.mark.simulation
-@pytest.mark.msl_v4_simulation
 class SpawnModelConnectorSingleBuildingTest(TestCaseBase):
-    def test_spawn_single(self):
+    def setUp(self):
+        super().setUp()
+
         project_name = "spawn_single"
         self.data_dir, self.output_dir = self.set_up(os.path.dirname(__file__), project_name)
 
@@ -92,16 +93,22 @@ class SpawnModelConnectorSingleBuildingTest(TestCaseBase):
             Coupling(spawn, cold_stub),
         ])
 
-        district = District(
+        self.district = District(
             root_dir=self.output_dir,
             project_name=project_name,
             system_parameters=sys_params,
             coupling_graph=graph
         )
 
-        district.to_modelica()
+        self.district.to_modelica()
 
-        root_path = os.path.abspath(os.path.join(district._scaffold.districts_path.files_dir))
-        self.run_and_assert_in_docker(os.path.join(root_path, 'DistrictEnergySystem.mo'),
-                                      project_path=district._scaffold.project_path,
-                                      project_name=district._scaffold.project_name)
+    def test_build_spawn_cooling(self):
+        root_path = Path(self.district._scaffold.districts_path.files_dir).resolve()
+        assert ((root_path) / 'DistrictEnergySystem.mo').exists()
+
+    @pytest.mark.simulation
+    def test_simulate_spawn_single(self):
+        root_path = Path(self.district._scaffold.districts_path.files_dir).resolve()
+        self.run_and_assert_in_docker(Path(root_path) / 'DistrictEnergySystem.mo',
+                                      project_path=self.district._scaffold.project_path,
+                                      project_name=self.district._scaffold.project_name)

--- a/tests/model_connectors/test_spawn_cooling.py
+++ b/tests/model_connectors/test_spawn_cooling.py
@@ -119,7 +119,7 @@ class TestSpawnCooling(TestCaseBase):
 
     def test_build_spawn_cooling(self):
         root_path = Path(self.district._scaffold.districts_path.files_dir).resolve()
-        assert ((root_path) / 'DistrictEnergySystem.mo').exists()
+        assert (root_path / 'DistrictEnergySystem.mo').exists()
 
     @pytest.mark.simulation
     def test_simulate_spawn_cooling(self):

--- a/tests/model_connectors/test_spawn_cooling.py
+++ b/tests/model_connectors/test_spawn_cooling.py
@@ -37,6 +37,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
 import os
+from pathlib import Path
 
 import pytest
 from geojson_modelica_translator.geojson.urbanopt_geojson import (
@@ -73,10 +74,10 @@ from geojson_modelica_translator.system_parameters.system_parameters import (
 from ..base_test_case import TestCaseBase
 
 
-@pytest.mark.simulation
-@pytest.mark.msl_v4_simulation
 class TestSpawnCooling(TestCaseBase):
-    def test_spawn_cooling(self):
+    def setUp(self):
+        super().setUp()
+
         project_name = 'spawn_district_cooling'
         self.data_dir, self.output_dir = self.set_up(os.path.dirname(__file__), project_name)
 
@@ -108,15 +109,21 @@ class TestSpawnCooling(TestCaseBase):
         # create the couplings and graph
         graph = CouplingGraph(all_couplings)
 
-        district = District(
+        self.district = District(
             root_dir=self.output_dir,
             project_name=project_name,
             system_parameters=sys_params,
             coupling_graph=graph
         )
-        district.to_modelica()
+        self.district.to_modelica()
 
-        root_path = os.path.abspath(os.path.join(district._scaffold.districts_path.files_dir))
-        self.run_and_assert_in_docker(os.path.join(root_path, 'DistrictEnergySystem.mo'),
-                                      project_path=district._scaffold.project_path,
-                                      project_name=district._scaffold.project_name)
+    def test_build_spawn_cooling(self):
+        root_path = Path(self.district._scaffold.districts_path.files_dir).resolve()
+        assert ((root_path) / 'DistrictEnergySystem.mo').exists()
+
+    @pytest.mark.simulation
+    def test_simulate_spawn_cooling(self):
+        root_path = Path(self.district._scaffold.districts_path.files_dir).resolve()
+        self.run_and_assert_in_docker(Path(root_path) / 'DistrictEnergySystem.mo',
+                                      project_path=self.district._scaffold.project_path,
+                                      project_name=self.district._scaffold.project_name)

--- a/tests/model_connectors/test_spawn_district_heating_and_cooling_systems.py
+++ b/tests/model_connectors/test_spawn_district_heating_and_cooling_systems.py
@@ -124,7 +124,7 @@ class DistrictHeatingAndCoolingSystemsTest(TestCaseBase):
 
     def test_build_spawn_cooling(self):
         root_path = Path(self.district._scaffold.districts_path.files_dir).resolve()
-        assert ((root_path) / 'DistrictEnergySystem.mo').exists()
+        assert (root_path / 'DistrictEnergySystem.mo').exists()
 
     @pytest.mark.simulation
     def test_simulate_spawn_district_heating_and_cooling_systems(self):

--- a/tests/model_connectors/test_spawn_heating.py
+++ b/tests/model_connectors/test_spawn_heating.py
@@ -119,7 +119,7 @@ class TestSpawnHeating(TestCaseBase):
 
     def test_build_spawn_cooling(self):
         root_path = Path(self.district._scaffold.districts_path.files_dir).resolve()
-        assert ((root_path) / 'DistrictEnergySystem.mo').exists()
+        assert (root_path / 'DistrictEnergySystem.mo').exists()
 
     @pytest.mark.simulation
     def test_simulate_spawn_heating(self):

--- a/tests/model_connectors/test_spawn_heating.py
+++ b/tests/model_connectors/test_spawn_heating.py
@@ -37,6 +37,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
 import os
+from pathlib import Path
 
 import pytest
 from geojson_modelica_translator.geojson.urbanopt_geojson import (
@@ -73,10 +74,10 @@ from geojson_modelica_translator.system_parameters.system_parameters import (
 from ..base_test_case import TestCaseBase
 
 
-@pytest.mark.simulation
-@pytest.mark.msl_v4_simulation
 class TestSpawnHeating(TestCaseBase):
-    def test_spawn_heating(self):
+    def setUp(self):
+        super().setUp()
+
         project_name = 'spawn_district_heating'
         self.data_dir, self.output_dir = self.set_up(os.path.dirname(__file__), project_name)
 
@@ -108,15 +109,21 @@ class TestSpawnHeating(TestCaseBase):
         # create the couplings and graph
         graph = CouplingGraph(all_couplings)
 
-        district = District(
+        self.district = District(
             root_dir=self.output_dir,
             project_name=project_name,
             system_parameters=sys_params,
             coupling_graph=graph
         )
-        district.to_modelica()
+        self.district.to_modelica()
 
-        root_path = os.path.abspath(os.path.join(district._scaffold.districts_path.files_dir))
-        self.run_and_assert_in_docker(os.path.join(root_path, 'DistrictEnergySystem.mo'),
-                                      project_path=district._scaffold.project_path,
-                                      project_name=district._scaffold.project_name)
+    def test_build_spawn_cooling(self):
+        root_path = Path(self.district._scaffold.districts_path.files_dir).resolve()
+        assert ((root_path) / 'DistrictEnergySystem.mo').exists()
+
+    @pytest.mark.simulation
+    def test_simulate_spawn_heating(self):
+        root_path = Path(self.district._scaffold.districts_path.files_dir).resolve()
+        self.run_and_assert_in_docker(Path(root_path) / 'DistrictEnergySystem.mo',
+                                      project_path=self.district._scaffold.project_path,
+                                      project_name=self.district._scaffold.project_name)

--- a/tests/model_connectors/test_teaser.py
+++ b/tests/model_connectors/test_teaser.py
@@ -109,6 +109,6 @@ class TeaserModelConnectorSingleBuildingTest(TestCaseBase):
     @pytest.mark.simulation
     def test_simulate_teaser_single(self):
         root_path = Path(self.district._scaffold.districts_path.files_dir).resolve()
-        self.run_and_assert_in_docker(Path(root_path) / 'DistrictEnergySystem.mo',
+        self.run_and_assert_in_docker(root_path / 'DistrictEnergySystem.mo',
                                       project_path=self.district._scaffold.project_path,
                                       project_name=self.district._scaffold.project_name)

--- a/tests/model_connectors/test_teaser.py
+++ b/tests/model_connectors/test_teaser.py
@@ -37,6 +37,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
 import os
+from pathlib import Path
 
 import pytest
 from geojson_modelica_translator.geojson.urbanopt_geojson import (
@@ -67,10 +68,10 @@ from geojson_modelica_translator.system_parameters.system_parameters import (
 from ..base_test_case import TestCaseBase
 
 
-@pytest.mark.simulation
-@pytest.mark.msl_v4_simulation
 class TeaserModelConnectorSingleBuildingTest(TestCaseBase):
-    def test_teaser_single(self):
+    def setUp(self):
+        super().setUp()
+
         project_name = "teaser_single"
         self.data_dir, self.output_dir = self.set_up(os.path.dirname(__file__), project_name)
 
@@ -92,16 +93,22 @@ class TeaserModelConnectorSingleBuildingTest(TestCaseBase):
             Coupling(teaser, cold_stub),
         ])
 
-        district = District(
+        self.district = District(
             root_dir=self.output_dir,
             project_name=project_name,
             system_parameters=sys_params,
             coupling_graph=graph
         )
 
-        district.to_modelica()
+        self.district.to_modelica()
 
-        root_path = os.path.abspath(os.path.join(district._scaffold.districts_path.files_dir))
-        self.run_and_assert_in_docker(os.path.join(root_path, 'DistrictEnergySystem.mo'),
-                                      project_path=district._scaffold.project_path,
-                                      project_name=district._scaffold.project_name)
+    def test_build_teaser_single(self):
+        root_path = Path(self.district._scaffold.districts_path.files_dir).resolve()
+        assert ((root_path) / 'DistrictEnergySystem.mo').exists()
+
+    @pytest.mark.simulation
+    def test_simulate_teaser_single(self):
+        root_path = Path(self.district._scaffold.districts_path.files_dir).resolve()
+        self.run_and_assert_in_docker(Path(root_path) / 'DistrictEnergySystem.mo',
+                                      project_path=self.district._scaffold.project_path,
+                                      project_name=self.district._scaffold.project_name)

--- a/tests/model_connectors/test_teaser.py
+++ b/tests/model_connectors/test_teaser.py
@@ -104,7 +104,7 @@ class TeaserModelConnectorSingleBuildingTest(TestCaseBase):
 
     def test_build_teaser_single(self):
         root_path = Path(self.district._scaffold.districts_path.files_dir).resolve()
-        assert ((root_path) / 'DistrictEnergySystem.mo').exists()
+        assert (root_path / 'DistrictEnergySystem.mo').exists()
 
     @pytest.mark.simulation
     def test_simulate_teaser_single(self):

--- a/tests/model_connectors/test_teaser_cooling.py
+++ b/tests/model_connectors/test_teaser_cooling.py
@@ -119,7 +119,7 @@ class TestTeaserCooling(TestCaseBase):
 
     def test_simulate_teaser_cooling(self):
         root_path = Path(self.district._scaffold.districts_path.files_dir).resolve()
-        assert ((root_path) / 'DistrictEnergySystem.mo').exists()
+        assert (root_path / 'DistrictEnergySystem.mo').exists()
 
     @pytest.mark.simulation
     def test_build_teaser_cooling(self):

--- a/tests/model_connectors/test_teaser_cooling.py
+++ b/tests/model_connectors/test_teaser_cooling.py
@@ -37,6 +37,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
 import os
+from pathlib import Path
 
 import pytest
 from geojson_modelica_translator.geojson.urbanopt_geojson import (
@@ -73,10 +74,10 @@ from geojson_modelica_translator.system_parameters.system_parameters import (
 from ..base_test_case import TestCaseBase
 
 
-@pytest.mark.simulation
-@pytest.mark.msl_v4_simulation
 class TestTeaserCooling(TestCaseBase):
-    def test_teaser_cooling(self):
+    def setUp(self):
+        super().setUp()
+
         project_name = 'teaser_district_cooling'
         self.data_dir, self.output_dir = self.set_up(os.path.dirname(__file__), project_name)
 
@@ -108,15 +109,21 @@ class TestTeaserCooling(TestCaseBase):
         # create the couplings and graph
         graph = CouplingGraph(all_couplings)
 
-        district = District(
+        self.district = District(
             root_dir=self.output_dir,
             project_name=project_name,
             system_parameters=sys_params,
             coupling_graph=graph
         )
-        district.to_modelica()
+        self.district.to_modelica()
 
-        root_path = os.path.abspath(os.path.join(district._scaffold.districts_path.files_dir))
-        self.run_and_assert_in_docker(os.path.join(root_path, 'DistrictEnergySystem.mo'),
-                                      project_path=district._scaffold.project_path,
-                                      project_name=district._scaffold.project_name)
+    def test_simulate_teaser_cooling(self):
+        root_path = Path(self.district._scaffold.districts_path.files_dir).resolve()
+        assert ((root_path) / 'DistrictEnergySystem.mo').exists()
+
+    @pytest.mark.simulation
+    def test_build_teaser_cooling(self):
+        root_path = Path(self.district._scaffold.districts_path.files_dir).resolve()
+        self.run_and_assert_in_docker(Path(root_path) / 'DistrictEnergySystem.mo',
+                                      project_path=self.district._scaffold.project_path,
+                                      project_name=self.district._scaffold.project_name)

--- a/tests/model_connectors/test_teaser_district_heating_and_cooling_systems.py
+++ b/tests/model_connectors/test_teaser_district_heating_and_cooling_systems.py
@@ -126,7 +126,7 @@ class TestTeaserDistrictHeatingAndCoolingSystems(TestCaseBase):
 
     def test_build_teaser_district_heating_and_cooling_systems(self):
         root_path = Path(self.district._scaffold.districts_path.files_dir).resolve()
-        assert ((root_path) / 'DistrictEnergySystem.mo').exists()
+        assert (root_path / 'DistrictEnergySystem.mo').exists()
 
     @pytest.mark.simulation
     def test_teaser_district_heating_and_cooling_systems(self):

--- a/tests/model_connectors/test_teaser_district_heating_and_cooling_systems.py
+++ b/tests/model_connectors/test_teaser_district_heating_and_cooling_systems.py
@@ -65,10 +65,10 @@ from geojson_modelica_translator.system_parameters.system_parameters import (
 from ..base_test_case import TestCaseBase
 
 
-@pytest.mark.simulation
-@pytest.mark.msl_v4_simulation
 class TestTeaserDistrictHeatingAndCoolingSystems(TestCaseBase):
     def setUp(self):
+        super().setUp()
+
         self.project_name = 'teaser_district_heating_and_cooling_systems'
         self.data_dir, self.output_dir = self.set_up(Path(__file__).parent, self.project_name)
 
@@ -79,7 +79,6 @@ class TestTeaserDistrictHeatingAndCoolingSystems(TestCaseBase):
         filename = Path(self.data_dir) / "teaser_system_params_two_loads.json"
         self.sys_params = SystemParameters(filename)
 
-    def test_teaser_district_heating_and_cooling_systems(self):
         # create cooling network and plant
         cooling_network = Network2Pipe(self.sys_params)
         cooling_plant = CoolingPlant(self.sys_params)
@@ -96,12 +95,12 @@ class TestTeaserDistrictHeatingAndCoolingSystems(TestCaseBase):
         ]
 
         # keep track of separate loads and etses for testing purposes
-        loads = []
+        self.loads = []
         heat_etses = []
         cool_etses = []
         for geojson_load in self.gj.buildings:
             teaser_load = Teaser(self.sys_params, geojson_load)
-            loads.append(teaser_load)
+            self.loads.append(teaser_load)
             geojson_load_id = geojson_load.feature.properties["id"]
 
             cooling_indirect = CoolingIndirect(self.sys_params, geojson_load_id)
@@ -117,28 +116,33 @@ class TestTeaserDistrictHeatingAndCoolingSystems(TestCaseBase):
         # create the couplings and graph
         graph = CouplingGraph(all_couplings)
 
-        district = District(
+        self.district = District(
             root_dir=self.output_dir,
             project_name=self.project_name,
             system_parameters=self.sys_params,
             coupling_graph=graph
         )
-        district.to_modelica()
+        self.district.to_modelica()
 
-        root_path = Path(district._scaffold.districts_path.files_dir).resolve()
+    def test_build_teaser_district_heating_and_cooling_systems(self):
+        root_path = Path(self.district._scaffold.districts_path.files_dir).resolve()
+        assert ((root_path) / 'DistrictEnergySystem.mo').exists()
+
+    @pytest.mark.simulation
+    def test_teaser_district_heating_and_cooling_systems(self):
+        root_path = Path(self.district._scaffold.districts_path.files_dir).resolve()
         self.run_and_assert_in_docker(Path(root_path) / 'DistrictEnergySystem.mo',
-                                      project_path=district._scaffold.project_path,
-                                      project_name=district._scaffold.project_name)
-
+                                      project_path=self.district._scaffold.project_path,
+                                      project_name=self.district._scaffold.project_name)
         #
         # Validate model outputs
         #
-        results_dir = f'{district._scaffold.project_path}_results'
+        results_dir = f'{self.district._scaffold.project_path}_results'
         mat_file = f'{results_dir}/{self.project_name}_Districts_DistrictEnergySystem_result.mat'
         mat_results = Reader(mat_file, 'dymola')
 
         # check the mass flow rates of the first load are in the expected range
-        load = loads[0]
+        load = self.loads[0]
         (_, heat_m_flow) = mat_results.values(f'{load.id}.ports_aHeaWat[1].m_flow')
         (_, cool_m_flow) = mat_results.values(f'{load.id}.ports_aChiWat[1].m_flow')
         self.assertTrue((heat_m_flow >= 0).all(), 'Heating mass flow rate must be greater than or equal to zero')

--- a/tests/model_connectors/test_teaser_heating.py
+++ b/tests/model_connectors/test_teaser_heating.py
@@ -37,6 +37,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
 import os
+from pathlib import Path
 
 import pytest
 from geojson_modelica_translator.geojson.urbanopt_geojson import (
@@ -73,10 +74,10 @@ from geojson_modelica_translator.system_parameters.system_parameters import (
 from ..base_test_case import TestCaseBase
 
 
-@pytest.mark.simulation
-@pytest.mark.msl_v4_simulation
 class TestTeaserHeating(TestCaseBase):
-    def test_Teaser_heating(self):
+    def setUp(self):
+        super().setUp()
+
         project_name = 'teaser_district_heating'
         self.data_dir, self.output_dir = self.set_up(os.path.dirname(__file__), project_name)
 
@@ -108,15 +109,21 @@ class TestTeaserHeating(TestCaseBase):
         # create the couplings and graph
         graph = CouplingGraph(all_couplings)
 
-        district = District(
+        self.district = District(
             root_dir=self.output_dir,
             project_name=project_name,
             system_parameters=sys_params,
             coupling_graph=graph
         )
-        district.to_modelica()
+        self.district.to_modelica()
 
-        root_path = os.path.abspath(os.path.join(district._scaffold.districts_path.files_dir))
-        self.run_and_assert_in_docker(os.path.join(root_path, 'DistrictEnergySystem.mo'),
-                                      project_path=district._scaffold.project_path,
-                                      project_name=district._scaffold.project_name)
+    def test_build_teaser_heating(self):
+        root_path = Path(self.district._scaffold.districts_path.files_dir).resolve()
+        assert ((root_path) / 'DistrictEnergySystem.mo').exists()
+
+    @pytest.mark.simulation
+    def test_simulate_teaser_heating(self):
+        root_path = Path(self.district._scaffold.districts_path.files_dir).resolve()
+        self.run_and_assert_in_docker(Path(root_path) / 'DistrictEnergySystem.mo',
+                                      project_path=self.district._scaffold.project_path,
+                                      project_name=self.district._scaffold.project_name)

--- a/tests/model_connectors/test_teaser_heating.py
+++ b/tests/model_connectors/test_teaser_heating.py
@@ -119,7 +119,7 @@ class TestTeaserHeating(TestCaseBase):
 
     def test_build_teaser_heating(self):
         root_path = Path(self.district._scaffold.districts_path.files_dir).resolve()
-        assert ((root_path) / 'DistrictEnergySystem.mo').exists()
+        assert (root_path / 'DistrictEnergySystem.mo').exists()
 
     @pytest.mark.simulation
     def test_simulate_teaser_heating(self):

--- a/tests/model_connectors/test_time_series.py
+++ b/tests/model_connectors/test_time_series.py
@@ -54,10 +54,10 @@ from geojson_modelica_translator.system_parameters.system_parameters import (
 from ..base_test_case import TestCaseBase
 
 
-@pytest.mark.simulation
-@pytest.mark.msl_v4_simulation
 class TimeSeriesModelConnectorSingleBuildingTest(TestCaseBase):
-    def test_no_ets_and_run(self):
+    def setUp(self):
+        super().setUp()
+
         project_name = "time_series_no_ets"
         self.data_dir, self.output_dir = self.set_up(os.path.dirname(__file__), project_name)
 
@@ -65,9 +65,10 @@ class TimeSeriesModelConnectorSingleBuildingTest(TestCaseBase):
         filename = os.path.join(self.data_dir, "time_series_ex1.json")
         self.gj = UrbanOptGeoJson(filename)
         # scaffold the project ourselves
-        scaffold = Scaffold(self.output_dir, project_name)
-        scaffold.create()
+        self.scaffold = Scaffold(self.output_dir, project_name)
+        self.scaffold.create()
 
+    def test_build_model(self):
         # load system parameter data
         filename = os.path.join(self.data_dir, "time_series_system_params_no_ets.json")
         sys_params = SystemParameters(filename)
@@ -82,19 +83,48 @@ class TimeSeriesModelConnectorSingleBuildingTest(TestCaseBase):
 
         # currently we must setup the root project before we can run to_modelica
         package = PackageParser.new_from_template(
-            scaffold.project_path, scaffold.project_name, order=[])
+            self.scaffold.project_path, self.scaffold.project_name, order=[])
         package.save()
-        self.time_series.to_modelica(scaffold)
+        self.time_series.to_modelica(self.scaffold)
 
-        root_path = os.path.abspath(os.path.join(scaffold.loads_path.files_dir, 'B5a6b99ec37f4de7f94020090'))
+        self.root_path = os.path.abspath(os.path.join(self.scaffold.loads_path.files_dir, 'B5a6b99ec37f4de7f94020090'))
         files = [
-            os.path.join(root_path, 'building.mo'),
+            os.path.join(self.root_path, 'building.mo'),
         ]
 
         # verify that there are only 2 files that matter (coupling and building)
         for file in files:
             self.assertTrue(os.path.exists(file), f"File does not exist: {file}")
 
-        self.run_and_assert_in_docker(os.path.join(root_path, 'building.mo'),
-                                      project_path=scaffold.project_path,
-                                      project_name=scaffold.project_name)
+    @pytest.mark.simulation
+    def test_build_and_simulate_no_ets(self):
+        # load system parameter data
+        filename = os.path.join(self.data_dir, "time_series_system_params_no_ets.json")
+        sys_params = SystemParameters(filename)
+
+        # now test the connector (independent of the larger geojson translator)
+        self.time_series = TimeSeries(sys_params, self.gj.buildings[0])
+
+        self.assertIsNotNone(self.time_series)
+        self.assertIsNotNone(self.time_series.building)
+        self.assertEqual("time_series",
+                         self.time_series.system_parameters.get_param("buildings.custom")[0]["load_model"])
+
+        # currently we must setup the root project before we can run to_modelica
+        package = PackageParser.new_from_template(
+            self.scaffold.project_path, self.scaffold.project_name, order=[])
+        package.save()
+        self.time_series.to_modelica(self.scaffold)
+
+        self.root_path = os.path.abspath(os.path.join(self.scaffold.loads_path.files_dir, 'B5a6b99ec37f4de7f94020090'))
+        files = [
+            os.path.join(self.root_path, 'building.mo'),
+        ]
+
+        # verify that there are only 2 files that matter (coupling and building)
+        for file in files:
+            self.assertTrue(os.path.exists(file), f"File does not exist: {file}")
+
+        self.run_and_assert_in_docker(os.path.join(self.root_path, 'building.mo'),
+                                      project_path=self.scaffold.project_path,
+                                      project_name=self.scaffold.project_name)

--- a/tests/model_connectors/test_time_series_heating_indirect.py
+++ b/tests/model_connectors/test_time_series_heating_indirect.py
@@ -118,7 +118,7 @@ class DistrictSystemTest(TestCaseBase):
 
     def test_build_district_system(self):
         root_path = Path(self.district._scaffold.districts_path.files_dir).resolve()
-        assert ((root_path) / 'DistrictEnergySystem.mo').exists()
+        assert (root_path / 'DistrictEnergySystem.mo').exists()
 
     @pytest.mark.simulation
     def test_simulate_district_system(self):

--- a/tests/model_connectors/test_time_series_heating_indirect.py
+++ b/tests/model_connectors/test_time_series_heating_indirect.py
@@ -37,6 +37,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
 import os
+from pathlib import Path
 
 import pytest
 from geojson_modelica_translator.geojson.urbanopt_geojson import (
@@ -70,10 +71,10 @@ from geojson_modelica_translator.system_parameters.system_parameters import (
 from ..base_test_case import TestCaseBase
 
 
-@pytest.mark.simulation
-@pytest.mark.msl_v4_simulation
 class DistrictSystemTest(TestCaseBase):
-    def test_district_system(self):
+    def setUp(self):
+        super().setUp()
+
         project_name = "time_series_heating_indirect"
         self.data_dir, self.output_dir = self.set_up(os.path.dirname(__file__), project_name)
 
@@ -106,15 +107,22 @@ class DistrictSystemTest(TestCaseBase):
             ts_cw_coupling,
         ])
 
-        district = District(
+        self.district = District(
             root_dir=self.output_dir,
             project_name=project_name,
             system_parameters=sys_params,
             coupling_graph=graph
         )
-        district.to_modelica()
 
-        root_path = os.path.abspath(os.path.join(district._scaffold.districts_path.files_dir))
-        self.run_and_assert_in_docker(os.path.join(root_path, 'DistrictEnergySystem.mo'),
-                                      project_path=district._scaffold.project_path,
-                                      project_name=district._scaffold.project_name)
+        self.district.to_modelica()
+
+    def test_build_district_system(self):
+        root_path = Path(self.district._scaffold.districts_path.files_dir).resolve()
+        assert ((root_path) / 'DistrictEnergySystem.mo').exists()
+
+    @pytest.mark.simulation
+    def test_simulate_district_system(self):
+        root_path = Path(self.district._scaffold.districts_path.files_dir).resolve()
+        self.run_and_assert_in_docker(Path(root_path) / 'DistrictEnergySystem.mo',
+                                      project_path=self.district._scaffold.project_path,
+                                      project_name=self.district._scaffold.project_name)

--- a/tests/model_connectors/test_time_series_mft_ets.py
+++ b/tests/model_connectors/test_time_series_mft_ets.py
@@ -121,7 +121,7 @@ class TimeSeriesModelConnectorSingleBuildingMFTETSTest(TestCaseBase):
 
     def test_build_district_system(self):
         root_path = Path(self.district._scaffold.districts_path.files_dir).resolve()
-        assert ((root_path) / 'DistrictEnergySystem.mo').exists()
+        assert (root_path / 'DistrictEnergySystem.mo').exists()
 
     @pytest.mark.simulation
     def test_mft_time_series_to_modelica_and_run(self):

--- a/tests/model_connectors/test_time_series_mft_ets.py
+++ b/tests/model_connectors/test_time_series_mft_ets.py
@@ -38,6 +38,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import os
 import re
+from pathlib import Path
 
 import pytest
 from buildingspy.io.outputfile import Reader
@@ -72,10 +73,10 @@ from modelica_builder.model import Model
 from ..base_test_case import TestCaseBase
 
 
-@pytest.mark.simulation
-@pytest.mark.msl_v4_simulation
 class TimeSeriesModelConnectorSingleBuildingMFTETSTest(TestCaseBase):
-    def test_mft_time_series_to_modelica_and_run(self):
+    def setUp(self):
+        super().setUp()
+
         project_name = "time_series_massflow"
         self.data_dir, self.output_dir = self.set_up(os.path.dirname(__file__), project_name)
 
@@ -105,7 +106,7 @@ class TimeSeriesModelConnectorSingleBuildingMFTETSTest(TestCaseBase):
         ci_cw_coupling = Coupling(cooling_indirect_system, chilled_water_stub)
 
         # build the district system
-        district = District(
+        self.district = District(
             root_dir=self.output_dir,
             project_name=project_name,
             system_parameters=sys_params,
@@ -116,20 +117,26 @@ class TimeSeriesModelConnectorSingleBuildingMFTETSTest(TestCaseBase):
                 ci_cw_coupling,
             ])
         )
-        district.to_modelica()
+        self.district.to_modelica()
 
-        root_path = os.path.abspath(os.path.join(district._scaffold.districts_path.files_dir))
-        mo_file_name = os.path.join(root_path, 'DistrictEnergySystem.mo')
+    def test_build_district_system(self):
+        root_path = Path(self.district._scaffold.districts_path.files_dir).resolve()
+        assert ((root_path) / 'DistrictEnergySystem.mo').exists()
+
+    @pytest.mark.simulation
+    def test_mft_time_series_to_modelica_and_run(self):
+        root_path = Path(self.district._scaffold.districts_path.files_dir).resolve()
+        mo_file_name = Path(root_path) / 'DistrictEnergySystem.mo'
         # set the run time to 31536000 (full year in seconds)
         mofile = Model(mo_file_name)
         mofile.update_model_annotation({"experiment": {"StopTime": 31536000}})
         mofile.save()
         self.run_and_assert_in_docker(mo_file_name,
-                                      project_path=district._scaffold.project_path,
-                                      project_name=district._scaffold.project_name)
+                                      project_path=self.district._scaffold.project_path,
+                                      project_name=self.district._scaffold.project_name)
 
         # Check the results
-        results_dir = f'{district._scaffold.project_path}_results'
+        results_dir = f'{self.district._scaffold.project_path}_results'
         mat_file = f'{results_dir}/time_series_massflow_Districts_DistrictEnergySystem_result.mat'
         mat_results = Reader(mat_file, 'dymola')
 


### PR DESCRIPTION
#### Any background context you want to provide?
Current tests rely on building and simulating the models in a single test method.

#### What does this PR accomplish?
* Move the model assembly into the Test SetUp, then check the results in a build test
* Simulate the generated model if not marked as `not simulation`
* remove old pytest markers of `msl_v4` and `mbl_v9`
* remove testing with `issue2204_gmt_mbl` branch

#### How should this be manually tested?
* if tests pass, then should be good!

#### What are the relevant tickets?
n/a
#### Screenshots (if appropriate)
