### PR TITLE
Downgrade to OMC 1.20

### DIFF
--- a/geojson_modelica_translator/modelica/lib/runner/Dockerfile
+++ b/geojson_modelica_translator/modelica/lib/runner/Dockerfile
@@ -1,6 +1,6 @@
 # Use the OpenModelica Docker image
 # We only need this file for the copy command. The image can be/is loaded in the shell script instead of here.
-FROM openmodelica/openmodelica:v1.21.0-gui
+FROM openmodelica/openmodelica:v1.20.0-gui
 
 # libgfortran4 is needed to load FMU for FMUZoneAdapterZones1.mo
 RUN apt update && apt --no-install-recommends install -y \
@@ -18,6 +18,3 @@ RUN echo \
 
 # Put the om.py CLI into the container
 COPY ./om.py /mnt/lib/om.py
-
-
-# ln -s /mnt/Users/nlong/working/urban-analysis/modelica-buildings/Buildings ~/.openmodelica/libraries/Buildings\ 9.1.0


### PR DESCRIPTION
#### Any background context you want to provide?
OMC 1.21 does not work with the 7-building example file

#### What does this PR accomplish?
Downgrade the Dockerfile to pull from openmodelica:1.20-gui

#### How should this be manually tested?
New image has already been pushed to dockerhub. The CI should handle the tests.

#### What are the relevant tickets?
n/a

