### PR TITLE
Cli less brittle

### DIFF
--- a/geojson_modelica_translator/system_parameters/system_parameters.py
+++ b/geojson_modelica_translator/system_parameters/system_parameters.py
@@ -822,9 +822,10 @@ class SystemParameters(object):
                     building['load_model_parameters']['time_series']['filepath'] = str(measure_file_path.resolve())
                 if (measure_file_path.suffix == '.csv') and ('_export_time_series_modelica' in str(measure_folder_name)):
                     mfrt_df = pd.read_csv(measure_file_path)
-                    building_nominal_mfrt = mfrt_df['massFlowRateHeating'].max().round(3)
-                    building['ets_model_parameters']['indirect']['nominal_mass_flow_building'] = float(
-                        building_nominal_mfrt)
+                    if 'massFlowRateHeating' in mfrt_df.columns:
+                        building_nominal_mfrt = mfrt_df['massFlowRateHeating'].max().round(3)
+                        building['ets_model_parameters']['indirect']['nominal_mass_flow_building'] = float(
+                            building_nominal_mfrt)
                 district_nominal_mfrt += building_nominal_mfrt
 
         # Remove template buildings that weren't used or don't have successful simulations with modelica outputs

--- a/geojson_modelica_translator/system_parameters/system_parameters.py
+++ b/geojson_modelica_translator/system_parameters/system_parameters.py
@@ -822,10 +822,14 @@ class SystemParameters(object):
                     building['load_model_parameters']['time_series']['filepath'] = str(measure_file_path.resolve())
                 if (measure_file_path.suffix == '.csv') and ('_export_time_series_modelica' in str(measure_folder_name)):
                     mfrt_df = pd.read_csv(measure_file_path)
-                    if 'massFlowRateHeating' in mfrt_df.columns:
+                    try:
                         building_nominal_mfrt = mfrt_df['massFlowRateHeating'].max().round(3)
                         building['ets_model_parameters']['indirect']['nominal_mass_flow_building'] = float(
                             building_nominal_mfrt)
+                    except KeyError:
+                        # If massFlowRateHeating is not in the export_time_series_modelica output, just skip this step.
+                        # It probably won't be in the export for hpxml residential buildings, at least as of 2022-06-29
+                        continue
                 district_nominal_mfrt += building_nominal_mfrt
 
         # Remove template buildings that weren't used or don't have successful simulations with modelica outputs


### PR DESCRIPTION
#### Any background context you want to provide?
UO SDK can send residential buildings in the geojson feature file. The `export_time_series_modelica` measure returns reduced output with residential buildings, some of which the `build-sys-params` cli command was expecting.
#### What does this PR accomplish?
If the `massFlowRateHeating` column is not present in the `export_time_series_modelica` output, it's ok, just skip it!
#### How should this be manually tested?
- Create an sdk project with the --combined flag, and run the simulations.
- Run `uo_des build-sys-params` using that project.
- Observe how sad develop branch is when doing this (to replicate the issue), and how nonchalant this branch is (to prove the problem has been solutioned).
#### What are the relevant tickets?
This was first detected in the SDK CLI: https://github.com/urbanopt/urbanopt-cli/pull/360
