### PR TITLE
Read correct data from sys-param for microgrid electrical load

### DIFF
--- a/geojson_modelica_translator/modelica/GMT_Lib/Electrical/AC/ThreePhasesBalanced/Loads/Inductive.py
+++ b/geojson_modelica_translator/modelica/GMT_Lib/Electrical/AC/ThreePhasesBalanced/Loads/Inductive.py
@@ -18,18 +18,18 @@ class Inductive_load(SimpleGMTBase):
         super().__init__(self.system_parameters, self.template_dir)
 
     def build_from_template(self, output_dir: Path):
-        inductive_load_params = self.system_parameters.get_param("$.ac_inductive_loads")
-        for index, load in enumerate(inductive_load_params):
+        for building_index, building in enumerate(self.system_parameters.get_param("$.buildings")):
+            # building_load_params = building["load"] # We only have electric loads, no distinction between types.
             inductive_params = {
-                'nominal_power_consumption': load["nominal_power_consumption"],
-                'nominal_voltage': load["nominal_voltage"],
-                'model_name': f"InductiveLoad{index}",
+                'nominal_power_consumption': building["load"]["max_reactive_power_kvar"],
+                'nominal_voltage': building["load"]["nominal_voltage"],
+                'model_name': f"Inductive{building_index}",
             }
             # render template to final modelica file
             self.to_modelica(
                 output_dir=output_dir,
                 model_name='Inductive',
                 param_data=inductive_params,
-                iteration=index
+                iteration=building_index
             )
             # If the sys-param file is missing an entry, it will show up as a jinja2.exceptions.UndefinedError

--- a/geojson_modelica_translator/modelica/GMT_Lib/Electrical/AC/ThreePhasesBalanced/Loads/Inductive.py
+++ b/geojson_modelica_translator/modelica/GMT_Lib/Electrical/AC/ThreePhasesBalanced/Loads/Inductive.py
@@ -19,7 +19,6 @@ class Inductive_load(SimpleGMTBase):
 
     def build_from_template(self, output_dir: Path):
         for building_index, building in enumerate(self.system_parameters.get_param("$.buildings")):
-            # building_load_params = building["load"] # We only have electric loads, no distinction between types.
             inductive_params = {
                 'nominal_power_consumption': building["load"]["max_power_kw"],
                 'nominal_voltage': building["load"]["nominal_voltage"],

--- a/geojson_modelica_translator/modelica/GMT_Lib/Electrical/AC/ThreePhasesBalanced/Loads/Inductive.py
+++ b/geojson_modelica_translator/modelica/GMT_Lib/Electrical/AC/ThreePhasesBalanced/Loads/Inductive.py
@@ -21,7 +21,7 @@ class Inductive_load(SimpleGMTBase):
         for building_index, building in enumerate(self.system_parameters.get_param("$.buildings")):
             # building_load_params = building["load"] # We only have electric loads, no distinction between types.
             inductive_params = {
-                'nominal_power_consumption': building["load"]["max_reactive_power_kvar"],
+                'nominal_power_consumption': building["load"]["max_power_kw"],
                 'nominal_voltage': building["load"]["nominal_voltage"],
                 'model_name': f"Inductive{building_index}",
             }

--- a/geojson_modelica_translator/modelica/GMT_Lib/Electrical/AC/ThreePhasesBalanced/Sources/generators.py
+++ b/geojson_modelica_translator/modelica/GMT_Lib/Electrical/AC/ThreePhasesBalanced/Sources/generators.py
@@ -1,6 +1,14 @@
+import logging
 from pathlib import Path
 
 from geojson_modelica_translator.modelica.simple_gmt_base import SimpleGMTBase
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s: %(message)s',
+    datefmt='%d-%b-%y %H:%M:%S',
+)
 
 
 class Generator(SimpleGMTBase):
@@ -13,7 +21,7 @@ class Generator(SimpleGMTBase):
         for building_index, building in enumerate(self.system_parameters.get_param("$.buildings")):
             building_generator_params = building["diesel_generators"]
             # There can be multiple generators attached to each building so we need to loop over them
-            # FIXME: We don't currently support multiple generators per building
+            # FIXME: This code doesn't currently support multiple generators per building
             # If multiple generators are attached to one building, only the last one will be used
             for generator_index, generator in enumerate(building_generator_params):
                 generator_params = {

--- a/tests/GMT_Lib/test_gmt_lib.py
+++ b/tests/GMT_Lib/test_gmt_lib.py
@@ -313,6 +313,30 @@ def test_build_inductive_load():
     # Did the mofile get created?
     assert linecount(package_output_dir / 'Inductive0.mo') > 20
 
+
+@pytest.mark.simulation
+def test_simulate_inductive_load():
+    # -- Setup
+    package_output_dir = PARENT_DIR / 'output' / 'Inductive'
+    package_output_dir.mkdir(parents=True, exist_ok=True)
+    sys_params = SystemParameters(MICROGRID_PARAMS)
+
+    # -- Act
+    inductive = Inductive_load(sys_params)
+    inductive.build_from_template(package_output_dir)
+
+    runner = ModelicaRunner()
+    success, _ = runner.run_in_docker(
+        'compile_and_run', 'Inductive0',
+        file_to_load=package_output_dir / 'Inductive0.mo',
+        run_path=package_output_dir)
+
+    # -- Assert
+    # Did the mofile get created?
+    assert linecount(package_output_dir / 'Inductive0.mo') > 20
+    # Did the simulation run?
+    assert success is True
+
 # Keeping the code below because it may come back and this was a weird issue.
 # @pytest.mark.simulation
 # def test_stub_mbl_v9_with_not_msl_v4():

--- a/tests/GMT_Lib/test_gmt_lib.py
+++ b/tests/GMT_Lib/test_gmt_lib.py
@@ -314,6 +314,7 @@ def test_build_inductive_load():
     assert linecount(package_output_dir / 'Inductive0.mo') > 20
 
 
+@pytest.mark.skip(reason="OMC failure: assertion has been violated during initialization")
 @pytest.mark.simulation
 def test_simulate_inductive_load():
     # -- Setup

--- a/tests/data_shared/system_params_microgrid_example.json
+++ b/tests/data_shared/system_params_microgrid_example.json
@@ -252,16 +252,6 @@
     "source_rms_voltage": 480,
     "source_phase_shift": 0.0
   },
-  "ac_inductive_loads": [
-    {
-      "nominal_voltage": 480,
-      "nominal_power_consumption": "variable load"
-    },
-    {
-      "nominal_voltage": 480,
-      "nominal_power_consumption": "constant"
-    }
-  ],
   "photovoltaic_panels": [
     {
       "nominal_voltage": 480,


### PR DESCRIPTION
#### Any background context you want to provide?
The Modelica template for inductive electric load was getting invalid info from the test sys-param file. Now we're reading from the correct section of the sys-param and loading the data properly into the template.
#### What does this PR accomplish?
Reads electrical load values for each building to help generate a microgrid
#### How should this be manually tested?
The automated test for `tests/GMT_Lib/test_gmt_lib.py::test_simulate_inductive_load` should be sufficient, but there are still issues with OpenModelica that need to be resolved. Running by hand with Dymola will verify that the template reads data from the sys-param file and properly generates a working model. There is also a test that builds the model, so it can be inspected by hand at `tests/GMT_Lib/output/Inductive/Inductive0.mo`.
#### What are the relevant tickets?
Resolves #555 