### PR TITLE
Add district nominal pump head to system parameters file

### DIFF
--- a/geojson_modelica_translator/model_connectors/networks/templates/NetworkDistributionPump_Instance.mopt
+++ b/geojson_modelica_translator/model_connectors/networks/templates/NetworkDistributionPump_Instance.mopt
@@ -22,7 +22,7 @@
     use_inputFilter=true,
     riseTime=20,
     m_flow_nominal=datDes.mPumDis_flow_nominal,
-    dp_nominal=50000)
+    dp_nominal={{ sys_params.district_system.fifth_generation.central_pump_parameters.pump_design_head }})
     "Distribution pump"
     {% raw %}annotation (Placement(transformation(extent={{10,-10},{-10,10}},rotation=270,origin={-44,-60})));
   // pump controller

--- a/geojson_modelica_translator/system_parameters/schema.json
+++ b/geojson_modelica_translator/system_parameters/schema.json
@@ -1213,6 +1213,16 @@
                   }
                 }
               ]
+            },
+            "central_pump_parameters": {
+              "description": "Parameters for central pump",
+              "type": "object",
+              "properties": {
+                "pump_design_head": {
+                  "description": "Height at which a pump can raise fluid up. ",
+                  "type": "number"
+                }
+              }
             }
           }
         }
@@ -1238,6 +1248,16 @@
                   }
                 }
               ]
+            },
+            "central_pump_parameters": {
+              "description": "Parameters for central pump",
+              "type": "object",
+              "properties": {
+                "pump_design_head": {
+                  "description": "Height at which a pump can raise fluid up. ",
+                  "type": "number"
+                }
+              }
             }
           }
         }

--- a/geojson_modelica_translator/system_parameters/schema.json
+++ b/geojson_modelica_translator/system_parameters/schema.json
@@ -1219,7 +1219,7 @@
               "type": "object",
               "properties": {
                 "pump_design_head": {
-                  "description": "Height at which a pump can raise fluid up. ",
+                  "description": "Measured in Pa",
                   "type": "number"
                 }
               }
@@ -1254,7 +1254,7 @@
               "type": "object",
               "properties": {
                 "pump_design_head": {
-                  "description": "Height at which a pump can raise fluid up. ",
+                  "description": "Measured in Pa.",
                   "type": "number"
                 }
               }

--- a/geojson_modelica_translator/system_parameters/time_series_microgrid_template.json
+++ b/geojson_modelica_translator/system_parameters/time_series_microgrid_template.json
@@ -77,6 +77,9 @@
         "temp_setpoint_hhw": 54,
         "pressure_drop_hhw_valve_nominal": 6001,
         "chp_installed": false
+      },
+      "central_pump_parameters": {
+        "pump_design_head": 60000
       }
     }
   },

--- a/geojson_modelica_translator/system_parameters/time_series_template.json
+++ b/geojson_modelica_translator/system_parameters/time_series_template.json
@@ -74,6 +74,9 @@
         "temp_setpoint_hhw": 54,
         "pressure_drop_hhw_valve_nominal": 6001,
         "chp_installed": false
+      },
+      "central_pump_parameters": {
+        "pump_design_head": 60000
       }
     },
     "fifth_generation": {
@@ -135,6 +138,9 @@
             }
           }
         ]
+      },
+      "central_pump_parameters": {
+        "pump_design_head": 60000
       }
     }
   },

--- a/management/data/baseline_sys_params.json
+++ b/management/data/baseline_sys_params.json
@@ -118,6 +118,9 @@
         "temp_setpoint_hhw": 68,
         "pressure_drop_hhw_valve_nominal": 6001,
         "chp_installed": false
+      },
+      "central_pump_parameters": {
+        "pump_design_head": 60000
       }
     }
   },

--- a/tests/model_connectors/data/system_params_ghe.json
+++ b/tests/model_connectors/data/system_params_ghe.json
@@ -40,6 +40,9 @@
   ],
   "district_system": {
     "fifth_generation": {
+      "central_pump_parameters": {
+        "pump_design_head": 60000
+      },
       "ghe_parameters": {
         "version": "1.0",
         "ghe_dir": "../../management/data/sdk_project_scraps/run/baseline_scenario/ghe_dir",

--- a/tests/model_connectors/data/system_params_ghe_2.json
+++ b/tests/model_connectors/data/system_params_ghe_2.json
@@ -82,6 +82,9 @@
       "central_heating_plant_parameters": {
         "temp_setpoint_hhw": 25
       },
+      "central_pump_parameters": {
+        "pump_design_head": 60000
+      },
       "ghe_parameters": {
         "version": "1.0",
         "ghe_dir": "../../management/data/sdk_project_scraps/run/baseline_scenario/ghe_dir",


### PR DESCRIPTION
#### Any background context you want to provide?
MBLv10 has changes to their pump model which sets an upper bound to the actual pump head based on the nominal head. This has caused the 5G district models to fail if the nominal pump head is not set correctly.

#### What does this PR accomplish?
This PR fixes the above issue by allowing the users to change the nominal district pump head from the system parameters file.

#### How should this be manually tested?
poetry run pytest -m 'not dymola' tests/model_connectors/test_district_single_ghe.py

#### What are the relevant tickets?
#609 

#### Screenshots (if appropriate)
