### PR TITLE
Add simulation flag to not remove all output files

### DIFF
--- a/geojson_modelica_translator/modelica/lib/runner/om.py
+++ b/geojson_modelica_translator/modelica/lib/runner/om.py
@@ -19,12 +19,11 @@ logging.basicConfig(
 
 
 def configure_mbl_path() -> None:
-    """Configure the Modelica Building Library path"""
-    # The mbl is always mounted into the same folder within the Docker container
-    # If the user has checked out MBL, then the folder will already be at the
-    # level of Buildings folder, otherwise, the user most likely is developing
-    # from a git checkout and we need to go down one level to get to the Buildings.
-
+    """Configure the Modelica Building Library (MBL) path.  The mbl is always mounted into the
+    same folder within the Docker container. If the user has checked out MBL, then the folder
+    will already be at the level of Buildings folder, otherwise, the user most likely is
+    developing from a git checkout and we need to go down one level to get to the Buildings.
+    """
     if Path('/mnt/lib/mbl/package.mo').exists():
         mbl_path = Path('/mnt/lib/mbl')
         mbl_package_file = mbl_path / 'package.mo'

--- a/geojson_modelica_translator/modelica/lib/runner/om.py
+++ b/geojson_modelica_translator/modelica/lib/runner/om.py
@@ -7,6 +7,7 @@
 import argparse
 import logging
 import os
+import shutil
 from pathlib import Path
 from typing import Optional
 
@@ -95,6 +96,16 @@ def run_with_omc() -> bool:
     # import time
     # time.sleep(10000)
     os.system(cmd)
+
+    # remove the 'tmp' folder that was created, because it will
+    # have different permissions than the user running the container
+    path = Path(__file__).parent.absolute()
+    if (path / 'tmp' / 'temperatureResponseMatrix').exists():
+        shutil.rmtree(path / 'tmp' / 'temperatureResponseMatrix')
+        # check if the tmp folder is empty now, and if so remove
+        if not any((path / 'tmp').iterdir()):
+            (path / 'tmp').rmdir()
+
     return True
 
 

--- a/geojson_modelica_translator/modelica/modelica_runner.py
+++ b/geojson_modelica_translator/modelica/modelica_runner.py
@@ -323,8 +323,8 @@ class ModelicaRunner(object):
                 Path(f).unlink(missing_ok=True)
 
         # remove the 'tmp/temperatureResponseMatrix/*' folder if it exists
-        if (path / 'tmp/temperatureResponseMatrix').exists():
-            shutil.rmtree(path / 'tmp/temperatureResponseMatrix')
+        if (path / 'tmp' / 'temperatureResponseMatrix').exists():
+            shutil.rmtree(path / 'tmp' / 'temperatureResponseMatrix')
             # check if the tmp folder is empty now, and if so remove
             if not any((path / 'tmp').iterdir()):
                 (path / 'tmp').rmdir()

--- a/geojson_modelica_translator/modelica/modelica_runner.py
+++ b/geojson_modelica_translator/modelica/modelica_runner.py
@@ -322,9 +322,5 @@ class ModelicaRunner(object):
             for f in path.glob(pattern):  # type: ignore
                 Path(f).unlink(missing_ok=True)
 
-        # remove the 'tmp/temperatureResponseMatrix/*' folder if it exists
-        if (path / 'tmp' / 'temperatureResponseMatrix').exists():
-            shutil.rmtree(path / 'tmp' / 'temperatureResponseMatrix')
-            # check if the tmp folder is empty now, and if so remove
-            if not any((path / 'tmp').iterdir()):
-                (path / 'tmp').rmdir()
+        # Note that the om.py script that runs within the container does cleanup
+        # the 'tmp' folder including the 'tmp/temperatureResponseMatrix' folder

--- a/geojson_modelica_translator/modelica/modelica_runner.py
+++ b/geojson_modelica_translator/modelica/modelica_runner.py
@@ -319,7 +319,7 @@ class ModelicaRunner(object):
             f'{model_name}*.bin',
         ]
         for pattern in remove_files_glob:
-            for f in path.glob(pattern):
+            for f in path.glob(pattern):  # type: ignore
                 Path(f).unlink(missing_ok=True)
 
         # remove the 'tmp/temperatureResponseMatrix/*' folder if it exists

--- a/geojson_modelica_translator/modelica/modelica_runner.py
+++ b/geojson_modelica_translator/modelica/modelica_runner.py
@@ -320,7 +320,7 @@ class ModelicaRunner(object):
         ]
         for pattern in remove_files_glob:
             for f in path.glob(pattern):
-                f.unlink(missing_ok=True)
+                Path(f).unlink(missing_ok=True)
 
         # remove the 'tmp/temperatureResponseMatrix/*' folder if it exists
         if (path / 'tmp/temperatureResponseMatrix').exists():

--- a/geojson_modelica_translator/modelica/modelica_runner.py
+++ b/geojson_modelica_translator/modelica/modelica_runner.py
@@ -288,7 +288,7 @@ class ModelicaRunner(object):
                 debug (bool): whether to remove all files or not
         """
         # list of files to always remove
-        always_remove_files = [
+        files_to_remove = [
             f'{model_name}',
             f'{model_name}.makefile',
             f'{model_name}.libs',
@@ -304,9 +304,9 @@ class ModelicaRunner(object):
         ]
 
         if not kwargs.get('debug', False):
-            always_remove_files.extend(conditional_remove_files)
+            files_to_remove.extend(conditional_remove_files)
 
-        for f in always_remove_files:
+        for f in files_to_remove:
             (path / f).unlink(missing_ok=True)
 
         # The other files below will always be removed, debug or not

--- a/tests/model_connectors/test_mixed_loads.py
+++ b/tests/model_connectors/test_mixed_loads.py
@@ -109,7 +109,7 @@ class MixedLoadsTest(TestCaseBase):
         root_path = Path(self.district._scaffold.districts_path.files_dir).resolve()
         assert (root_path / 'DistrictEnergySystem.mo').exists()
 
-    @pytest.mark.simulatio
+    @pytest.mark.simulation
     @pytest.mark.skip("OMC Spawn - Failed to find spawn executable in Buildings Library")
     def test_simulate_mixed_loads_district_energy_system(self):
         self.run_and_assert_in_docker(


### PR DESCRIPTION
#### Any background context you want to provide?
It is not always desired to remove all the config and output files from the simulation

#### What does this PR accomplish?
Add a keyword arg to the `run_in_docker` and `cleanup_path` methods to not remove all the files upon simulation completion.

#### How should this be manually tested?
Ideally, use a Jupyter Notebook to test running w/ and w/o the debug flag.

```
mr = ModelicaRunner()
success, _ = mr.run_in_docker('compile_and_run', 'baseline.Districts.district', 
                         run_path=analysis_baseline_dir,
                         file_to_load=(analysis_baseline_dir / 'package.mo'),
                         start_time=0, stop_time=86400, step_size=300,
                         debug=True)
```

and 

```
mr = ModelicaRunner()
success, _ = mr.run_in_docker('compile_and_run', 'baseline.Districts.district', 
                         run_path=analysis_baseline_dir,
                         file_to_load=(analysis_baseline_dir / 'package.mo'),
                         start_time=0, stop_time=86400, step_size=300)
```

#### What are the relevant tickets?
n/a

#### Screenshots (if appropriate)
n/a
