### PR TITLE
Update Docker command in CI to work with current syntax

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           python -c "import sys; print(sys.version)"
           docker --version
-          docker-compose --version
+          docker compose version
       - name: Install Poetry
         uses: Gr1N/setup-poetry@v8 # optionally set specific poetry version. Defaults to latest
       - name: Install dependencies with Poetry


### PR DESCRIPTION
#### Any background context you want to provide?
On July 29 Github Actions [removed access to Docker Compose v1](https://github.com/actions/runner-images/issues/9692) (which has been deprecated since July 2023). This means we have to use the v2 syntax, which this PR achieves.

_Since we have this in an early step of our CI workflow, all CI will fail until this is merged._
#### What does this PR accomplish?
Use Docker Compose v2 syntax in a CI check
#### How should this be manually tested?
CI is sufficient
