### PR TITLE
Force a dummy value for SHW in modelica loads even if not present

### DIFF
--- a/geojson_modelica_translator/model_connectors/districts/district.py
+++ b/geojson_modelica_translator/model_connectors/districts/district.py
@@ -160,4 +160,5 @@ class District:
             root_package.save()
 
         # Hack workaround for MBLv10.0.0 bug that requires DHW in the loads even if it's not used
+        # This hack runs after the scaffold is created and before the simulation is run.
         _add_water_heating_patch(self._scaffold.project_path)

--- a/geojson_modelica_translator/model_connectors/districts/district.py
+++ b/geojson_modelica_translator/model_connectors/districts/district.py
@@ -4,13 +4,14 @@
 from pathlib import Path
 
 from jinja2 import Environment, FileSystemLoader, StrictUndefined
+from modelica_builder.modelica_mos_file import ModelicaMOS
 from modelica_builder.package_parser import PackageParser
 
 from geojson_modelica_translator.jinja_filters import ALL_CUSTOM_FILTERS
 from geojson_modelica_translator.model_connectors.couplings.diagram import Diagram
 from geojson_modelica_translator.model_connectors.load_connectors.load_base import LoadBase
 from geojson_modelica_translator.scaffold import Scaffold
-from geojson_modelica_translator.utils import _add_water_heating_patch, mbl_version
+from geojson_modelica_translator.utils import mbl_version
 
 
 def render_template(template_name, template_params):
@@ -159,6 +160,27 @@ class District:
             root_package.add_model("Districts")
             root_package.save()
 
-        # Hack workaround for MBLv10.0.0 bug that requires DHW in the loads even if it's not used
-        # This hack runs after the scaffold is created and before the simulation is run.
-        _add_water_heating_patch(self._scaffold.project_path)
+        # If the file is an MOS file and Peak water heating load is set to zero, then set it to a minimum value
+        data_dir = Path(self._scaffold.project_path) / "Loads" / "Resources" / "Data"
+        # Find the MOS data files in the Modelica package.
+        if data_dir.is_dir():
+            for bldg_dir in data_dir.iterdir():
+                mo_load_file = data_dir / bldg_dir / "modelica.mos"
+                # In case the modelica loads file isn't named modelica.mos:
+                if not mo_load_file.is_file():
+                    modelica_loads = list((data_dir / bldg_dir).rglob("*"))
+                    if len(modelica_loads) == 1:
+                        mo_load_file = modelica_loads[0]
+                if mo_load_file.is_file():
+                    mos_file = ModelicaMOS(mo_load_file)
+                    # Force peak water heating load to be at least 5000W
+                    peak_water = mos_file.retrieve_header_variable_value("Peak water heating load", cast_type=float)
+                    if peak_water == 0:
+                        peak_heat = mos_file.retrieve_header_variable_value("Peak space heating load", cast_type=float)
+                        peak_swh = max(peak_heat / 10, 5000)
+
+                        mos_file.replace_header_variable_value("Peak water heating load", peak_swh)
+                        mos_file.save()
+        else:
+            # The scaffold didn't get built properly or there are no loads in the Modelica package.
+            raise SystemExit(f"Could not find Modelica data directory {data_dir}")

--- a/geojson_modelica_translator/model_connectors/districts/district.py
+++ b/geojson_modelica_translator/model_connectors/districts/district.py
@@ -10,7 +10,7 @@ from geojson_modelica_translator.jinja_filters import ALL_CUSTOM_FILTERS
 from geojson_modelica_translator.model_connectors.couplings.diagram import Diagram
 from geojson_modelica_translator.model_connectors.load_connectors.load_base import LoadBase
 from geojson_modelica_translator.scaffold import Scaffold
-from geojson_modelica_translator.utils import mbl_version
+from geojson_modelica_translator.utils import _add_water_heating_patch, mbl_version
 
 
 def render_template(template_name, template_params):
@@ -158,3 +158,6 @@ class District:
         if "Districts" not in root_package.order:
             root_package.add_model("Districts")
             root_package.save()
+
+        # Hack workaround for MBLv10.0.0 bug that requires DHW in the loads even if it's not used
+        _add_water_heating_patch(self._scaffold.project_path)

--- a/geojson_modelica_translator/model_connectors/districts/district.py
+++ b/geojson_modelica_translator/model_connectors/districts/district.py
@@ -1,6 +1,7 @@
 # :copyright (c) URBANopt, Alliance for Sustainable Energy, LLC, and other contributors.
 # See also https://github.com/urbanopt/geojson-modelica-translator/blob/develop/LICENSE.md
 
