### PR TITLE
bugfix of the bugfix, yay

### DIFF
--- a/geojson_modelica_translator/system_parameters/system_parameters.py
+++ b/geojson_modelica_translator/system_parameters/system_parameters.py
@@ -808,7 +808,9 @@ class SystemParameters(object):
                     mfrt_df = pd.read_csv(measure_file_path)
                     try:
                         building_nominal_mfrt = round(mfrt_df['massFlowRateHeating'].max(), 3)  # round max to 3 decimal places
-                        building['ets_indirect_parameters']['nominal_mass_flow_building'] = building_nominal_mfrt
+                        # Multiply by 1.000 to force casting to float in cases where building_nominal_mfrt == 0
+                        # This might be related to building_type == `lodging` for non-zero building percentages
+                        building['ets_indirect_parameters']['nominal_mass_flow_building'] = building_nominal_mfrt * 1.000
                     except KeyError:
                         # If massFlowRateHeating is not in the export_time_series_modelica output, just skip this step.
                         # It probably won't be in the export for hpxml residential buildings, at least as of 2022-06-29

--- a/geojson_modelica_translator/system_parameters/system_parameters.py
+++ b/geojson_modelica_translator/system_parameters/system_parameters.py
@@ -808,9 +808,9 @@ class SystemParameters(object):
                     mfrt_df = pd.read_csv(measure_file_path)
                     try:
                         building_nominal_mfrt = round(mfrt_df['massFlowRateHeating'].max(), 3)  # round max to 3 decimal places
-                        # Multiply by 1.000 to force casting to float in cases where building_nominal_mfrt == 0
-                        # This might be related to building_type == `lodging` for non-zero building percentages
-                        building['ets_indirect_parameters']['nominal_mass_flow_building'] = building_nominal_mfrt * 1.000
+                        # Force casting to float even if building_nominal_mfrt == 0
+                        # FIXME: This might be related to building_type == `lodging` for non-zero building percentages
+                        building['ets_indirect_parameters']['nominal_mass_flow_building'] = float(building_nominal_mfrt)
                     except KeyError:
                         # If massFlowRateHeating is not in the export_time_series_modelica output, just skip this step.
                         # It probably won't be in the export for hpxml residential buildings, at least as of 2022-06-29
@@ -819,7 +819,7 @@ class SystemParameters(object):
                 district_nominal_mfrt += building_nominal_mfrt
 
         # Remove template buildings that weren't used or don't have successful simulations with modelica outputs
-        # FIXME: Another place where we only support time series for now.
+        # TODO: Another place where we only support time series for now.
         building_list = [x for x in building_list if not x['load_model_parameters']
                          ['time_series']['filepath'].endswith("populated")]
         if len(building_list) == 0:


### PR DESCRIPTION
#### Any background context you want to provide?
I removed a duplicate casting to float in #507 but it turns out there are cases where the second casting is required. My current theory is that `building_type: "lodging"` in the geojson file means `massFlowRateHeating` for the entire building is zero, even in a Mixed Use building if lodging is a non-zero percentage of the building. This zero, in turn, broke system_parameters.py by being an int and not a float.
#### What does this PR accomplish?
Force casting to float when mfrt heating load is 0