### PR TITLE
Use Ubuntu 20 and fix CHP model

### DIFF
--- a/geojson_modelica_translator/model_connectors/plants/templates/HeatingPlantWithCHP.mot
+++ b/geojson_modelica_translator/model_connectors/plants/templates/HeatingPlantWithCHP.mot
@@ -73,7 +73,7 @@ within {{ project_name }}.Plants;
     final unit="Pa")
     "Measured pressure difference"
     annotation (Placement(transformation(extent={{-160,-40},{-140,-20}}),iconTransformation(extent={{-140,-50},{-100,-10}})));
-  Boiler_TParallel boiHotWat(
+  Boiler_TParallel_new boiHotWat(
     redeclare package Medium=Medium,
     m_flow_nominal=mBoi_flow_nominal,
     Q_flow_nominal=QBoi_flow_nominal,
@@ -239,7 +239,7 @@ equation
     annotation (Line(points={{-99,-30},{-94,-30},{-94,4},{-82,4}},color={0,0,127}));
   connect(pumOn.y,pumHW.u)
     annotation (Line(points={{-59,10},{-46,10},{-46,72},{12,72},{12,54},{2,54}},color={0,0,127}));
-  connect(boiStaCon.y_On,heaWatPumCon.ON)
+  connect(on,heaWatPumCon.ON)
     annotation (Line(points={{-99,70.6},{-88,70.6},{-88,24},{-128,24},{-128,-23.4},{-121,-23.4}},color={255,0,255}));
   connect(mPum_flow.y,heaWatPumCon.masFloPum)
     annotation (Line(points={{-121,40},{-134,40},{-134,-25.6},{-121,-25.6}},color={0,0,127}));

--- a/geojson_modelica_translator/modelica/GMT_Lib/DHC/DHC_5G_waste_heat_GHX.mot
+++ b/geojson_modelica_translator/modelica/GMT_Lib/DHC/DHC_5G_waste_heat_GHX.mot
@@ -13,10 +13,6 @@ model district
       epsPla=0.935,
       {{ data['lDis'] }},
       {{ data['lCon'] }}
-      ),
-      dis(
-        {{ data['dhDis'] }},
-        {{ data['dhCon'] }}
       )
       );
   parameter String filNam[nBui]={

--- a/geojson_modelica_translator/modelica/GMT_Lib/DHC/DHC_5G_waste_heat_GHX.py
+++ b/geojson_modelica_translator/modelica/GMT_Lib/DHC/DHC_5G_waste_heat_GHX.py
@@ -98,8 +98,6 @@ class DHC5GWasteHeatAndGHX(SimpleGMTBase):
         nbuildings = len(template_data['building_load_files'])
         template_data['lDis'] = self.build_string("lDis = {", "0.5, ", nbuildings)
         template_data['lCon'] = self.build_string("lCon = {", "0.5, ", nbuildings)
-        template_data['dhDis'] = self.build_string("dhDis = {", "0.5, ", nbuildings)
-        template_data['dhCon'] = self.build_string("dhCon = {", "0.6, ", nbuildings)
 
         # 6: generate the modelica files from the template
         self.to_modelica(output_dir=Path(scaffold.districts_path.files_dir),

--- a/geojson_modelica_translator/modelica/GMT_Lib/DHC/DHC_5G_waste_heat_GHX_variable.mot
+++ b/geojson_modelica_translator/modelica/GMT_Lib/DHC/DHC_5G_waste_heat_GHX_variable.mot
@@ -13,10 +13,6 @@ model district
       epsPla=0.935,
       {{ data['lDis'] }},
       {{ data['lCon'] }}
-      ),
-      dis(
-        {{ data['dhDis'] }},
-        {{ data['dhCon'] }}
       )
       );
   parameter String filNam[nBui]={

--- a/geojson_modelica_translator/modelica/GMT_Lib/DHC/DHC_5G_waste_heat_GHX_variable.py
+++ b/geojson_modelica_translator/modelica/GMT_Lib/DHC/DHC_5G_waste_heat_GHX_variable.py
@@ -92,8 +92,6 @@ class DHC5GWasteHeatAndGHXVariable(SimpleGMTBase):
         nbuildings = len(template_data['building_load_files'])
         template_data['lDis'] = self.build_string("lDis = {", "0.5, ", nbuildings)
         template_data['lCon'] = self.build_string("lCon = {", "0.5, ", nbuildings)
-        template_data['dhDis'] = self.build_string("dhDis = {", "0.5, ", nbuildings)
-        template_data['dhCon'] = self.build_string("dhCon = {", "0.6, ", nbuildings)
 
         # 6: generate the modelica files from the template
         self.to_modelica(output_dir=Path(scaffold.districts_path.files_dir),

--- a/geojson_modelica_translator/modelica/lib/runner/Dockerfile
+++ b/geojson_modelica_translator/modelica/lib/runner/Dockerfile
@@ -15,13 +15,15 @@ RUN apt update && apt --no-install-recommends install -y \
 # tests/GMT_Lib/test_gmt_lib_des.py fails with jammy, works with focal.
 ARG VERSION=1.22.1
 
-RUN export DEBIAN_FRONTEND="noninteractive" && echo "VERSION: $VERSION" && test ! -z "$VERSION" && apt-get update && apt-get upgrade -qy && apt-get dist-upgrade -qy \
-    && apt-get install -qy gnupg wget ca-certificates apt-transport-https \
+RUN export DEBIAN_FRONTEND="noninteractive" && echo "VERSION: $VERSION" && test ! -z "$VERSION" && apt update && apt upgrade -qy && apt dist-upgrade -qy \
+    && apt install -qy gnupg wget ca-certificates apt-transport-https \
     && echo "deb https://build.openmodelica.org/omc/builds/linux/releases/$VERSION/ `cat /etc/lsb-release | grep CODENAME | cut -d= -f2` release" > /etc/apt/sources.list.d/openmodelica.list \
-    && wget https://build.openmodelica.org/apt/openmodelica.asc -O- | apt-key add - \
-    && apt-get update && apt-get upgrade && apt-get dist-upgrade \
-    && apt-get install --no-install-recommends -qy omc \
-    && apt-get clean \
+    && wget -q https://build.openmodelica.org/apt/openmodelica.asc \
+    && apt-key add openmodelica.asc \
+    && rm openmodelica.asc \
+    && apt update && apt upgrade && apt dist-upgrade \
+    && apt install --no-install-recommends -qy omc \
+    && apt clean \
     && rm -rf /var/lib/apt/lists/*
 
 # Install MSL 4.0

--- a/geojson_modelica_translator/modelica/lib/runner/Dockerfile
+++ b/geojson_modelica_translator/modelica/lib/runner/Dockerfile
@@ -1,5 +1,6 @@
-FROM openmodelica/openmodelica:v1.22.1-gui
+FROM ubuntu:focal
 
+# These libraries help compile and simulate separately.
 # libgfortran4 is needed to load FMU for FMUZoneAdapterZones1.mo
 RUN apt update && apt --no-install-recommends install -y \
     vim \
@@ -7,6 +8,20 @@ RUN apt update && apt --no-install-recommends install -y \
     libpython3-dev \
     curl \
     cmake \
+    && rm -rf /var/lib/apt/lists/*
+
+# Duplicating code from OM Dockerfile: https://github.com/OpenModelica/OpenModelicaDockerImages/blob/v1.22.1/Dockerfile
+# This allows us to use a different Ubuntu version than the OM Dockerfile
+# tests/GMT_Lib/test_gmt_lib_des.py fails with jammy, works with focal.
+ARG VERSION=1.22.1
+
+RUN export DEBIAN_FRONTEND="noninteractive" && echo "VERSION: $VERSION" && test ! -z "$VERSION" && apt-get update && apt-get upgrade -qy && apt-get dist-upgrade -qy \
+    && apt-get install -qy gnupg wget ca-certificates apt-transport-https \
+    && echo "deb https://build.openmodelica.org/omc/builds/linux/releases/$VERSION/ `cat /etc/lsb-release | grep CODENAME | cut -d= -f2` release" > /etc/apt/sources.list.d/openmodelica.list \
+    && wget https://build.openmodelica.org/apt/openmodelica.asc -O- | apt-key add - \
+    && apt-get update && apt-get upgrade && apt-get dist-upgrade \
+    && apt-get install --no-install-recommends -qy omc \
+    && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 # Install MSL 4.0

--- a/geojson_modelica_translator/modelica/lib/runner/README.md
+++ b/geojson_modelica_translator/modelica/lib/runner/README.md
@@ -35,7 +35,8 @@ In GMT Runner Version 2.0.0 we detached the OM version from the GMT Runner versi
 Releasing is only available to individuals with write access to the NREL org. Unfortunately, the NREL org is still
 under a free plan resulting in a maximum of 3 users for the entire org, which have already been allocated.
 
-Building for release is a bit different than development since you will need to handle multiple platforms. See
+Building for release is a bit different than development since you will need to handle multiple platforms (only supporting
+ARM64 and AMD64 as openmodelica does not support 32-bit [only armhf]). See
 [docker's multi-platform images documentation](https://docs.docker.com/build/building/multi-platform/) on how to configure.
 
 ```bash
@@ -46,9 +47,10 @@ docker buildx create --use
 
 # update version of OMC and determine if the latest should be updated. Ideally, the latest should be updated
 # only if the new OMC release is needed to fix previous issues.
-docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 -t nrel/gmt-om-runner:v2.0.0 --push .
-docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 -t nrel/gmt-om-runner:latest --push .
+docker buildx build --platform linux/amd64,linux/arm64 -t nrel/gmt-om-runner:v2.0.1 --push .
 
+# Push the latest, if required
+docker buildx build --platform linux/amd64,linux/arm64 -t nrel/gmt-om-runner:latest --push .
 ```
 
 Sign into [Docker Hub](https://hub.docker.com/repository/docker/nrel/gmt-om-runner/general) and update the version

--- a/geojson_modelica_translator/modelica/lib/runner/README.md
+++ b/geojson_modelica_translator/modelica/lib/runner/README.md
@@ -24,6 +24,7 @@ In GMT Runner Version 2.0.0 we detached the OM version from the GMT Runner versi
 
 | GTM Runner Version | OM Version | MSL Version | MBL Version |
 | ------------------ | ---------- | ----------- | ----------- |
+| 2.0.1              | 1.22.1     | 4.0.0       | 10.0.0      |
 | 2.0.0              | 1.22.1     | 4.0.0       | 10.0.0      |
 | 1.22.1             | 1.22.1     | 4.0.0       | 9.1.1       |
 | 1.22.0             | 1.21.0     | 4.0.0       | 9.1.0       |

--- a/geojson_modelica_translator/modelica/modelica_runner.py
+++ b/geojson_modelica_translator/modelica/modelica_runner.py
@@ -151,7 +151,7 @@ class ModelicaRunner(object):
         os.chdir(run_path)
         stdout_log = open('stdout.log', 'w')
         model_name = run_path.parts[-1]
-        image_name = 'nrel/gmt-om-runner:v2.0.0'
+        image_name = 'nrel/gmt-om-runner:v2.0.1'
         mo_script = 'compile_fmu' if action == 'compile' else 'simulate'
         try:
             # create the command to call the open modelica compiler inside the docker image

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geojson-modelica-translator"
-version = "0.6.0-a0"
+version = "0.6.0"
 description = "Package for converting GeoJSON to Modelica models for Urban Scale Analyses."
 authors = ["URBANopt DES Team <nicholas.long@nrel.gov>"]
 license = "BSD-4-Clause"

--- a/tests/GMT_Lib/test_gmt_lib_des.py
+++ b/tests/GMT_Lib/test_gmt_lib_des.py
@@ -35,7 +35,6 @@ env = Environment(
 class GmtLibDesTest(unittest.TestCase):
 
     @pytest.mark.simulation
-    @pytest.mark.skip('Invalid root in initialization. Skipping until LBNL helps')
     def test_5G_des_waste_heat_and_ghx(self):
         # -- Setup
         package_output_dir = PARENT_DIR / 'output'
@@ -102,7 +101,6 @@ class GmtLibDesTest(unittest.TestCase):
         assert success is True
 
     @pytest.mark.simulation
-    @pytest.mark.skip('Invalid root in initialization. Skipping until LBNL helps')
     def test_5G_des_waste_heat_and_ghx_variable(self):
         # -- Setup
         package_output_dir = PARENT_DIR / 'output'

--- a/tests/model_connectors/test_chp_system.py
+++ b/tests/model_connectors/test_chp_system.py
@@ -87,13 +87,12 @@ class CombinedHeatingPowerTest(TestCaseBase):
         assert (root_path / 'DistrictEnergySystem.mo').exists()
 
     @pytest.mark.simulation
-    @pytest.mark.skip('Connector types are incompatible. HeatingPlantwithCHP:242')
     def test_simulate_chp_system(self):
         self.run_and_assert_in_docker(
             f'{self.district._scaffold.project_name}.Districts.DistrictEnergySystem',
             file_to_load=self.district._scaffold.package_path,
             run_path=self.district._scaffold.project_path,
-            start_time=17280000,  # Day 200 (in seconds) (Run in summer to keep chiller happy)
-            stop_time=17366400,  # For 1 day duration (in seconds)
-            step_size=3600  # (in seconds)
+            start_time=0,  # Day 0 (in seconds)
+            stop_time=9999,  # For 2.78 hours (in seconds)
+            step_size=300  # (in seconds)
         )


### PR DESCRIPTION
#### Any background context you want to provide?
- Our GMT_lib tests were failing in the new MBLv10 world. It turns out there is something in Ubuntu 22 that doesn't work with [this MBL model](https://github.com/lbl-srg/modelica-buildings/blob/master/Buildings/Experimental/DHC/Examples/Combined/SeriesConstantFlow.mo) that works fine in Ubuntu 20. Downgrading an Ubuntu version means maintaining more of the OM Docker installation code ourselves 👎.
- Fix & re-enable the CHP model that has been skipped for a while

#### What does this PR accomplish?
- Duplicates most of the OM dockerfile so we can set our own Ubuntu version
- Use the new Docker image in modelica_runner.py
- Re-enables the tests that were skipped because of this bug
- Update the Dockerfile version in the readme
- Bump to version 0.6.0 for the GMT
- Use a new boiler model in the CHP model
- Test the CHP model for the duration that works

#### How should this be manually tested?
CI is sufficient, once a new Docker image (tagged `v2.0.1`) is pushed to dockerhub
