### PR TITLE
Include 5G partial model in generation

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -26,6 +26,7 @@
     "Reparse",
     "setpoint",
     "tanushree",
+    "Templatized",
     "timeseries",
     "timestep",
     "urbanopt",

--- a/geojson_modelica_translator/modelica/GMT_Lib/DHC/DHC_5G_partial.mot
+++ b/geojson_modelica_translator/modelica/GMT_Lib/DHC/DHC_5G_partial.mot
@@ -106,14 +106,14 @@ partial model PartialSeries "Partial model for series network"
     final lEnd=datDes.lEnd,
     final allowFlowReversal=allowFlowReversalSer) "Distribution network"
     annotation (Placement(transformation(extent={{-20,130},{20,150}})));
-  Modelica.Fluid.Sensors.TemperatureTwoPort TDisWatSup(
+  Buildings.Fluid.Sensors.TemperatureTwoPort TDisWatSup(
     redeclare final package Medium = Medium,
     final m_flow_nominal=datDes.mPumDis_flow_nominal)
     "District water supply temperature"
     annotation (Placement(transformation(extent={{-10,-10},{10,10}},
         rotation=90,
         origin={-80,20})));
-  Modelica.Fluid.Sensors.TemperatureTwoPort TDisWatRet(
+  Buildings.Fluid.Sensors.TemperatureTwoPort TDisWatRet(
     redeclare final package Medium = Medium,
     final m_flow_nominal=datDes.mPumDis_flow_nominal)
     "District water return temperature"
@@ -121,7 +121,7 @@ partial model PartialSeries "Partial model for series network"
         extent={{10,-10},{-10,10}},
         rotation=90,
         origin={80,0})));
-  Modelica.Fluid.Sensors.TemperatureTwoPort TDisWatBorLvg(
+  Buildings.Fluid.Sensors.TemperatureTwoPort TDisWatBorLvg(
     redeclare final package Medium = Medium,
     final m_flow_nominal=datDes.mPumDis_flow_nominal)
     "District water borefield leaving temperature"

--- a/geojson_modelica_translator/modelica/GMT_Lib/DHC/DHC_5G_partial.mot
+++ b/geojson_modelica_translator/modelica/GMT_Lib/DHC/DHC_5G_partial.mot
@@ -1,3 +1,4 @@
+within {{ data['project_name'] }}.Districts;{% raw %}
 partial model PartialSeries "Partial model for series network"
   extends Modelica.Icons.Example;
   package Medium = Buildings.Media.Water "Medium model";
@@ -105,14 +106,14 @@ partial model PartialSeries "Partial model for series network"
     final lEnd=datDes.lEnd,
     final allowFlowReversal=allowFlowReversalSer) "Distribution network"
     annotation (Placement(transformation(extent={{-20,130},{20,150}})));
-  Fluid.Sensors.TemperatureTwoPort TDisWatSup(
+  Modelica.Fluid.Sensors.TemperatureTwoPort TDisWatSup(
     redeclare final package Medium = Medium,
     final m_flow_nominal=datDes.mPumDis_flow_nominal)
     "District water supply temperature"
     annotation (Placement(transformation(extent={{-10,-10},{10,10}},
         rotation=90,
         origin={-80,20})));
-  Fluid.Sensors.TemperatureTwoPort TDisWatRet(
+  Modelica.Fluid.Sensors.TemperatureTwoPort TDisWatRet(
     redeclare final package Medium = Medium,
     final m_flow_nominal=datDes.mPumDis_flow_nominal)
     "District water return temperature"
@@ -120,7 +121,7 @@ partial model PartialSeries "Partial model for series network"
         extent={{10,-10},{-10,10}},
         rotation=90,
         origin={80,0})));
