### PR TITLE
Weather file at top level

### DIFF
--- a/geojson_modelica_translator/model_connectors/load_connectors/spawn.py
+++ b/geojson_modelica_translator/model_connectors/load_connectors/spawn.py
@@ -75,17 +75,16 @@ class Spawn(LoadBase):
             self.building_name, scaffold.loads_path.files_dir, True
         )
 
+        mos_weather_filename = self.system_parameters.get_param("$.weather")
+        epw_filename = os.path.splitext(mos_weather_filename)[0] + '.epw'
+        # This assumes the epw and mos files are named the same and in the same directory.
+        # If coming from the SDK, this is a safe assumption.
+
         # grab the data from the system_parameter file for this building id
-        # TODO: create method in system_parameter class to make this easier and respect the defaults
+        # TODO: create method in system_parameter class to make this easier
 
         idf_filename = self.system_parameters.get_param_by_building_id(
             self.building_id, "load_model_parameters.spawn.idf_filename"
-        )
-        epw_filename = self.system_parameters.get_param_by_building_id(
-            self.building_id, "load_model_parameters.spawn.epw_filename"
-        )
-        mos_weather_filename = self.system_parameters.get_param_by_building_id(
-            self.building_id, "load_model_parameters.spawn.mos_weather_filename",
         )
         thermal_zones = self.system_parameters.get_param_by_building_id(
             self.building_id, "load_model_parameters.spawn.thermal_zone_names",

--- a/geojson_modelica_translator/model_connectors/load_connectors/teaser.py
+++ b/geojson_modelica_translator/model_connectors/load_connectors/teaser.py
@@ -206,8 +206,7 @@ class Teaser(LoadBase):
         # Need to investigate moving this into a more testable location.
         # create a list of strings that we need to replace in all the file as we go along
         string_replace_list = []
-        mos_weather_filename = self.system_parameters.get_param_by_building_id(
-            self.building_id, "load_model_parameters.rc.mos_weather_filename")
+        mos_weather_filename = self.system_parameters.get_param("$.weather")
         # create a new modelica based path for the buildings # TODO: make this work at the toplevel, somehow.
         b_modelica_path = ModelicaPath(self.building_name, scaffold.loads_path.files_dir, True)
 

--- a/geojson_modelica_translator/model_connectors/plants/cooling_plant.py
+++ b/geojson_modelica_translator/model_connectors/plants/cooling_plant.py
@@ -65,9 +65,7 @@ class CoolingPlant(PlantBase):
 
         :param scaffold: Scaffold object, Scaffold of the entire directory of the project.
         """
-        weather_filepath = Path(self.system_parameters.get_param(
-            "$.district_system.fourth_generation.central_cooling_plant_parameters.weather_filepath"
-        ))
+        weather_filepath = Path(self.system_parameters.get_param("$.weather"))
 
         # verify that the weather file exists
         if not weather_filepath.exists():

--- a/geojson_modelica_translator/system_parameters/schema.json
+++ b/geojson_modelica_translator/system_parameters/schema.json
@@ -29,6 +29,10 @@
             }
           ]
         },
+        "weather": {
+          "description": "Path, relative or absolute, to a weather file for the district",
+          "type": "string"
+        },
         "topology": {
           "title": "defaults",
           "description": "[unused] Parameters associated with district topologies.",
@@ -155,7 +159,10 @@
           }
         }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "required": [
+        "weather"
+      ]
     },
     "topology_def": {
       "title": "defaults",
@@ -534,18 +541,6 @@
           "description": "Absolute path or relative path from location where file instance is saved.",
           "type": "string"
         },
-        "epw_filename": {
-          "description": "Absolute path or relative path from location where file instance is saved.",
-          "type": "string"
-        },
-        "mos_weather_filename": {
-          "description": "Relative path from location where file instance is saved to the MOS weather file.",
-          "type": "string"
-        },
-        "weather_filepath": {
-          "description": "Absolute path or relative path from location where file instance is saved to the weather filename. This is needed for the central cooling plants.",
-          "type": "string"
-        },
         "thermal_zone_names": {
           "description": "List of thermal zones in the Spawn / EnergyPlus model.",
           "type": "array",
@@ -576,8 +571,6 @@
         "temp_chw_supply",
         "temp_chw_return",
         "idf_filename",
-        "epw_filename",
-        "mos_weather_filename",
         "thermal_zone_names",
         "zone_nom_htg_loads",
         "zone_nom_clg_loads"
@@ -648,10 +641,6 @@
           ],
           "default": 2
         },
-        "mos_weather_filename": {
-          "description": "Relative path from location where file instance is saved to the MOS weather file.",
-          "type": "string"
-        },
         "fraction_latent_person": {
           "description": "Fraction latent of sensible persons load (e.g., 0.8 = home, 1.25 = office).",
           "type": "number",
@@ -662,7 +651,6 @@
         "temp_setpoint_cooling",
         "temp_setpoint_heating",
         "temp_hw_supply",
-        "mos_weather_filename",
         "fraction_latent_person"
       ],
       "additionalProperties": false
@@ -838,10 +826,6 @@
           "description": "To be defined",
           "type": "number",
           "default": 0.625
-        },
-        "weather_filepath": {
-          "description": "Filename for weather file",
-          "type": "string"
         }
       },
       "required": [

--- a/geojson_modelica_translator/system_parameters/system_parameters.py
+++ b/geojson_modelica_translator/system_parameters/system_parameters.py
@@ -67,7 +67,7 @@ class SystemParameters(object):
         {"json_path": "$.buildings[?load_model=rc].load_model_parameters.rc.mos_weather_filename"},
         {"json_path": "$.buildings[?load_model=time_series].load_model_parameters.time_series.filepath"},
         {"json_path": "$.buildings[?load_model=time_series_massflow_temperature].load_model_parameters.time_series.filepath"},
-        {"json_path": "$.district_system.fourth_generation.central_cooling_plant_parameters.weather_filepath"},
+        {"json_path": "$.weather"},
         {"json_path": "$.combined_heat_and_power_systems.[*].performance_data_path"}
     ]
 
@@ -842,8 +842,7 @@ class SystemParameters(object):
 
         # Update district sys-param settings
         # Parens are to allow the line break
-        (self.param_template['district_system']['fourth_generation']
-            ['central_cooling_plant_parameters']['weather_filepath']) = str(weather_path)
+        self.param_template['weather'] = str(weather_path)
         if microgrid and not feature_opt_file.exists():
             logger.warn("Microgrid requires OpenDSS and REopt feature optimization for full functionality.\n"
                         "Run opendss and reopt-feature post-processing in the UO SDK for a full-featured microgrid.")

--- a/geojson_modelica_translator/system_parameters/time_series_microgrid_template.json
+++ b/geojson_modelica_translator/system_parameters/time_series_microgrid_template.json
@@ -48,7 +48,6 @@
   "district_system": {
     "fourth_generation": {
       "central_cooling_plant_parameters": {
-        "weather_filepath": "../../data_shared/USA_CA_San.Francisco.Intl.AP.724940_TMY3.mos",
         "heat_flow_nominal": 7999,
         "cooling_tower_fan_power_nominal": 4999,
         "mass_chw_flow_nominal": 9.9,
@@ -80,6 +79,7 @@
       }
     }
   },
+  "weather": "../../data_shared/USA_CA_San.Francisco.Intl.AP.724940_TMY3.mos",
   "electrical_grid": {},
   "photovoltaic_panels": [],
   "wind_turbines": [],

--- a/geojson_modelica_translator/system_parameters/time_series_template.json
+++ b/geojson_modelica_translator/system_parameters/time_series_template.json
@@ -45,7 +45,6 @@
   "district_system": {
     "fourth_generation": {
       "central_cooling_plant_parameters": {
-        "weather_filepath": "../../data_shared/USA_CA_San.Francisco.Intl.AP.724940_TMY3.mos",
         "heat_flow_nominal": 7999,
         "cooling_tower_fan_power_nominal": 4999,
         "mass_chw_flow_nominal": 9.9,
@@ -76,5 +75,6 @@
         "chp_installed": false
       }
     }
-  }
+  },
+  "weather": "../../data_shared/USA_CA_San.Francisco.Intl.AP.724940_TMY3.mos"
 }

--- a/management/data/baseline_sys_params.json
+++ b/management/data/baseline_sys_params.json
@@ -121,7 +121,6 @@
   "district_system": {
     "default": {
       "central_cooling_plant_parameters": {
-        "weather_filepath": "./baseline_weather.mos",
         "heat_flow_nominal": 7999,
         "cooling_tower_fan_power_nominal": 4999,
         "mass_chw_flow_nominal": 9.9,
@@ -152,5 +151,6 @@
         "chp_installed": false
       }
     }
-  }
+  },
+  "weather": "./baseline_weather.mos"
 }

--- a/tests/data_shared/geojson_district/system_params.json
+++ b/tests/data_shared/geojson_district/system_params.json
@@ -88,7 +88,6 @@
       "load_model_parameters": {
         "rc": {
           "order": 4,
-          "mos_weather_filename": "SRRL_2013AMY_60min.mos",
           "has_liquid_heating": true,
           "has_electric_heating": false,
           "has_liquid_cooling": true,
@@ -129,7 +128,6 @@
       "load_model_parameters": {
         "rc": {
           "order": 4,
-          "mos_weather_filename": "SRRL_2013AMY_60min.mos",
           "has_liquid_heating": true,
           "has_electric_heating": false,
           "has_liquid_cooling": true,
@@ -170,8 +168,6 @@
       "load_model_parameters": {
         "spawn": {
           "idf_filename": "SEB.idf",
-          "epw_filename": "SRRL_2013AMY_60min.epw",
-          "mos_weather_filename": "SRRL_2013AMY_60min.mos",
           "has_liquid_heating": true,
           "has_electric_heating": false,
           "has_liquid_cooling": true,
@@ -232,7 +228,6 @@
       "load_model_parameters": {
         "rc": {
           "order": 4,
-          "mos_weather_filename": "SRRL_2013AMY_60min.mos",
           "has_liquid_heating": true,
           "has_electric_heating": false,
           "has_liquid_cooling": true,
@@ -271,7 +266,6 @@
   "district_system": {
     "fourth_generation": {
       "central_cooling_plant_parameters": {
-        "weather_filepath": "../USA_CA_San.Francisco.Intl.AP.724940_TMY3.mos",
         "heat_flow_nominal": 7999,
         "cooling_tower_fan_power_nominal": 4999,
         "mass_chw_flow_nominal": 9.9,
@@ -302,5 +296,6 @@
         "chp_installed": false
       }
     }
-  }
+  },
+  "weather": "SRRL_2013AMY_60min.mos"
 }

--- a/tests/data_shared/mixed_loads_district/system_params.json
+++ b/tests/data_shared/mixed_loads_district/system_params.json
@@ -47,8 +47,6 @@
       "load_model_parameters": {
         "spawn": {
           "idf_filename": "../RefBldgSmallOfficeNew2004_v1.4_9.6_5A_USA_IL_CHICAGO-OHARE.idf",
-          "epw_filename": "../USA_CA_San.Francisco.Intl.AP.724940_TMY3.epw",
-          "mos_weather_filename": "../USA_CA_San.Francisco.Intl.AP.724940_TMY3.mos",
           "has_liquid_heating": true,
           "has_electric_heating": false,
           "has_liquid_cooling": true,
@@ -109,7 +107,6 @@
       "load_model_parameters": {
         "rc": {
           "order": 4,
-          "mos_weather_filename": "../USA_CA_San.Francisco.Intl.AP.724940_TMY3.mos",
           "has_liquid_heating": true,
           "has_electric_heating": false,
           "has_liquid_cooling": true,
@@ -148,7 +145,6 @@
   "district_system": {
     "fourth_generation": {
       "central_cooling_plant_parameters": {
-        "weather_filepath": "../USA_CA_San.Francisco.Intl.AP.724940_TMY3.mos",
         "heat_flow_nominal": 7999,
         "cooling_tower_fan_power_nominal": 4999,
         "mass_chw_flow_nominal": 9.9,
@@ -179,5 +175,6 @@
         "chp_installed": false
       }
     }
-  }
+  },
+  "weather": "../USA_CA_San.Francisco.Intl.AP.724940_TMY3.mos"
 }

--- a/tests/data_shared/system_params_microgrid_example.json
+++ b/tests/data_shared/system_params_microgrid_example.json
@@ -1,4 +1,5 @@
 {
+  "weather": "../../data_shared/USA_CA_San.Francisco.Intl.AP.724940_TMY3.mos",
   "buildings": [
     {
       "geojson_id": "1",
@@ -196,7 +197,6 @@
   "district_system": {
     "fourth_generation": {
       "central_cooling_plant_parameters": {
-        "mos_wet_bulb_filename": "../../data_shared/USA_CA_San.Francisco.Intl.AP.724940_TMY3.mos",
         "heat_flow_nominal": 7999,
         "cooling_tower_fan_power_nominal": 4999,
         "mass_chw_flow_nominal": 9.9,

--- a/tests/geojson_modelica_translator/data/system_parameters_mix_models.json
+++ b/tests/geojson_modelica_translator/data/system_parameters_mix_models.json
@@ -1,4 +1,5 @@
 {
+  "weather": "../../data_shared/USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.mos",
   "buildings": [
     {
       "geojson_id": "5a6b99ec37f4de7f94020090",
@@ -6,8 +7,6 @@
       "load_model_parameters": {
         "spawn": {
           "idf_filename": "../../data_shared/RefBldgSmallOfficeNew2004_v1.4_9.6_5A_USA_IL_CHICAGO-OHARE.idf",
-          "epw_filename": "../../data_shared/USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw",
-          "mos_weather_filename": "../../data_shared/USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.mos",
           "has_liquid_heating": true,
           "has_electric_heating": false,
           "has_liquid_cooling": true,
@@ -108,7 +107,6 @@
       "load_model": "rc",
       "load_model_parameters": {
         "rc": {
-          "mos_weather_filename": "../../data_shared/USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.mos",
           "has_liquid_heating": true,
           "has_electric_heating": false,
           "has_liquid_cooling": true,
@@ -147,7 +145,6 @@
   "district_system": {
     "fourth_generation": {
       "central_cooling_plant_parameters": {
-        "weather_filepath": "../../data_shared/USA_CA_San.Francisco.Intl.AP.724940_TMY3.mos",
         "heat_flow_nominal": 7999,
         "cooling_tower_fan_power_nominal": 4999,
         "mass_chw_flow_nominal": 9.9,

--- a/tests/model_connectors/data/spawn_system_params_ex1.json
+++ b/tests/model_connectors/data/spawn_system_params_ex1.json
@@ -6,8 +6,6 @@
       "load_model_parameters": {
         "spawn": {
           "idf_filename": "../../data_shared/RefBldgSmallOfficeNew2004_v1.4_9.6_5A_USA_IL_CHICAGO-OHARE.idf",
-          "epw_filename": "../../data_shared/USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw",
-          "mos_weather_filename": "../../data_shared/USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.mos",
           "has_liquid_heating": true,
           "has_electric_heating": false,
           "has_liquid_cooling": true,
@@ -66,7 +64,6 @@
   "district_system": {
     "fourth_generation": {
       "central_cooling_plant_parameters": {
-        "weather_filepath": "../../data_shared/USA_CA_San.Francisco.Intl.AP.724940_TMY3.mos",
         "heat_flow_nominal": 7999,
         "cooling_tower_fan_power_nominal": 4999,
         "mass_chw_flow_nominal": 9.9,
@@ -97,5 +94,6 @@
         "chp_installed": false
       }
     }
-  }
+  },
+  "weather": "../../data_shared/USA_CA_San.Francisco.Intl.AP.724940_TMY3.mos"
 }

--- a/tests/model_connectors/data/teaser_system_params_ex1.json
+++ b/tests/model_connectors/data/teaser_system_params_ex1.json
@@ -1,4 +1,5 @@
 {
+  "weather": "../../data_shared/USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.mos",
   "buildings": [
     {
       "geojson_id": "5a6b99ec37f4de7f94020090",
@@ -6,7 +7,6 @@
       "load_model_parameters": {
         "rc": {
           "order": 4,
-          "mos_weather_filename": "../../data_shared/USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.mos",
           "has_liquid_heating": true,
           "has_electric_heating": false,
           "has_liquid_cooling": true,
@@ -45,7 +45,6 @@
   "district_system": {
     "fourth_generation": {
       "central_cooling_plant_parameters": {
-        "weather_filepath": "../../data_shared/USA_CA_San.Francisco.Intl.AP.724940_TMY3.mos",
         "heat_flow_nominal": 7999,
         "cooling_tower_fan_power_nominal": 4999,
         "mass_chw_flow_nominal": 9.9,

--- a/tests/model_connectors/data/teaser_system_params_two_loads.json
+++ b/tests/model_connectors/data/teaser_system_params_two_loads.json
@@ -6,7 +6,6 @@
       "load_model_parameters": {
         "rc": {
           "order": 4,
-          "mos_weather_filename": "../../data_shared/USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.mos",
           "has_liquid_heating": true,
           "has_electric_heating": false,
           "has_liquid_cooling": true,
@@ -47,7 +46,6 @@
       "load_model_parameters": {
         "rc": {
           "order": 4,
-          "mos_weather_filename": "../../data_shared/USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.mos",
           "has_liquid_heating": true,
           "has_electric_heating": false,
           "has_liquid_cooling": true,
@@ -86,7 +84,6 @@
   "district_system": {
     "fourth_generation": {
       "central_cooling_plant_parameters": {
-        "weather_filepath": "../../data_shared/USA_CA_San.Francisco.Intl.AP.724940_TMY3.mos",
         "heat_flow_nominal": 7999,
         "cooling_tower_fan_power_nominal": 4999,
         "mass_chw_flow_nominal": 9.9,
@@ -117,5 +114,6 @@
         "chp_installed": false
       }
     }
-  }
+  },
+  "weather": "../../data_shared/USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.mos"
 }

--- a/tests/model_connectors/data/time_series_system_params_chp.json
+++ b/tests/model_connectors/data/time_series_system_params_chp.json
@@ -1,4 +1,5 @@
 {
+  "weather": "../../data_shared/USA_CA_San.Francisco.Intl.AP.724940_TMY3.mos",
   "buildings": [
     {
       "geojson_id": "5a6b99ec37f4de7f94020090",
@@ -86,7 +87,6 @@
   "district_system": {
     "fourth_generation": {
       "central_cooling_plant_parameters": {
-        "weather_filepath": "../../data_shared/USA_CA_San.Francisco.Intl.AP.724940_TMY3.mos",
         "heat_flow_nominal": 7999,
         "cooling_tower_fan_power_nominal": 4999,
         "mass_chw_flow_nominal": 9.9,

--- a/tests/model_connectors/data/time_series_system_params_ets.json
+++ b/tests/model_connectors/data/time_series_system_params_ets.json
@@ -1,4 +1,5 @@
 {
+  "weather": "../../data_shared/USA_CA_San.Francisco.Intl.AP.724940_TMY3.mos",
   "buildings": [
     {
       "geojson_id": "5a6b99ec37f4de7f94020090",
@@ -86,7 +87,6 @@
   "district_system": {
     "fourth_generation": {
       "central_cooling_plant_parameters": {
-        "weather_filepath": "../../data_shared/USA_CA_San.Francisco.Intl.AP.724940_TMY3.mos",
         "heat_flow_nominal": 7999,
         "cooling_tower_fan_power_nominal": 4999,
         "mass_chw_flow_nominal": 9.9,

--- a/tests/model_connectors/data/time_series_system_params_massflow_ex1.json
+++ b/tests/model_connectors/data/time_series_system_params_massflow_ex1.json
@@ -1,4 +1,5 @@
 {
+  "weather": "../../data_shared/USA_CA_San.Francisco.Intl.AP.724940_TMY3.mos",
   "buildings": [
     {
       "geojson_id": "5a6b99ec37f4de7f94020090",
@@ -45,7 +46,6 @@
   "district_system": {
     "fourth_generation": {
       "central_cooling_plant_parameters": {
-        "weather_filepath": "../../data_shared/USA_CA_San.Francisco.Intl.AP.724940_TMY3.mos",
         "heat_flow_nominal": 7999,
         "cooling_tower_fan_power_nominal": 4999,
         "mass_chw_flow_nominal": 9.9,

--- a/tests/model_connectors/data/time_series_system_params_no_ets.json
+++ b/tests/model_connectors/data/time_series_system_params_no_ets.json
@@ -1,4 +1,5 @@
 {
+  "weather": "../../data_shared/USA_CA_San.Francisco.Intl.AP.724940_TMY3.mos",
   "buildings": [
     {
       "geojson_id": "5a6b99ec37f4de7f94020090",
@@ -26,7 +27,6 @@
   "district_system": {
     "fourth_generation": {
       "central_cooling_plant_parameters": {
-        "weather_filepath": "../../data_shared/USA_CA_San.Francisco.Intl.AP.724940_TMY3.mos",
         "heat_flow_nominal": 7999,
         "cooling_tower_fan_power_nominal": 4999,
         "mass_chw_flow_nominal": 9.9,

--- a/tests/system_parameters/data/system_params_1.json
+++ b/tests/system_parameters/data/system_params_1.json
@@ -1,4 +1,5 @@
 {
+  "weather": "../../data_shared/USA_CA_San.Francisco.Intl.AP.724940_TMY3.mos",
   "buildings": [
     {
       "geojson_id": "abcd1234",
@@ -10,7 +11,6 @@
       "load_model_parameters": {
         "rc": {
           "order": 2,
-          "mos_weather_filename": "example_weather_2.mos",
           "fraction_latent_person": 1.25,
           "temp_hw_supply": 40,
           "temp_setpoint_cooling": 20,
@@ -44,7 +44,6 @@
       "load_model_parameters": {
         "rc": {
           "order": 2,
-          "mos_weather_filename": "example_weather_2.mos",
           "fraction_latent_person": 1.25,
           "temp_hw_supply": 40,
           "temp_setpoint_cooling": 20,
@@ -78,8 +77,6 @@
       "load_model_parameters": {
         "spawn": {
           "idf_filename": "example_model.idf",
-          "mos_weather_filename": "example_weather.mos",
-          "epw_filename": "example_weather.epw",
           "has_liquid_heating": true,
           "has_electric_heating": false,
           "has_liquid_cooling": true,
@@ -128,8 +125,6 @@
       "load_model_parameters": {
         "spawn": {
           "idf_filename": "example_model_2.idf",
-          "mos_weather_filename": "example_weather_2.mos",
-          "epw_filename": "example_weather_2.epw",
           "has_liquid_heating": true,
           "has_electric_heating": false,
           "has_liquid_cooling": true,
@@ -181,7 +176,6 @@
   "district_system": {
     "fourth_generation": {
       "central_cooling_plant_parameters": {
-        "weather_filepath": "../../data_shared/USA_CA_San.Francisco.Intl.AP.724940_TMY3.mos",
         "heat_flow_nominal": 7999,
         "cooling_tower_fan_power_nominal": 4999,
         "mass_chw_flow_nominal": 9.9,

--- a/tests/system_parameters/data/system_params_2.json
+++ b/tests/system_parameters/data/system_params_2.json
@@ -1,4 +1,5 @@
 {
+  "weather": "../../data_shared/USA_CA_San.Francisco.Intl.AP.724940_TMY3.mos",
   "buildings": [
     {
       "geojson_id": "abcd1234",
@@ -29,8 +30,6 @@
       "load_model_parameters": {
         "spawn": {
           "idf_filename": "path to a file",
-          "epw_filename": "path to a file",
-          "mos_weather_filename": "path to a file",
           "has_liquid_heating": true,
           "has_electric_heating": false,
           "has_liquid_cooling": true,
@@ -80,7 +79,6 @@
   "district_system": {
     "fourth_generation": {
       "central_cooling_plant_parameters": {
-        "weather_filepath": "../../data_shared/USA_CA_San.Francisco.Intl.AP.724940_TMY3.mos",
         "heat_flow_nominal": 7999,
         "cooling_tower_fan_power_nominal": 4999,
         "mass_chw_flow_nominal": 9.9,

--- a/tests/system_parameters/test_system_parameters.py
+++ b/tests/system_parameters/test_system_parameters.py
@@ -75,10 +75,8 @@ class SystemParametersTest(unittest.TestCase):
             print(s)
         value = sdp.get_param_by_building_id("ijk678", "load_model_parameters.spawn.idf_filename")
         self.assertEqual(Path(value), Path(filename).parent / 'example_model.idf')
-        value = sdp.get_param_by_building_id("ijk678", "load_model_parameters.spawn.mos_weather_filename")
-        self.assertEqual(Path(value), Path(filename).parent / 'example_weather.mos')
-        value = sdp.get_param_by_building_id("ijk678", "load_model_parameters.spawn.epw_filename")
-        self.assertEqual(Path(value), Path(filename).parent / 'example_weather.epw')
+        value = sdp.get_param("$.weather")
+        self.assertEqual(Path(value), Path(filename).parent / '../../data_shared/USA_CA_San.Francisco.Intl.AP.724940_TMY3.mos')
 
         # verify that the second spawn paths resolve too.
         value = sdp.get_param_by_building_id("lmn000", "load_model_parameters.spawn.idf_filename")
@@ -124,7 +122,6 @@ class SystemParametersTest(unittest.TestCase):
         sp = SystemParameters.loadd(incomplete_teaser_params, validate_on_load=False)
         self.assertEqual(len(sp.validate()), 6)
         self.assertIn("'fraction_latent_person' is a required property", sp.validate())
-        self.assertIn("'mos_weather_filename' is a required property", sp.validate())
         self.assertIn("'temp_hw_supply' is a required property", sp.validate())
         self.assertIn("'temp_setpoint_cooling' is a required property", sp.validate())
         self.assertIn("'temp_setpoint_heating' is a required property", sp.validate())
@@ -132,6 +129,7 @@ class SystemParametersTest(unittest.TestCase):
 
     def test_get_param(self):
         data = {
+            "weather": "path/to/weatherfile.mos",
             "buildings": [
                 {
                     "geojson_id": "asdf",
@@ -140,7 +138,6 @@ class SystemParametersTest(unittest.TestCase):
                     "load_model_parameters": {
                         "rc": {
                             "order": 4,
-                            "mos_weather_filename": "path-to-file",
                             "fraction_latent_person": 1.25,
                             "temp_hw_supply": 40,
                             "temp_setpoint_heating": 40,
@@ -168,7 +165,6 @@ class SystemParametersTest(unittest.TestCase):
                     "load_model_parameters": {
                         "rc": {
                             "order": 4,
-                            "mos_weather_filename": "path-to-file",
                             "fraction_latent_person": 1.25,
                             "temp_hw_supply": 40,
                             "temp_setpoint_heating": 40,


### PR DESCRIPTION
#### Any background context you want to provide?
@amyeallen1 found some brittleness in our existing use of weather files. This completes the weather file location work, superseding her excellent attempts that were thwarted by the old schema.
#### What does this PR accomplish?
- Moves weather file to top-level in the sys-param files
- Assumes `epw` file is same name & location as `mos` weather file (for spawn)
    - This is a valid assumption for sys-params built by the CLI
- Updates the sys-param test file to work with new schema
#### How should this be manually tested?
#### What are the relevant tickets?
- Resolves #461 
- Supersedes #483 