### PR TITLE
automate canceling existing CI if a new one starts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ defaults:
     shell: bash
 
 # Cancel existing run if a new one is started
-concurrency: 
+concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,11 @@ defaults:
   run:
     shell: bash
 
+# Cancel existing run if a new one is started
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     strategy:


### PR DESCRIPTION
#### Any background context you want to provide?
I often push commits and promptly realize I need to add something more. Then I end up with CI running on something I know is outdated or destined to fail. It's inefficient.
#### What does this PR accomplish?
Automatically cancels an existing CI run of the same workflow when a new one is started. Only test the newest version!
#### How should this be manually tested?
Intentionally have poor form in your pushes?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
