### PR TITLE
Improve ci config settings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,11 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         python-version: ["3.7.1", "3.10"]
         test_env: [python, precommit, docs]
-        mbl_branch: [master]
+        mbl_branch: [maint_9.1.x]
         include:
           - os: ubuntu-latest
             test_env: python
-            mbl_branch: master
+            mbl_branch: maint_9.1.x
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -123,7 +123,8 @@ jobs:
         name: Coveralls
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.test_env == 'python' && matrix.mbl_branch == 'master' }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.test_env == 'python' && matrix.mbl_branch == 'maint_9.1.x' }}
         run: |
           poetry run coveralls
       -

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
           poetry update
       # -
       #   name: Save Optimica license to file
-      #   if: matrix.os == 'ubuntu-latest'
+      #   if: matrix.os == 'ubuntu-20.04'
       #   shell: bash
       #   run: |
       #     mkdir -p /home/runner/modelon

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-20.04, windows-latest]
         python-version: ["3.7.1", "3.10"]
         test_env: [python, precommit, docs]
         mbl_branch: [maint_9.1.x]
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             test_env: python
             mbl_branch: maint_9.1.x
     runs-on: ${{ matrix.os }}
@@ -124,7 +124,7 @@ jobs:
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.test_env == 'python' && matrix.mbl_branch == 'maint_9.1.x' }}
+        if: ${{ matrix.os == 'ubuntu-20.04' && matrix.test_env == 'python' && matrix.mbl_branch == 'maint_9.1.x' }}
         run: |
           poetry run coveralls
       -

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
           MATRIX_OS: ${{ matrix.os }}
           MBL_BRANCH: ${{ matrix.mbl_branch }}
         run: |
-          if [[ "${MATRIX_OS}" == 'ubuntu-latest' ]]; then
+          if [[ "${MATRIX_OS}" == 'ubuntu-20.04' ]]; then
             MODELICAPATH='/home/runner/work/modelica-buildings'
           else
             echo $GITHUB_WORKSPACE

--- a/docs/developer_resources.rst
+++ b/docs/developer_resources.rst
@@ -62,7 +62,7 @@ Follow the instructions below in order to configure your local environment:
 * (optional/as-needed) Add Python 3 to the environment variables
 * For developers, dependency management is through `Poetry`_. Installation is accomplished by running :code:`pip install poetry`.
 * Return to the GMT root directory and run :code:`poetry install`
-* Test if everything is installed correctly by running :code:`poetry run pytest`. This will run all the unit and integration tests.
+* Test if everything is installed correctly by running :code:`poetry run pytest -m 'not compilation and not simulation'`. This will run all the unit and integration tests.
 * Follow the instructions below to install pre-commit.
 * To test pre-commit and building the documentation, you can run :code:`poetry run tox`
 


### PR DESCRIPTION
#### Any background context you want to provide?
Our CI should test the appropriate settings and environments

#513  failed CI which made this solution apparent. Merging this PR should make CI pass in that PR.
#### What does this PR accomplish?
- Explicitly use Ubuntu 20.04 because apparently 22.04 doesn't support Python 3.7
- Add the Github Token secret to make Coveralls happy
- Explicitly point to the MBL 9.1 branch, instead of master
- Adds the message command currently required with pytest to not run compilation or simulation tests
#### How should this be manually tested?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
