### PR TITLE
Add downloaded weatherfiles to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,5 +115,6 @@ tests/modelica/data/packages/*/*.txt
 tests/modelica/data/packages/*/*.c
 tests/modelica/data/packages/*/dymosim
 tests/management/data/sdk_project_scraps/run/baseline_scenario/system_parameter.json
+tests/management/data/sdk_project_scraps/run/baseline_scenario/DEU_Stuttgart.107380_IWEC*
 geojson_modelica_translator/modelica/buildingslibrary/
 not/


### PR DESCRIPTION
#### Any background context you want to provide?
#654 added new tests which download new weatherfiles. That test output isn't required to be stored in github.
#### What does this PR accomplish?
Gitignore German weather files downloaded via https://github.com/urbanopt/geojson-modelica-translator/blob/develop/tests/management/test_uo_des.py#L73