+import logging
 from pathlib import Path
 
 from jinja2 import Environment, FileSystemLoader, StrictUndefined
@@ -12,6 +13,8 @@ from geojson_modelica_translator.model_connectors.couplings.diagram import Diagr
 from geojson_modelica_translator.model_connectors.load_connectors.load_base import LoadBase
 from geojson_modelica_translator.scaffold import Scaffold
 from geojson_modelica_translator.utils import mbl_version
+
+logger = logging.getLogger(__name__)
 
 
 def render_template(template_name, template_params):
@@ -183,4 +186,7 @@ class District:
                         mos_file.save()
         else:
             # The scaffold didn't get built properly or there are no loads in the Modelica package.
-            raise SystemExit(f"Could not find Modelica data directory {data_dir}")
+            logger.warn(
+                f"Could not find Modelica data directory {data_dir}. Perhaps there are no loads in the model,"
+                " and perhaps that is intentional."
+            )

--- a/geojson_modelica_translator/model_connectors/districts/district.py
+++ b/geojson_modelica_translator/model_connectors/districts/district.py
@@ -186,7 +186,7 @@ class District:
                         mos_file.save()
         else:
             # The scaffold didn't get built properly or there are no loads in the Modelica package.
-            logger.warn(
+            logger.warning(
                 f"Could not find Modelica data directory {data_dir}. Perhaps there are no loads in the model,"
                 " and perhaps that is intentional."
             )

--- a/geojson_modelica_translator/model_connectors/model_base.py
+++ b/geojson_modelica_translator/model_connectors/model_base.py
@@ -12,11 +12,6 @@ from modelica_builder.model import Model
 from geojson_modelica_translator.jinja_filters import ALL_CUSTOM_FILTERS
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(levelname)s: %(message)s",
-    datefmt="%d-%b-%y %H:%M:%S",
-)
 
 
 class ModelBase:

--- a/geojson_modelica_translator/model_connectors/plants/borefield.py
+++ b/geojson_modelica_translator/model_connectors/plants/borefield.py
@@ -14,11 +14,6 @@ from geojson_modelica_translator.model_connectors.plants.plant_base import Plant
 from geojson_modelica_translator.utils import ModelicaPath, simple_uuid
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(levelname)s: %(message)s",
-    datefmt="%d-%b-%y %H:%M:%S",
-)
 
 
 class Borefield(PlantBase):

--- a/geojson_modelica_translator/modelica/GMT_Lib/DHC/Components/Plants/Heating/boiler_polynomial.py
+++ b/geojson_modelica_translator/modelica/GMT_Lib/DHC/Components/Plants/Heating/boiler_polynomial.py
@@ -4,11 +4,6 @@ from pathlib import Path
 from geojson_modelica_translator.modelica.simple_gmt_base import SimpleGMTBase
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(levelname)s: %(message)s",
-    datefmt="%d-%b-%y %H:%M:%S",
-)
 
 
 class PolynomialBoiler(SimpleGMTBase):

--- a/geojson_modelica_translator/modelica/GMT_Lib/Electrical/AC/ThreePhasesBalanced/Loads/Inductive.py
+++ b/geojson_modelica_translator/modelica/GMT_Lib/Electrical/AC/ThreePhasesBalanced/Loads/Inductive.py
@@ -4,11 +4,6 @@ from pathlib import Path
 from geojson_modelica_translator.modelica.simple_gmt_base import SimpleGMTBase
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(levelname)s: %(message)s",
-    datefmt="%d-%b-%y %H:%M:%S",
-)
 
 
 class InductiveLoad(SimpleGMTBase):

--- a/geojson_modelica_translator/modelica/GMT_Lib/Electrical/AC/ThreePhasesBalanced/Loads/capacitive.py
+++ b/geojson_modelica_translator/modelica/GMT_Lib/Electrical/AC/ThreePhasesBalanced/Loads/capacitive.py
@@ -4,11 +4,6 @@ from pathlib import Path
 from geojson_modelica_translator.modelica.simple_gmt_base import SimpleGMTBase
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(levelname)s: %(message)s",
-    datefmt="%d-%b-%y %H:%M:%S",
-)
 
 
 class CapacitiveLoad(SimpleGMTBase):

