### PR TITLE
Add default cop values for 5G district heat pump efficiencies

### DIFF
--- a/geojson_modelica_translator/system_parameters/schema.json
+++ b/geojson_modelica_translator/system_parameters/schema.json
@@ -1260,7 +1260,7 @@
               }
             },
             "wahp": {
-              "description": "Parameters for WAHP",
+              "description": "Parameters for a Water-to-Air Heat Pump",
               "type": "object",
               "properties": {
                 "cop_c": {

--- a/geojson_modelica_translator/system_parameters/schema.json
+++ b/geojson_modelica_translator/system_parameters/schema.json
@@ -295,7 +295,7 @@
               "type": "number"
             },
             "max_power": {
-              "description": "Maximim load power (kW)",
+              "description": "Maximum load power (kW)",
               "type": "number"
             },
             "max_reactive_power": {
@@ -1003,7 +1003,7 @@
           "description": "Net PV Surface Area (m2)",
           "type": "number"
         },
-        "suface_tilt": {
+        "surface_tilt": {
           "description": "PV Surface Tilt (degrees)",
           "type": "number"
         },

--- a/geojson_modelica_translator/system_parameters/schema.json
+++ b/geojson_modelica_translator/system_parameters/schema.json
@@ -1258,6 +1258,20 @@
                   "type": "number"
                 }
               }
+            },
+            "wahp": {
+              "description": "Parameters for WAHP",
+              "type": "object",
+              "properties": {
+                "cop_c": {
+                  "description": "Efficiency of heat pump during cooling.",
+                  "type": "number"
+                },
+                "cop_h": {
+                  "description": "Efficiency of heat pump during heating.",
+                  "type": "number"
+                }
+              }
             }
           }
         }

--- a/geojson_modelica_translator/system_parameters/schema.json
+++ b/geojson_modelica_translator/system_parameters/schema.json
@@ -1259,7 +1259,7 @@
                 }
               }
             },
-            "wahp": {
+            "water_to_air_heat_pump": {
               "description": "Parameters for a Water-to-Air Heat Pump",
               "type": "object",
               "properties": {

--- a/geojson_modelica_translator/system_parameters/time_series_template.json
+++ b/geojson_modelica_translator/system_parameters/time_series_template.json
@@ -184,7 +184,7 @@
       "central_pump_parameters": {
         "pump_design_head": 60000
       },
-      "wahp": {
+      "water_to_air_heat_pump": {
         "cop_c": 3.0,
         "cop_h": 3.0
       }

--- a/geojson_modelica_translator/system_parameters/time_series_template.json
+++ b/geojson_modelica_translator/system_parameters/time_series_template.json
@@ -183,6 +183,10 @@
       },
       "central_pump_parameters": {
         "pump_design_head": 60000
+      },
+      "wahp": {
+        "cop_c": 3.0,
+        "cop_h": 3.0
       }
     }
   },


### PR DESCRIPTION
#### Any background context you want to provide?
We should have a user-configurable 5G heat-pump. COP values are important to be able to customize.
#### What does this PR accomplish?
- [x] Adds `wahp` (and sub-items) to sys-param template
-  [x] Add `cop_c` and `cop_h` to schema
#### How should this be manually tested?
Confirm that [this test](https://github.com/urbanopt/geojson-modelica-translator/blob/develop/tests/management/test_uo_des.py#L52) generates a sys-param file (saved into [this folder](https://github.com/urbanopt/geojson-modelica-translator/tree/develop/tests/management/data/sdk_project_scraps/run/baseline_scenario)) that includes `district_system.fifth_generation.wahp`.
#### What are the relevant tickets?
#### Screenshots (if appropriate)
