### PR TITLE
Add MOS file wrapper and size the 5G mass flow rate

### DIFF
--- a/geojson_modelica_translator/modelica/GMT_Lib/DHC/DHC_5G_waste_heat_GHX.mot
+++ b/geojson_modelica_translator/modelica/GMT_Lib/DHC/DHC_5G_waste_heat_GHX.mot
@@ -5,10 +5,11 @@ model district
     Buildings.Experimental.DHC.Examples.Combined.BaseClasses.PartialSeries(      redeclare
       Buildings.Experimental.DHC.Loads.Combined.BuildingTimeSeriesWithETS
       bui[nBui](final filNam=filNam), datDes(
-      {% endraw %}nBui={{ data['building_load_files'] | count }},{% raw %}
-      mPumDis_flow_nominal=95,
-      mPipDis_flow_nominal=95,
-      dp_length_nominal=250,
+      {% endraw %}nBui={{ data['building_load_files'] | count }},
+      mPumDis_flow_nominal={{ data['max_flow_rate']}},
+      mPipDis_flow_nominal={{ data['max_flow_rate']}},
+      mPla_flow_nominal={{ data['max_flow_rate']}},
+      dp_length_nominal=250,{% raw %}
       epsPla=0.935));
   parameter String filNam[nBui]={
     {% endraw %}{% for building in data['building_load_files'] %}

--- a/geojson_modelica_translator/modelica/GMT_Lib/DHC/DHC_5G_waste_heat_GHX.py
+++ b/geojson_modelica_translator/modelica/GMT_Lib/DHC/DHC_5G_waste_heat_GHX.py
@@ -80,9 +80,9 @@ class DHC5GWasteHeatAndGHX(SimpleGMTBase):
             rel_path_name = f"{project_name}/{scaffold.districts_path.resources_relative_dir}/{file_to_copy['geojson_id']}/{file_to_copy['save_filename']}"
             template_data['building_load_files'].append(f"modelica://{rel_path_name}")  # type: ignore
 
-        # 5: Calculate the mass flow rates (kg/s) for the heating and cooling networks
-        #    (assuming 15C delta T and 4.18 Cp (kJ/kgK)). Add 1.5x the peak for oversizing
-        delta_t = 15
+        # 5: Calculate the mass flow rates (kg/s) for the heating and cooling networks peak load (in Watts)
+        #    (assuming 10C delta T and 4.18 Cp (kJ/kgK)). Add 1.5x the peak for oversizing
+        delta_t = 10
         heating_flow_rate = 1.5 * total_heating_load / (1000 * delta_t * 4.18)
         cooling_flow_rate = 1.5 * total_cooling_load / (1000 * delta_t * 4.18)
         swh_flow_rate = 1.5 * total_swh_load / (1000 * delta_t * 4.18)
@@ -96,5 +96,5 @@ class DHC5GWasteHeatAndGHX(SimpleGMTBase):
                          save_file_name='district.mo',
                          generate_package=True)
 
-        # 4: save the root package.mo
+        # 7: save the root package.mo
         package.save()

--- a/geojson_modelica_translator/modelica/GMT_Lib/DHC/DHC_5G_waste_heat_GHX.py
+++ b/geojson_modelica_translator/modelica/GMT_Lib/DHC/DHC_5G_waste_heat_GHX.py
@@ -87,7 +87,7 @@ class DHC5GWasteHeatAndGHX(SimpleGMTBase):
         cooling_flow_rate = 1.5 * total_cooling_load / (1000 * delta_t * 4.18)
         swh_flow_rate = 1.5 * total_swh_load / (1000 * delta_t * 4.18)
 