--- a/geojson_modelica_translator/modelica/GMT_Lib/Electrical/AC/ThreePhasesBalanced/Sources/generators.py
+++ b/geojson_modelica_translator/modelica/GMT_Lib/Electrical/AC/ThreePhasesBalanced/Sources/generators.py
@@ -4,11 +4,6 @@ from pathlib import Path
 from geojson_modelica_translator.modelica.simple_gmt_base import SimpleGMTBase
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(levelname)s: %(message)s",
-    datefmt="%d-%b-%y %H:%M:%S",
-)
 
 
 class Generator(SimpleGMTBase):

--- a/geojson_modelica_translator/modelica/GMT_Lib/Electrical/AC/ThreePhasesBalanced/Sources/grid.py
+++ b/geojson_modelica_translator/modelica/GMT_Lib/Electrical/AC/ThreePhasesBalanced/Sources/grid.py
@@ -4,11 +4,6 @@ from pathlib import Path
 from geojson_modelica_translator.modelica.simple_gmt_base import SimpleGMTBase
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(levelname)s: %(message)s",
-    datefmt="%d-%b-%y %H:%M:%S",
-)
 
 
 class Grid(SimpleGMTBase):

--- a/geojson_modelica_translator/modelica/modelica_runner.py
+++ b/geojson_modelica_translator/modelica/modelica_runner.py
@@ -15,11 +15,6 @@ from jinja2 import Environment, FileSystemLoader, StrictUndefined
 from geojson_modelica_translator.jinja_filters import ALL_CUSTOM_FILTERS
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(levelname)s: %(message)s",
-    datefmt="%d-%b-%y %H:%M:%S",
-)
 
 
 class ModelicaRunner:

--- a/geojson_modelica_translator/system_parameters/system_parameters.py
+++ b/geojson_modelica_translator/system_parameters/system_parameters.py
@@ -918,7 +918,7 @@ class SystemParameters:
             mos_weather_path = mos_weather_path.relative_to(self.rel_path)
         self.param_template["weather"] = str(mos_weather_path)
         if microgrid and not feature_opt_file.exists():
-            logger.warning(
+            logger.warn(
                 "Microgrid requires OpenDSS and REopt feature optimization for full functionality.\n"
                 "Run opendss and reopt-feature post-processing in the UO SDK for a full-featured microgrid."
             )

--- a/geojson_modelica_translator/system_parameters/system_parameters.py
+++ b/geojson_modelica_translator/system_parameters/system_parameters.py
@@ -913,7 +913,7 @@ class SystemParameters:
             mos_weather_path = mos_weather_path.relative_to(self.rel_path)
         self.param_template["weather"] = str(mos_weather_path)
         if microgrid and not feature_opt_file.exists():
-            logger.warn(
+            logger.warning(
                 "Microgrid requires OpenDSS and REopt feature optimization for full functionality.\n"
                 "Run opendss and reopt-feature post-processing in the UO SDK for a full-featured microgrid."
             )

--- a/geojson_modelica_translator/system_parameters/system_parameters.py
+++ b/geojson_modelica_translator/system_parameters/system_parameters.py
@@ -15,11 +15,6 @@ from jsonpath_ng.ext import parse
 from jsonschema.validators import Draft202012Validator as LatestValidator
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(levelname)s: %(message)s",
-    datefmt="%d-%b-%y %H:%M:%S",
-)
 
 
 class SystemParameters:

--- a/geojson_modelica_translator/utils.py
+++ b/geojson_modelica_translator/utils.py
@@ -60,12 +60,17 @@ def _add_water_heating_patch(modelica_dir: Path):
     if data_dir.is_dir():
         for bldg_dir in data_dir.iterdir():
             mo_load_file = data_dir / bldg_dir / "modelica.mos"
+            # In case the modelica loads file isn't named modelica.mos:
+            if not mo_load_file.is_file():
+                modelica_loads = list((data_dir / bldg_dir).rglob("*"))
+                if len(modelica_loads) == 1:
+                    mo_load_file = modelica_loads[0]
             if mo_load_file.is_file():
                 fixed_lines, fl_found = [], False
                 with open(mo_load_file) as mlf:
                     for line in mlf:
                         if line == "#Peak water heating load = 0 Watts\n":
-                            logger.debug(f"Adding dummy value for water heating for {bldg_dir}")
+                            logger.debug(f"Adding dummy value for water heating to {mo_load_file}")
                             nl = "#Peak water heating load = 1 Watts\n"
                             fixed_lines.append(nl)
                         elif not fl_found and ";" in line:

--- a/geojson_modelica_translator/utils.py
+++ b/geojson_modelica_translator/utils.py
@@ -7,7 +7,12 @@ import shutil
 from pathlib import Path
 from uuid import uuid4
 
-_log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s: %(message)s",
+    datefmt="%d-%b-%y %H:%M:%S",
+)
 
 
 def copytree(src, dst, symlinks=False, ignore=None):
