### PR TITLE
initialize empty variable before potential use

### DIFF
--- a/geojson_modelica_translator/geojson/urbanopt_geojson.py
+++ b/geojson_modelica_translator/geojson/urbanopt_geojson.py
@@ -55,6 +55,7 @@ class UrbanOptGeoJson(object):
 
         self.schemas = Schemas()
 
+        errors = ""
         building_errors = {}
         self.buildings = []
         for feature in self.data.features:


### PR DESCRIPTION
#### Any background context you want to provide?
When running the GMT via the CLI on a Windows computer we found a situation where we could reference a variable before assigning it.
#### What does this PR accomplish?
Initialize the variable as an empty string first.
#### How should this be manually tested?
