### PR TITLE
Use feature ids in load names instead of simple_uuid

### DIFF
--- a/geojson_modelica_translator/model_connectors/load_connectors/spawn.py
+++ b/geojson_modelica_translator/model_connectors/load_connectors/spawn.py
@@ -7,7 +7,7 @@ import shutil
 from modelica_builder.package_parser import PackageParser
 
 from geojson_modelica_translator.model_connectors.load_connectors.load_base import LoadBase
-from geojson_modelica_translator.utils import ModelicaPath, convert_c_to_k, simple_uuid
+from geojson_modelica_translator.utils import ModelicaPath, convert_c_to_k
 
 
 class Spawn(LoadBase):
@@ -15,7 +15,7 @@ class Spawn(LoadBase):
 
     def __init__(self, system_parameters, geojson_load):
         super().__init__(system_parameters, geojson_load)
-        self.id = "SpawnLoad_" + simple_uuid()
+        self.id = f"SpawnLoad_{self.building_name}"
 
     def to_modelica(self, scaffold, keep_original_models=False):
         """Create spawn models based on the data in the buildings and geojsons

--- a/geojson_modelica_translator/model_connectors/load_connectors/teaser.py
+++ b/geojson_modelica_translator/model_connectors/load_connectors/teaser.py
@@ -14,7 +14,7 @@ from modelica_builder.package_parser import PackageParser
 from teaser.project import Project
 
 from geojson_modelica_translator.model_connectors.load_connectors.load_base import LoadBase
-from geojson_modelica_translator.utils import ModelicaPath, convert_c_to_k, copytree, simple_uuid
+from geojson_modelica_translator.utils import ModelicaPath, convert_c_to_k, copytree
 
 
 class Teaser(LoadBase):
@@ -25,7 +25,7 @@ class Teaser(LoadBase):
 
     def __init__(self, system_parameters, geojson_load):
         super().__init__(system_parameters, geojson_load)
-        self.id = "TeaserLoad_" + simple_uuid()
+        self.id = f"TeaserLoad_{self.building_name}"
 
     def lookup_building_type(self, building_type):
         """Look up the building type from the Enumerations in the building_properties.json schema. TEASER

--- a/geojson_modelica_translator/model_connectors/load_connectors/time_series.py
+++ b/geojson_modelica_translator/model_connectors/load_connectors/time_series.py
@@ -7,7 +7,7 @@ import shutil
 from modelica_builder.package_parser import PackageParser
 
 from geojson_modelica_translator.model_connectors.load_connectors.load_base import LoadBase
-from geojson_modelica_translator.utils import ModelicaPath, convert_c_to_k, simple_uuid
+from geojson_modelica_translator.utils import ModelicaPath, convert_c_to_k
 
 
 class TimeSeries(LoadBase):
@@ -15,7 +15,7 @@ class TimeSeries(LoadBase):
 
     def __init__(self, system_parameters, geojson_load):
         super().__init__(system_parameters, geojson_load)
-        self.id = "TimeSerLoa_" + simple_uuid()
+        self.id = f"TimeSerLoa_{self.building_name}"
 
     def to_modelica(self, scaffold):
         """Create timeSeries models based on the data in the buildings and geojsons

--- a/geojson_modelica_translator/model_connectors/load_connectors/time_series_mft_ets_coupling.py
+++ b/geojson_modelica_translator/model_connectors/load_connectors/time_series_mft_ets_coupling.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from modelica_builder.package_parser import PackageParser
 
 from geojson_modelica_translator.model_connectors.load_connectors.load_base import LoadBase
-from geojson_modelica_translator.utils import ModelicaPath, mbl_version, simple_uuid
+from geojson_modelica_translator.utils import ModelicaPath, mbl_version
 
 
 class TimeSeriesMFT(LoadBase):
@@ -16,7 +16,7 @@ class TimeSeriesMFT(LoadBase):
 
     def __init__(self, system_parameters, geojson_load):
         super().__init__(system_parameters, geojson_load)
-        self.id = "TimeSerMFTLoa_" + simple_uuid()
+        self.id = f"TimeSerMFTLoa_{self.building_name}"
 
         # Note that the order of the required MO files is important as it will be the order that
         # the "package.order" will be in.

--- a/tests/model_connectors/test_time_series_mft_ets.py
+++ b/tests/model_connectors/test_time_series_mft_ets.py
@@ -75,9 +75,9 @@ class TimeSeriesModelConnectorSingleBuildingMFTETSTest(TestCaseBase):
     def test_mft_time_series_to_modelica_and_run(self):
         root_path = Path(self.district._scaffold.districts_path.files_dir).resolve()
         mo_file_name = Path(root_path) / "DistrictEnergySystem.mo"
-        # set the run time to 31536000 (full year in seconds)
         mofile = Model(mo_file_name)
-        mofile.update_model_annotation({"experiment": {"StopTime": 31536000}})
+        one_year_in_seconds = 31536000  # 1 year in seconds
+        mofile.update_model_annotation({"experiment": {"StopTime": one_year_in_seconds}})
         mofile.save()
 
         self.run_and_assert_in_docker(
@@ -85,7 +85,7 @@ class TimeSeriesModelConnectorSingleBuildingMFTETSTest(TestCaseBase):
             file_to_load=self.district._scaffold.package_path,
             run_path=self.district._scaffold.project_path,
             start_time=0,
-            stop_time=31536000,
+            stop_time=one_year_in_seconds,
         )
 
         # Check the results
@@ -101,7 +101,8 @@ class TimeSeriesModelConnectorSingleBuildingMFTETSTest(TestCaseBase):
         coolflow_var = None
         heatflow_var = None
         for var in mat_results.varNames():
-            m = re.match("TimeSerMFTLoa_(.{8})", var)
+            # search for 25 characters because that is the length of the id for the test load
+            m = re.match("TimeSerMFTLoa_(.{25})", var)
             if m:
                 timeseries_load_var = m[1]
                 continue


### PR DESCRIPTION
#### Any background context you want to provide?
This will simplify access to results of Modelica simulations by naming the Modelica variables with the geojson_id of the load (building). Future work should do the same thing for borefields when modeling GHEs.
#### What does this PR accomplish?
Update `self.id` for the loads to use the geojson_id instead of generating a simple_uuid. We retain simple_uuid for objects that aren't being supplied by the geojson file, such as networks, couplings, ETSs, etc.
#### How should this be manually tested?
CI is sufficient
#### What are the relevant tickets?
Resolves #645 
#### Screenshots (if appropriate)
