### PR TITLE
Rename new modelica models to clarify MBL version

### DIFF
--- a/geojson_modelica_translator/model_connectors/plants/chp.py
+++ b/geojson_modelica_translator/model_connectors/plants/chp.py
@@ -25,11 +25,11 @@ class HeatingPlantWithOptionalCHP(PlantBase):
             self.id = 'heaPla' + simple_uuid()
 
         self.required_mo_files.append(Path(self.template_dir) / 'Boiler_TParallel.mo')
-        self.required_mo_files.append(Path(self.template_dir) / 'Boiler_TParallel_new.mo')
+        self.required_mo_files.append(Path(self.template_dir) / 'Boiler_TParallel_v10.mo')
         self.required_mo_files.append(Path(self.template_dir) / 'BoilerStage.mo')
         self.required_mo_files.append(Path(self.template_dir) / 'HeatingWaterPumpSpeed.mo')
         self.required_mo_files.append(Path(self.template_dir) / 'PartialPlantParallel.mo')
-        self.required_mo_files.append(Path(self.template_dir) / 'PartialPlantParallel_v1new.mo')
+        self.required_mo_files.append(Path(self.template_dir) / 'PartialPlantParallel_v10.mo')
         self.required_mo_files.append(Path(self.template_dir) / 'PartialPlantParallelInterface.mo')
         self.required_mo_files.append(Path(self.template_dir) / 'ValveParameters.mo')
 

--- a/geojson_modelica_translator/model_connectors/plants/templates/Boiler_TParallel_v10.mo
+++ b/geojson_modelica_translator/model_connectors/plants/templates/Boiler_TParallel_v10.mo
@@ -1,7 +1,7 @@
 within district_heating_and_cooling_systems.Plants;
-model Boiler_TParallel_new
+model Boiler_TParallel_v10
   "Multiple identical boiler"
-  extends PartialPlantParallel_v1new(
+  extends PartialPlantParallel_v10(
     num=numBoi,
     redeclare Buildings.Fluid.Boilers.BoilerPolynomial boi(
       each Q_flow_nominal=Q_flow_nominal,
@@ -113,4 +113,4 @@ equation
         Rectangle(
           extent={{-54,54},{54,-54}},
           lineColor={102,44,145})}));
-end Boiler_TParallel_new;
+end Boiler_TParallel_v10;

--- a/geojson_modelica_translator/model_connectors/plants/templates/CentralHeatingPlant.mo
+++ b/geojson_modelica_translator/model_connectors/plants/templates/CentralHeatingPlant.mo
@@ -73,7 +73,7 @@ model CentralHeatingPlant
     final unit="Pa")
     "Measured pressure difference"
     annotation (Placement(transformation(extent={{-160,-40},{-140,-20}}),iconTransformation(extent={{-140,-50},{-100,-10}})));
-  Boiler_TParallel_new boiHotWat(
+  Boiler_TParallel_v10 boiHotWat(
     redeclare package Medium=Medium,
     m_flow_nominal=mBoi_flow_nominal,
     Q_flow_nominal=QBoi_flow_nominal,

--- a/geojson_modelica_translator/model_connectors/plants/templates/HeatingPlantWithCHP.mot
+++ b/geojson_modelica_translator/model_connectors/plants/templates/HeatingPlantWithCHP.mot
@@ -73,7 +73,7 @@ within {{ project_name }}.Plants;
     final unit="Pa")
     "Measured pressure difference"
     annotation (Placement(transformation(extent={{-160,-40},{-140,-20}}),iconTransformation(extent={{-140,-50},{-100,-10}})));
-  Boiler_TParallel_new boiHotWat(
+  Boiler_TParallel_v10 boiHotWat(
     redeclare package Medium=Medium,
     m_flow_nominal=mBoi_flow_nominal,
     Q_flow_nominal=QBoi_flow_nominal,

--- a/geojson_modelica_translator/model_connectors/plants/templates/PartialPlantParallel_v10.mo
+++ b/geojson_modelica_translator/model_connectors/plants/templates/PartialPlantParallel_v10.mo
@@ -1,5 +1,5 @@
 within district_heating_and_cooling_systems.Plants;
-partial model PartialPlantParallel_v1new
+partial model PartialPlantParallel_v10
   "Partial source plant model with associated valves"
   extends PartialPlantParallelInterface;
   extends ValveParameters(
@@ -75,4 +75,4 @@ First implementation.
 </li>
 </ul>
 </html>"));
-end PartialPlantParallel_v1new;
+end PartialPlantParallel_v10;

--- a/geojson_modelica_translator/modelica/lib/runner/README.md
+++ b/geojson_modelica_translator/modelica/lib/runner/README.md
@@ -16,7 +16,7 @@ cd geojson_modelica_translator/modelica/lib/runner
 docker build -t nrel/gmt-om-runner:latest .
 ```
 
-The default tag will be `nrel/gmt-om-runner:v2.0.0`, which is the default version used in the modelica_runner.py file.
+The default tag will be `nrel/gmt-om-runner:v2.0.1`, which is the default version used in the modelica_runner.py file.
 
 ### Versioning
 


### PR DESCRIPTION
#### Any background context you want to provide?
We had to make some new models to support MBLv10. They were just named `..._new` which could get confusing once we forgot when/why these were created.
#### What does this PR accomplish?
- Renames 2 models to clarify that they work with/are intended for MBLv10
- Update Docker readme to reference current version of our Dockerfile
    - This is not substantive. I happened to notice it when rebuilding the image locally

@nllong What naming convention should we use?
#### How should this be manually tested?
CI is sufficient
#### What are the relevant tickets?
Resolves #612 
