### PR TITLE
Stop and remove containers if user cancels a simulation

### DIFF
--- a/geojson_modelica_translator/modelica/lib/runner/om_docker.sh
+++ b/geojson_modelica_translator/modelica/lib/runner/om_docker.sh
@@ -6,19 +6,6 @@
 DOCKER_USERNAME=nrel
 IMG_NAME=gmt-om-runner
 
-# Catch signals to kill the container if it is interrupted
-# https://www.shellscript.sh/trap.html
-# Addresses https://github.com/urbanopt/geojson-modelica-translator/issues/384
-trap cleanup 1 2 3 6
-
-cleanup()
-{
-  echo "Caught Signal ... cleaning up."
-  rm -rf /tmp/temp_*.$$
-  echo "Done cleanup ... quitting."
-  exit 1
-}
-
 function create_mount_command()
 # Split path somehow. Replace double-slashes with single-slashes, to ensure compatibility with
 # Windows paths.


### PR DESCRIPTION
#### Any background context you want to provide?
When running tests developers often `ctrl-c` to cancel a test midway through a long-running simulation. The container is then left alive unnecessarily which is a resource drain.
#### What does this PR accomplish?
Catch KeyboardInterrupt while simulating and `kill` all containers from the `gmt-om-runner` image
#### How should this be manually tested?
- Start a simulation test
    - For instance `tests/GMT_Lib/test_gmt_lib.py::test_simulate_cooling_plant`
- `ctrl-c` once the simulation begins
- `docker ps -a` to check that containers from the image are removed
#### What are the relevant tickets?
Resolves #384 