@@ -49,7 +54,7 @@ def mbl_version():
     return "10.0.0"
 
 
-def _add_water_heating_patch(modelica_dir):
+def _add_water_heating_patch(modelica_dir: Path):
     """Add a dummy value for water heating for MBL 10 limitation."""
     data_dir = Path(modelica_dir) / "Loads" / "Resources" / "Data"
     if data_dir.is_dir():
@@ -60,6 +65,7 @@ def _add_water_heating_patch(modelica_dir):
                 with open(mo_load_file) as mlf:
                     for line in mlf:
                         if line == "#Peak water heating load = 0 Watts\n":
+                            logger.debug(f"Adding dummy value for water heating for {bldg_dir}")
                             nl = "#Peak water heating load = 1 Watts\n"
                             fixed_lines.append(nl)
                         elif not fl_found and ";" in line:

--- a/geojson_modelica_translator/utils.py
+++ b/geojson_modelica_translator/utils.py
@@ -54,36 +54,6 @@ def mbl_version():
     return "10.0.0"
 
 
-def _add_water_heating_patch(modelica_dir: Path):
-    """Add a dummy value for water heating for MBL 10 limitation."""
-    data_dir = Path(modelica_dir) / "Loads" / "Resources" / "Data"
-    if data_dir.is_dir():
-        for bldg_dir in data_dir.iterdir():
-            mo_load_file = data_dir / bldg_dir / "modelica.mos"
-            # In case the modelica loads file isn't named modelica.mos:
-            if not mo_load_file.is_file():
-                modelica_loads = list((data_dir / bldg_dir).rglob("*"))
-                if len(modelica_loads) == 1:
-                    mo_load_file = modelica_loads[0]
-            if mo_load_file.is_file():
-                fixed_lines, fl_found = [], False
-                with open(mo_load_file) as mlf:
-                    for line in mlf:
-                        if line == "#Peak water heating load = 0 Watts\n":
-                            logger.debug(f"Adding dummy value for water heating to {mo_load_file}")
-                            nl = "#Peak water heating load = 1 Watts\n"
-                            fixed_lines.append(nl)
-                        elif not fl_found and ";" in line:
-                            split_vals = line.split(";")
-                            split_vals[-1] = "1.0\n"
-                            fixed_lines.append(";".join(split_vals))
-                            fl_found = True
-                        else:
-                            fixed_lines.append(line)
-                with open(mo_load_file, "w") as mlf:
-                    mlf.write("".join(fixed_lines))
-
-
 class ModelicaPath:
     """
     Class for storing Modelica paths. This allows the path to point to

--- a/geojson_modelica_translator/utils.py
+++ b/geojson_modelica_translator/utils.py
@@ -8,11 +8,6 @@ from pathlib import Path
 from uuid import uuid4
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(levelname)s: %(message)s",
-    datefmt="%d-%b-%y %H:%M:%S",
-)
 
 
 def copytree(src, dst, symlinks=False, ignore=None):

--- a/tests/modelica/test_modelica_runner.py
+++ b/tests/modelica/test_modelica_runner.py
@@ -12,11 +12,6 @@ from geojson_modelica_translator.modelica.modelica_runner import ModelicaRunner
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(levelname)s: %(message)s',
-    datefmt='%d-%b-%y %H:%M:%S',
-)
 
 
 class ModelicaRunnerTest(unittest.TestCase):


### PR DESCRIPTION
#### Any background context you want to provide?
MBLv10 requires a value in the Service Hot Water column of the loads timeseries, even if it isn't used. Modelica-Builder [has a feature](https://github.com/urbanopt/modelica-builder/blob/develop/modelica_builder/modelica_mos_file.py#L93) that can update values in .mos files, so lets use that.

_The UO SDK populates this column as of v0.11.0 with https://github.com/urbanopt/urbanopt-reporting-gem/pull/143. Load files generated before then may be missing this data._
#### What does this PR accomplish?
- Uses the modelica-builder method to set SHW load to 1/10 of the heating load or 5000W, whichever is higher.
- Improve logging a bit
#### How should this be manually tested?
Generate a model using timeseries data that does not have the SHW column populated. The updated file is `modelica_project/Loads/Resources/Data/<buildingname>/<load_timeseries>.mos`
