### PR TITLE
Improve gfunction path

### DIFF
--- a/geojson_modelica_translator/model_connectors/plants/borefield.py
+++ b/geojson_modelica_translator/model_connectors/plants/borefield.py
@@ -97,7 +97,11 @@ class Borefield(PlantBase):
         }
 
         # process g-function file
-        gfunction = pd.read_csv((Path(template_data["gfunction"]["input_path"]) / "Gfunction.csv").resolve(), header=0)
+        if Path(template_data["gfunction"]["input_path"]).expanduser().is_absolute():
+            gfunction = pd.read_csv(Path(template_data["gfunction"]["input_path"]) / "Gfunction.csv", header=0)
+        else:
+            sys_param_dir = Path(self.system_parameters.filename).parent.resolve()
+            gfunction = pd.read_csv(sys_param_dir / template_data["gfunction"]["input_path"] / "Gfunction.csv", header=0)
         template_data["gfunction"]["gfunction_file_rows"] = gfunction.shape[0] + 1
 
         # convert the values to match Modelica gfunctions

--- a/geojson_modelica_translator/model_connectors/plants/borefield.py
+++ b/geojson_modelica_translator/model_connectors/plants/borefield.py
@@ -1,6 +1,7 @@
 # :copyright (c) URBANopt, Alliance for Sustainable Energy, LLC, and other contributors.
 # See also https://github.com/urbanopt/geojson-modelica-translator/blob/develop/LICENSE.md
 
+import logging
 import math
 import os
 from pathlib import Path
@@ -13,6 +14,13 @@ from geojson_modelica_translator.model_connectors.plants.plant_base import (
 )
 from geojson_modelica_translator.modelica.input_parser import PackageParser
 from geojson_modelica_translator.utils import ModelicaPath, simple_uuid
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s: %(message)s',
+    datefmt='%d-%b-%y %H:%M:%S',
+)
 
 
 class Borefield(PlantBase):
@@ -101,7 +109,10 @@ class Borefield(PlantBase):
             gfunction = pd.read_csv(Path(template_data["gfunction"]["input_path"]) / "Gfunction.csv", header=0)
         else:
             sys_param_dir = Path(self.system_parameters.filename).parent.resolve()
-            gfunction = pd.read_csv(sys_param_dir / template_data["gfunction"]["input_path"] / "Gfunction.csv", header=0)
+            try:
+                gfunction = pd.read_csv(sys_param_dir / template_data["gfunction"]["input_path"] / "Gfunction.csv", header=0)
+            except FileNotFoundError:
+                raise SystemExit(f'When using a relative path to your ghe_dir, your path \'{template_data["gfunction"]["input_path"]}\' must be relative to the dir your sys-param file is in.')
         template_data["gfunction"]["gfunction_file_rows"] = gfunction.shape[0] + 1
 
         # convert the values to match Modelica gfunctions

--- a/geojson_modelica_translator/system_parameters/schema.json
+++ b/geojson_modelica_translator/system_parameters/schema.json
@@ -919,7 +919,7 @@
           "type": "string"
         },
         "ghe_dir": {
-          "description": "Results directory for GHE Designer",
+          "description": "Results directory for GHE Designer. Absolute path, or relative to the sys-param file.",
           "type": "string"
         },
         "ghe_specific_params": {

--- a/tests/model_connectors/data/system_params_ghe.json
+++ b/tests/model_connectors/data/system_params_ghe.json
@@ -42,7 +42,7 @@
     "fifth_generation": {
       "ghe_parameters": {
         "version": "1.0",
-        "ghe_dir": "tests/model_connectors/data",
+        "ghe_dir": "./",
         "fluid": {
           "fluid_name": "Water",
           "concentration_percent": 0.0,


### PR DESCRIPTION
#### Any background context you want to provide?
The code to read the ghe_dir worked, but was brittle - it only worked if the user was in the GMT root.
#### What does this PR accomplish?
Borefield.py now checks if the path supplied by the user in the sys-param file is absolute, and if so, uses it. If it's not absolute, it assumes the path is relative to the sys-param file. The schema entry was updated to say exactly that.
#### How should this be manually tested?
Try supplying either an absolute path or a path relative to the sys-param file (`./`) and running tests/model_connectors/test_borefield.py::test_build_district_system. Try supplying bogus paths to confirm the graceful error message appears.