-        template_data['max_flow_rate'] = round(max(heating_flow_rate, cooling_flow_rate, swh_flow_rate), 3)
+        template_data['max_flow_rate'] = round(max(heating_flow_rate, cooling_flow_rate, swh_flow_rate), 3)  # type: ignore
 
         # 6: generate the modelica files from the template
         self.to_modelica(output_dir=Path(scaffold.districts_path.files_dir),

--- a/geojson_modelica_translator/modelica/GMT_Lib/DHC/DHC_5G_waste_heat_GHX.py
+++ b/geojson_modelica_translator/modelica/GMT_Lib/DHC/DHC_5G_waste_heat_GHX.py
@@ -81,8 +81,8 @@ class DHC5GWasteHeatAndGHX(SimpleGMTBase):
             template_data['building_load_files'].append(f"modelica://{rel_path_name}")  # type: ignore
 
         # 5: Calculate the mass flow rates (kg/s) for the heating and cooling networks peak load (in Watts)
-        #    (assuming 10C delta T and 4.18 Cp (kJ/kgK)). Add 1.5x the peak for oversizing
-        delta_t = 10
+        #    (assuming 5C delta T [since 5G] and 4.18 Cp (kJ/kgK)). Add 1.5x the peak for oversizing
+        delta_t = 5
         heating_flow_rate = 1.5 * total_heating_load / (1000 * delta_t * 4.18)
         cooling_flow_rate = 1.5 * total_cooling_load / (1000 * delta_t * 4.18)
         swh_flow_rate = 1.5 * total_swh_load / (1000 * delta_t * 4.18)

--- a/geojson_modelica_translator/modelica/modelica_mos_file.py
+++ b/geojson_modelica_translator/modelica/modelica_mos_file.py
@@ -1,0 +1,90 @@
+# :copyright (c) URBANopt, Alliance for Sustainable Energy, LLC, and other contributors.
+# See also https://github.com/urbanopt/geojson-modelica-translator/blob/develop/LICENSE.md
+
+import re
+from pathlib import Path
+from typing import Any, Union
+
+
+class ModelicaMOS(object):
+    def __init__(self, filename: str, data: str = None):
+        """Read in a .mos file if it exists into a data object
+        The format is CSV with additional header info, so for
+        now read the data as a string.
+
+        Args:
+            filename (str): Name of the file to import, typically a full path
+
+        Raises:
+            FileNotFoundError: File does not exist
+            Exception: The file extension needs to be MOS
+        """
+        # allow reading in the data directly for testing purposes, for the
+        # most part.
+        if not data:
+            if Path(filename).exists():
+                self.filename = Path(filename)
+            else:
+                raise FileNotFoundError(f"{filename} does not exist")
+
+            if self.filename.suffix.lower() != ".mos":
+                raise Exception(f"{filename} is not a .mos file")
+
+            self.data = self.filename.read_text()
+        else:
+            self.data = data
+
+    def retrieve_header_variable_value(self, key: str, cast_type: type = str) -> Any:
+        """Retrieve a value from a variable in the header
+
+        Args:
+            key (str): Key to retrieve
+            cast_type (type, optional): Type to cast the value to. Defaults to str.
+
+        Returns:
+            str: Value of the key
+        """
+        # check if the peak water heating load is zero, otherwise just skip
+        key_re = rf'#(\s?{key}\s?)=\s?(-?\b\d[\d,.]*\b)(.*\s)'
+        match = re.search(key_re, self.data)
+        if match:
+            # the first group is the variable name, the second is the value
+            value = match.group(2).strip()
+            if value and cast_type:
+                try:
+                    if cast_type != str:
+                        value = value.replace(',', '')
+                        return cast_type(value)
+                    else:
+                        return value
+                except ValueError:
+                    raise Exception(f"Unable to cast {value} to {cast_type}")
+            else:
+                return value
+        else:
+            return None
+
+    def replace_header_variable_value(self, key: str, new_value: Any) -> bool:
+        key_re = rf'#(\s?{key}\s?)=\s?(-?\b\d[\d,.]*\b)(.*\s)'
+
+        # verify that group3 exists, otherwise the key doesn't exist
+        match = re.search(key_re, self.data)
+        if match:
+            if match.group(3):
+                # if there are units, then put the unit back in
+                self.data = re.sub(key_re, '#' + r'\g<1>' + f"= {new_value}" + r'\g<3>', self.data)
+            else:
+                # no g3, therefore, just replace the var and value.
+                self.data = re.sub(key_re, '#' + r'\g<1>' + f"= {new_value}", self.data)
+
+        # replace the value, this requires recreating the variable and value
+        self.data = re.sub(key_re, '#' + r'\g<1>' + f"= {new_value}" + r'\g<3>', self.data)
+        return True
+
+    def save(self):
+        """Save the file back to disk"""
+        self.filename.write_text(self.data)
+
+    def save_as(self, filename: Union[str, Path]):
+        """Save the file to a new filename"""
+        Path(filename).write_text(self.data)

--- a/geojson_modelica_translator/modelica/modelica_mos_file.py
+++ b/geojson_modelica_translator/modelica/modelica_mos_file.py
@@ -65,6 +65,15 @@ class ModelicaMOS(object):
             return None
 
     def replace_header_variable_value(self, key: str, new_value: Any) -> bool:
+        """Replace the variable value in the header vars
+
+        Args:
+            key (str): Key of the variable value to replace
+            new_value (Any): new value
+
+        Returns:
+            bool: Always True (for now)
+        """
         key_re = rf'#(\s?{key}\s?)=\s?(-?\b\d[\d,.]*\b)(.*\s)'
 
         # verify that group3 exists, otherwise the key doesn't exist

--- a/tests/GMT_Lib/test_gmt_lib_des.py
+++ b/tests/GMT_Lib/test_gmt_lib_des.py
@@ -45,4 +45,4 @@ def test_5G_des_waste_heat_and_ghx():
     # Test to make sure that a zero SWH peak is set to a minimum value.
     # Otherwise, Modelica will error out.
     with open(package_output_dir / package_name / 'Resources' / 'Data' / 'Districts' / '8' / 'B11.mos', 'r') as f:
-        assert '#Peak water heating load = 7714 Watts' in f.read()
+        assert '#Peak water heating load = 7714.5 Watts' in f.read()

--- a/tests/modelica/data/B2_no_water_load.mos
+++ b/tests/modelica/data/B2_no_water_load.mos
@@ -1,0 +1,25 @@
+#1
+#Heating and Cooling Model loads from OpenStudio Prototype Buildings
+#  Building Type: {{BUILDINGTYPE}}
+#  Climate Zone: {{CLIMATEZONE}}
+#  Vintage: {{VINTAGE}}
+#  Simulation ID (for debugging): {{SIMID}}
+#  URL: https://github.com/urbanopt/openstudio-prototype-loads
+
+#First column: Seconds in the year (loads are hourly)
+#Second column: cooling loads in Watts (as negative numbers).
+#Third column: space heating loads in Watts
+#Fourth column: water heating in Watts
+
+#Peak space cooling load = -113098.9 Watts
+#Peak space heating load = 38986.3 Watts
+#Peak water heating load = 0 Watts
+double tab1(8760,4)
+3600;0;0;0.0
+7200;0;0;0.0
+10800;0;0;0.0
+14400;0;0;0.0
+18000;0;16240.4;0.0
+21600;0;13281.1;0.0
+25200;0;9459.4;0.0
+28800;-1793.3;0;0.0

--- a/tests/modelica/test_modelica_mos.py
+++ b/tests/modelica/test_modelica_mos.py
@@ -1,0 +1,94 @@
+# :copyright (c) URBANopt, Alliance for Sustainable Energy, LLC, and other contributors.
+# See also https://github.com/urbanopt/geojson-modelica-translator/blob/develop/LICENSE.md
+
+import filecmp
+import os
+import unittest
+from pathlib import Path
+from geojson_modelica_translator.modelica.modelica_mos_file import ModelicaMOS
+
+
+class ModelicaMOSTest(unittest.TestCase):
+    def setUp(self):
+        self.data_dir = Path(os.path.dirname(__file__)) / 'data'
+        self.output_dir = Path(os.path.dirname(__file__)) / 'output'
+        if not os.path.exists(self.output_dir):
+            os.makedirs(self.output_dir)
+
+    def test_variable_retrieval_basic(self):
+        data = """
+#Var1 = 0 Watts
+#Var2 = 1 Watts
+#Var3 = 2
+"""
+        file = ModelicaMOS('not_a_real_file.mos', data=data)
+        self.assertEqual(file.retrieve_header_variable_value('Var1', cast_type=int), 0)
+        self.assertEqual(file.retrieve_header_variable_value('Var2'), '1')
+        self.assertEqual(file.retrieve_header_variable_value('Var3'), '2')
+
+    def test_variable_retrieval_floats(self):
+        # test with decimal separators
+        data = """
+#Var1 = 1,245.25 Watts
+# Var2 = 1,245 Watts
+# Var3 = 1,245 Watts with space
+# Var 4 = 1,245 Watts
+"""
+        file = ModelicaMOS('not_a_real_file.mos', data=data)
+        self.assertEqual(file.retrieve_header_variable_value('Var1', cast_type=float), 1245.25)
+        self.assertEqual(file.retrieve_header_variable_value('Var2', cast_type=float), 1245)
+        self.assertEqual(file.retrieve_header_variable_value('Var3', cast_type=float), 1245)
+        self.assertEqual(file.retrieve_header_variable_value('Var 4', cast_type=float), 1245)
+
+    def test_variable_retrieval_negatives(self):
+        # test with decimal separators
+        data = """
+#Var1 = -1,245.25 Watts
+"""
+        file = ModelicaMOS('not_a_real_file.mos', data=data)
+        self.assertEqual(file.retrieve_header_variable_value('Var1', cast_type=float), -1245.25)
+
+    def test_variable_retrieval_not_found(self):
+        data = """
+#Var1 = 1234 Watts
+"""
+        file = ModelicaMOS('not_a_real_file.mos', data=data)
+        self.assertEqual(file.retrieve_header_variable_value('Var2', cast_type=float), None)
+
+    def test_replace_variable_value(self):
+        data = """
+#Var1 = 0 Watts
+#Var2 = 1
+#Var3=2
+#Var4 = -3
+"""
+        file = ModelicaMOS('not_a_real_file.mos', data=data)
+        self.assertEqual(file.retrieve_header_variable_value('Var1', cast_type=float), 0)
+        file.replace_header_variable_value('Var1', 1234)
+        file.replace_header_variable_value('Var2', 2345)
+        file.replace_header_variable_value('Var3', 3456)
+        file.replace_header_variable_value('Var4', -1234)
+
+        # check that the value was replaced
+        self.assertEqual(file.retrieve_header_variable_value('Var1', cast_type=float), 1234)
+        self.assertEqual(file.retrieve_header_variable_value('Var2', cast_type=float), 2345)
+        self.assertEqual(file.retrieve_header_variable_value('Var3', cast_type=float), 3456)
+        self.assertEqual(file.retrieve_header_variable_value('Var4', cast_type=float), -1234)
+
+    def test_read_write_with_replace(self):
+
+        file = ModelicaMOS(self.data_dir / 'B2_no_water_load.mos')
+        self.assertEqual(file.retrieve_header_variable_value('Peak water heating load', cast_type=float), 0)
+        file.replace_header_variable_value('Peak water heating load', 5124)
+        file.replace_header_variable_value('Peak space cooling load', -10000)
+
+        # save off the new file
+        file.save_as(self.output_dir / 'B2_no_water_load_updated.mos')
+
+        # reread the saved file and check the values
+        new_file = ModelicaMOS(self.output_dir / 'B2_no_water_load_updated.mos')
+        self.assertEqual(new_file.retrieve_header_variable_value('Peak water heating load', cast_type=float), 5124)
+        self.assertEqual(new_file.retrieve_header_variable_value('Peak space cooling load', cast_type=float), -10000)
+        
+        # just call the save method for 'crash' check
+        new_file.save()


### PR DESCRIPTION
#### Any background context you want to provide?
We were parsing the MOS file by hand, the sizing of the mass flow rate was fixed, and the plant flow rate.

#### What does this PR accomplish?
* Add a new class to read in an MOS file. The class can read the variables in the header and can set variable values.
* Refactor the reading of the water heating load to use the new class
* Expose the plant mass flow rate to the DES5G mot file
* Size the mass flow rates according to the total heating/cooling load, delta T, and Cp

#### How should this be manually tested?
* Ideally, generate the DES_5G test and run in Dymola (I confirmed that it ran)
* The unit tests should cover the MOS file class

#### What are the relevant tickets?
n/a

#### Screenshots (if appropriate)