-  Fluid.Sensors.TemperatureTwoPort TDisWatBorLvg(
+  Modelica.Fluid.Sensors.TemperatureTwoPort TDisWatBorLvg(
     redeclare final package Medium = Medium,
     final m_flow_nominal=datDes.mPumDis_flow_nominal)
     "District water borefield leaving temperature"
@@ -142,19 +143,19 @@ partial model PartialSeries "Partial model for series network"
   Modelica.Blocks.Sources.Constant TSewWat(k=273.15 + 17)
     "Sewage water temperature"
     annotation (Placement(transformation(extent={{-280,30},{-260,50}})));
- Buildings.Controls.OBC.CDL.Continuous.Sources.Constant THeaWatSupMaxSet[nBui](
+  Buildings.Controls.OBC.CDL.Continuous.Sources.Constant THeaWatSupMaxSet[nBui](
     k=bui.THeaWatSup_nominal)
     "Heating water supply temperature set point - Maximum value"
     annotation (Placement(transformation(extent={{-250,210},{-230,230}})));
- Buildings.Controls.OBC.CDL.Continuous.Sources.Constant TChiWatSupSet[nBui](
+  Buildings.Controls.OBC.CDL.Continuous.Sources.Constant TChiWatSupSet[nBui](
     k=bui.TChiWatSup_nominal)
     "Chilled water supply temperature set point"
     annotation (Placement(transformation(extent={{-220,190},{-200,210}})));
- Buildings.Controls.OBC.CDL.Continuous.Sources.Constant THeaWatSupMinSet[nBui](
+  Buildings.Controls.OBC.CDL.Continuous.Sources.Constant THeaWatSupMinSet[nBui](
     each k=28 + 273.15)
     "Heating water supply temperature set point - Minimum value"
     annotation (Placement(transformation(extent={{-280,230},{-260,250}})));
- Buildings.Controls.OBC.CDL.Continuous.MultiSum PPumETS(
+  Buildings.Controls.OBC.CDL.Continuous.MultiSum PPumETS(
     final nin=nBui)
     "ETS pump power"
     annotation (Placement(transformation(extent={{140,190},{160,210}})));
@@ -173,10 +174,10 @@ partial model PartialSeries "Partial model for series network"
   Modelica.Blocks.Continuous.Integrator EPumPla(initType=Modelica.Blocks.Types.Init.InitialState)
     "Plant pump electric energy"
     annotation (Placement(transformation(extent={{220,30},{240,50}})));
- Buildings.Controls.OBC.CDL.Continuous.MultiSum EPum(nin=4)
+  Buildings.Controls.OBC.CDL.Continuous.MultiSum EPum(nin=4)
     "Total pump electric energy"
     annotation (Placement(transformation(extent={{280,110},{300,130}})));
- Buildings.Controls.OBC.CDL.Continuous.MultiSum PHeaPump(
+  Buildings.Controls.OBC.CDL.Continuous.MultiSum PHeaPump(
     final nin=nBui)
     "Heat pump power"
     annotation (Placement(transformation(extent={{140,150},{160,170}})));
@@ -184,7 +185,7 @@ partial model PartialSeries "Partial model for series network"
     initType=Modelica.Blocks.Types.Init.InitialState)
     "Heat pump electric energy"
     annotation (Placement(transformation(extent={{220,150},{240,170}})));
- Buildings.Controls.OBC.CDL.Continuous.MultiSum ETot(nin=2) "Total electric energy"
+  Buildings.Controls.OBC.CDL.Continuous.MultiSum ETot(nin=2) "Total electric energy"
     annotation (Placement(transformation(extent={{320,150},{340,170}})));
   Buildings.Experimental.DHC.Loads.BaseClasses.ConstraintViolation conVio(
     final uMin=datDes.TLooMin,
@@ -221,8 +222,8 @@ equation
           180},{20,160},{12,160},{12,150}}, color={0,127,255}));
   connect(dis.ports_bCon, bui.port_aSerAmb) annotation (Line(points={{-12,150},{
           -12,160},{-20,160},{-20,180},{-10,180}}, color={0,127,255}));
-  connect(TSewWat.y, pla.TSewWat) annotation (Line(points={{-259,40},{-180,40},{
-          -180,7.33333},{-161.333,7.33333}},
+  connect(TSewWat.y, pla.TSewWat) annotation (Line(points={{-259,40},{-180,40},
+          {-180,7.33333},{-161.333,7.33333}},
                               color={0,0,127}));
   connect(THeaWatSupMaxSet.y, bui.THeaWatSupMaxSet) annotation (Line(points={{-228,
           220},{-20,220},{-20,187},{-12,187}}, color={0,0,127}));
@@ -243,21 +244,21 @@ equation
     annotation (Line(points={{71,-71},{71,-80},{218,-80}}, color={0,0,127}));
   connect(pumSto.P, EPumSto.u) annotation (Line(points={{-169,-71},{-160,-71},{-160,
           -140},{218,-140}}, color={0,0,127}));
-  connect(pla.PPum, EPumPla.u) annotation (Line(points={{-138.667,5.33333},{-120,
-          5.33333},{-120,40},{218,40}},      color={0,0,127}));
+  connect(pla.PPum, EPumPla.u) annotation (Line(points={{-138.667,5.33333},{
+          -120,5.33333},{-120,40},{218,40}}, color={0,0,127}));
   connect(EPumETS.y, EPum.u[1]) annotation (Line(points={{241,200},{260,200},{
           260,121.5},{278,121.5}},
-                               color={0,0,127}));
+                              color={0,0,127}));
   connect(EPumPla.y, EPum.u[2]) annotation (Line(points={{241,40},{260,40},{260,
           120.5},{278,120.5}}, color={0,0,127}));
   connect(EPumDis.y, EPum.u[3]) annotation (Line(points={{241,-80},{262,-80},{
           262,119.5},{278,119.5}},
-                               color={0,0,127}));
+                              color={0,0,127}));
   connect(EPumSto.y, EPum.u[4]) annotation (Line(points={{241,-140},{264,-140},
           {264,118.5},{278,118.5}},color={0,0,127}));
   connect(bui.PHea, PHeaPump.u) annotation (Line(points={{12,189},{120,189},{
           120,160},{138,160}},
-                           color={0,0,127}));
+                          color={0,0,127}));
   connect(PHeaPump.y, EHeaPum.u)
     annotation (Line(points={{162,160},{218,160}}, color={0,0,127}));
   connect(EHeaPum.y, ETot.u[1]) annotation (Line(points={{241,160},{300,160},{
@@ -275,6 +276,10 @@ equation
     coordinateSystem(preserveAspectRatio=false, extent={{-360,-260},{360,260}})),
       Documentation(revisions="<html>
 <ul>
+<li>
+April 12, 2023, by Nicholas Long:<br/>
+Templatized for direct use in GMT with n-building connectors.
+<li>
 <li>
 November 16, 2022, by Michael Wetter:<br/>
 Set correct nominal pressure for distribution pump.
@@ -299,3 +304,4 @@ and configure some component sizes.
 </p>
 </html>"));
 end PartialSeries;
+{% endraw %}

--- a/geojson_modelica_translator/modelica/GMT_Lib/DHC/DHC_5G_waste_heat_GHX.mot
+++ b/geojson_modelica_translator/modelica/GMT_Lib/DHC/DHC_5G_waste_heat_GHX.mot
@@ -6,9 +6,9 @@ model district
       Buildings.Experimental.DHC.Loads.Combined.BuildingTimeSeriesWithETS
       bui[nBui](final filNam=filNam), datDes(
       {% endraw %}nBui={{ data['building_load_files'] | count }},
-      mPumDis_flow_nominal={{ data['max_flow_rate']}},
-      mPipDis_flow_nominal={{ data['max_flow_rate']}},
-      mPla_flow_nominal={{ data['max_flow_rate']}},
+      mPumDis_flow_nominal={{ data['max_flow_rate'] }},
+      mPla_flow_nominal={{ data['max_flow_rate'] }},
+      mSto_flow_nominal={{ data['max_flow_rate'] / 10 }},
       dp_length_nominal=250,{% raw %}
       epsPla=0.935));
   parameter String filNam[nBui]={
@@ -19,11 +19,15 @@ model district
   Modelica.Blocks.Sources.Constant masFloMaiPum(
     k=datDes.mPumDis_flow_nominal)
     "Distribution pump mass flow rate"
-    annotation (Placement(transformation(extent={{-280,-70},{-260,-50}})));
+    annotation (Placement(transformation(extent={{-300,-70},{-280,-50}})));
   Modelica.Blocks.Sources.Constant masFloDisPla(
     k=datDes.mPla_flow_nominal)
     "District water flow rate to plant"
-    annotation (Placement(transformation(extent={{-250,10},{-230,30}})));
+    annotation (Placement(transformation(extent={{-300,-6},{-280,14}})));
+  Modelica.Blocks.Sources.Constant masFloStoPum(
+    k=datDes.mSto_flow_nominal)
+    "Storage/GHX pump mass flow rate"
+    annotation (Placement(transformation(extent={{-300,-108},{-280,-88}})));
   Buildings.Controls.OBC.CDL.Continuous.Sources.Constant THotWatSupSet[nBui](
     k=fill(63 + 273.15, nBui))
     "Hot water supply temperature set point"
@@ -33,13 +37,12 @@ model district
     "Cold water temperature"
     annotation (Placement(transformation(extent={{-160,150},{-140,170}})));
 equation
-  connect(masFloMaiPum.y, pumDis.m_flow_in) annotation (Line(points={{-259,-60},
-          {60,-60},{60,-60},{68,-60}}, color={0,0,127}));
-  connect(pumSto.m_flow_in, masFloMaiPum.y) annotation (Line(points={{-180,-68},
-          {-180,-60},{-259,-60}}, color={0,0,127}));
-  connect(masFloDisPla.y, pla.mPum_flow) annotation (Line(points={{-229,20},{
-          -184,20},{-184,4.66667},{-161.333,4.66667}},
-                                  color={0,0,127}));
+  connect(masFloMaiPum.y, pumDis.m_flow_in) annotation (Line(points={{-279,-60},
+          {-106,-60},{68,-60}}, color={0,0,127}));
+  connect(masFloStoPum.y, pumSto.m_flow_in) annotation (Line(points={{-279,-98},
+          {-238,-98},{-238,-66},{-180,-66}},  color={0,0,127}));
+  connect(masFloDisPla.y, pla.mPum_flow) annotation (Line(points={{-279,4},{
+          -161.333,4},{-161.333,4.66667}}, color={0,0,127}));
   connect(THotWatSupSet.y, bui.THotWatSupSet) annotation (Line(points={{-168,
           180},{-24,180},{-24,183},{-12,183}}, color={0,0,127}));
   connect(TColWat.y, bui.TColWat) annotation (Line(points={{-138,160},{-40,160},
@@ -47,9 +50,6 @@ equation
   annotation (
   Diagram(
   coordinateSystem(preserveAspectRatio=false, extent={{-360,-260},{360,260}})),
-    __Dymola_Commands(
-  file="modelica://Buildings/Resources/Scripts/Dymola/Experimental/DHC/Examples/Combined/SeriesConstantFlow.mos"
-  "Simulate and plot"),
   experiment(
       StopTime=31536000,
       Interval=300,
@@ -79,7 +79,10 @@ Energy, Volume 199, 15 May 2020, 117418.
 <ul>
 <li>
 April 12, 2023, by Nicholas Long:<br/>
-Templatized for direct use in GMT with n-building connectors.
+Templatized for direct use in GMT with n-building connectors.<br/>
+Changes include: removing dymola run command tied to MBL path, adding
+a constant for borehole field mass flow rate (no longer tied to main
+distribution loop).
 <li>
 February 23, 2021, by Antoine Gautier:<br/>
 Refactored with base classes from the <code>DHC</code> package.<br/>

--- a/geojson_modelica_translator/modelica/GMT_Lib/DHC/DHC_5G_waste_heat_GHX.mot
+++ b/geojson_modelica_translator/modelica/GMT_Lib/DHC/DHC_5G_waste_heat_GHX.mot
@@ -2,7 +2,7 @@ within {{ data['project_name'] }}.Districts;{% raw %}
 model district
   "Series connection with constant district water mass flow rate"
   extends
-    Buildings.Experimental.DHC.Examples.Combined.BaseClasses.PartialSeries(      redeclare
+    PartialSeries(redeclare
       Buildings.Experimental.DHC.Loads.Combined.BuildingTimeSeriesWithETS
       bui[nBui](final filNam=filNam), datDes(
       {% endraw %}nBui={{ data['building_load_files'] | count }},

--- a/geojson_modelica_translator/modelica/GMT_Lib/DHC/DHC_5G_waste_heat_GHX.py
+++ b/geojson_modelica_translator/modelica/GMT_Lib/DHC/DHC_5G_waste_heat_GHX.py
@@ -75,7 +75,7 @@ class DHC5GWasteHeatAndGHX(SimpleGMTBase):
                 mos_file.replace_header_variable_value('Peak water heating load', peak_swh)
                 mos_file.save()
 
-            # 4: add the path to the param data with Modelica friendly path names
+            # 4: Add the path to the param data with Modelica friendly path names
             rel_path_name = f"{project_name}/{scaffold.districts_path.resources_relative_dir}/{file_to_copy['geojson_id']}/{file_to_copy['save_filename']}"
             template_data['building_load_files'].append(f"modelica://{rel_path_name}")  # type: ignore
 
@@ -93,7 +93,8 @@ class DHC5GWasteHeatAndGHX(SimpleGMTBase):
                          model_name='DHC_5G_waste_heat_GHX',
                          param_data=template_data,
                          save_file_name='district.mo',
-                         generate_package=True)
+                         generate_package=True,
+                         partial_files={'DHC_5G_partial': 'PartialSeries'})
 
         # 7: save the root package.mo
         package.save()

--- a/geojson_modelica_translator/modelica/modelica_project.py
+++ b/geojson_modelica_translator/modelica/modelica_project.py
@@ -82,7 +82,7 @@ class ModelicaProject:
     def __init__(self, package_file):
         self.root_directory = Path(package_file).parent
         self.file_types = ['.mo', '.txt', '.mos', '.order']
-        self.file_types_to_skip = ['.log', '.mat']
+        self.file_types_to_skip = ['.log', '.mat', '.DS_Store', ]
         self.file_data = {}
 
         self._load_data()

--- a/geojson_modelica_translator/modelica/simple_gmt_base.py
+++ b/geojson_modelica_translator/modelica/simple_gmt_base.py
@@ -17,7 +17,7 @@ class SimpleGMTBase(ModelBase):
         super().__init__(system_parameters, template_dir)
 
     def to_modelica(self, output_dir: Path, model_name: str, param_data: dict, iteration=None,
-                    save_file_name=None, generate_package=False) -> None:
+                    save_file_name=None, generate_package=False, partial_files: dict = None) -> None:
         """Render the template to a Modelica file.
 
         Args:
@@ -31,6 +31,8 @@ class SimpleGMTBase(ModelBase):
                                             Defaults to None.
             generate_package (bool, optional): If True, then a package.mo and package.order file will be created
                                                alongside the rendered template (Modelica) file. Defaults to False.
+            partial_files (dict, optional): If the model has partial files, then this is a dictionary of the
+                                            partial file name and the Modelica file name to save it as. Defaults to None.
         """
         # render template to final modelica file
         model_template = self.template_env.get_template(f"{model_name}.mot")
@@ -52,13 +54,28 @@ class SimpleGMTBase(ModelBase):
             data=param_data
         )
 
+        # store the order of the models that will be in the package (if requested)
+        package_order = []
+        package_order.append(save_file_name.stem)
+
+        # Check if there are partial models (or other templated data) to be evaluated / saved.
+        if partial_files:
+            for template, filename in partial_files.items():
+                self.run_template(
+                    template=self.template_env.get_template(f"{template}.mot"),
+                    save_file_name=output_dir / f"{filename}.mo",
+                    project_name=output_dir.stem,
+                    data=param_data
+                )
+                package_order.insert(0, filename)
+
         # include package.mo and package.order files if requested.
         # TODO: This will need to be updated to support multiple models in the "order".
         if generate_package:
             package = PackageParser.new_from_template(
                 str(output_dir),
                 output_dir.stem,
-                order=[save_file_name.stem],
+                order=package_order,
                 within=output_dir.parent.stem
             )
             package.save()

--- a/tests/GMT_Lib/test_gmt_lib_des.py
+++ b/tests/GMT_Lib/test_gmt_lib_des.py
@@ -54,14 +54,14 @@ class GmtLibDesTest(unittest.TestCase):
             assert '#Peak water heating load = 7714.5 Watts' in f.read()
 
         # -- Act - with simulation
-        # runner = ModelicaRunner()
-        # success, _ = runner.run_in_docker(
-        #     'compile_and_run', f"{package_name}.Districts.district",
-        #     file_to_load=package_output_dir / package_name / 'package.mo',
-        #     run_path=package_output_dir / package_name,
-        #     start_time=0, stop_time=86400)
+        runner = ModelicaRunner()
+        success, _ = runner.run_in_docker(
+            'compile_and_run', f"{package_name}.Districts.district",
+            file_to_load=package_output_dir / package_name / 'package.mo',
+            run_path=package_output_dir / package_name,
+            start_time=0, stop_time=86400)
 
-        # assert success is True
+        assert success is True
 
     @pytest.mark.dymola
     def test_5G_des_waste_heat_and_ghx_dymola(self):

--- a/tests/GMT_Lib/test_gmt_lib_des.py
+++ b/tests/GMT_Lib/test_gmt_lib_des.py
@@ -53,7 +53,7 @@ class GmtLibDesTest(unittest.TestCase):
         with open(package_output_dir / package_name / 'Resources' / 'Data' / 'Districts' / '8' / 'B11.mos', 'r') as f:
             assert '#Peak water heating load = 7714.5 Watts' in f.read()
 
-        # -- Act - with simulation
+        # # -- Act - with simulation
         runner = ModelicaRunner()
         success, _ = runner.run_in_docker(
             'compile_and_run', f"{package_name}.Districts.district",
@@ -61,7 +61,7 @@ class GmtLibDesTest(unittest.TestCase):
             run_path=package_output_dir / package_name,
             start_time=0, stop_time=86400)
 
-        assert success is True
+        # assert success is True
 
     @pytest.mark.dymola
     def test_5G_des_waste_heat_and_ghx_dymola(self):

--- a/tests/GMT_Lib/test_gmt_lib_des.py
+++ b/tests/GMT_Lib/test_gmt_lib_des.py
@@ -54,14 +54,14 @@ class GmtLibDesTest(unittest.TestCase):
             assert '#Peak water heating load = 7714.5 Watts' in f.read()
 
         # -- Act - with simulation
-        runner = ModelicaRunner()
-        success, _ = runner.run_in_docker(
-            'compile_and_run', f"{package_name}.Districts.district",
-            file_to_load=package_output_dir / package_name / 'package.mo',
-            run_path=package_output_dir / package_name,
-            start_time=0, stop_time=86400)
+        # runner = ModelicaRunner()
+        # success, _ = runner.run_in_docker(
+        #     'compile_and_run', f"{package_name}.Districts.district",
+        #     file_to_load=package_output_dir / package_name / 'package.mo',
+        #     run_path=package_output_dir / package_name,
+        #     start_time=0, stop_time=86400)
 
-        assert success is True
+        # assert success is True
 
     @pytest.mark.dymola
     def test_5G_des_waste_heat_and_ghx_dymola(self):


### PR DESCRIPTION
#### Any background context you want to provide?
Many of the 'operational' variables of the 5G systems are buried in the partial model within the MBL. Need to expose the model to the GMT to allow for model manipulation.

#### What does this PR accomplish?
* template the PartialSeries model
* update the Simple GMT Base to allow passing a dict of 'template' models to replace. In a very simple way.

#### How should this be manually tested?
* code review
* CI 
* Generate 5G_DES model and run in dymola.

#### What are the relevant tickets?
n/a
#### Screenshots (if appropriate)
