### PR TITLE
specify ports for each time series building in instance template

### DIFF
--- a/geojson_modelica_translator/model_connectors/load_connectors/templates/TimeSeries_Instance.mopt
+++ b/geojson_modelica_translator/model_connectors/load_connectors/templates/TimeSeries_Instance.mopt
@@ -6,7 +6,11 @@
     delTAirCoo(displayUnit="degC")=10,
     delTAirHea(displayUnit="degC")=20,
     k=0.1,
-    Ti=120
+    Ti=120,
+    nPorts_aHeaWat=1,
+    nPorts_bHeaWat=1,
+    nPorts_aChiWat=1,
+    nPorts_bChiWat=1
     ), ets(have_hotWat = false)
     {% else %}
     T_aHeaWat_nominal(displayUnit="K")=318.15,
@@ -14,7 +18,11 @@
     delTAirCoo(displayUnit="degC")=10,
     delTAirHea(displayUnit="degC")=20,
     k=0.1,
-    Ti=120
+    Ti=120,
+    nPorts_aHeaWat=1,
+    nPorts_bHeaWat=1,
+    nPorts_aChiWat=1,
+    nPorts_bChiWat=1
     {% endif %}
     )
     "Building model integrating multiple time series thermal zones."


### PR DESCRIPTION
#### Any background context you want to provide?
We found our time-series instance template was missing information about the available ports
#### What does this PR accomplish?
Specifies that there are one each of input/output ports for hot and cold water
#### How should this be manually tested?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
