### PR TITLE
Putting GHEs downstream of the buildings

### DIFF
--- a/geojson_modelica_translator/model_connectors/couplings/5G_templates/UnidirectionalSeries_Borefield/ConnectStatements.mopt
+++ b/geojson_modelica_translator/model_connectors/couplings/5G_templates/UnidirectionalSeries_Borefield/ConnectStatements.mopt
@@ -1,6 +1,6 @@
 // Borefield and distribution coupling connections
 {% if graph.get_ghe_id(coupling.id) == loop_order.data[0].list_ghe_ids_in_group[0] %}
-  connect(pumDis.port_b, TIn_{{ coupling.id }}.port_a)
+  connect(pumDis.port_b, TDisSup_{{ coupling.id }}.port_a)
   {% raw %}annotation (Line(points={{-44,-50},{-44,10},{-40,10}}, color={0,127,255}));
   {% endraw %}
 {% endif %}
@@ -14,7 +14,7 @@ connect(TIn_{{ coupling.id }}.port_b, conSto_{{ coupling.plant.id }}.port_aDis)
 {% raw %}annotation (Line(points={{-20,50},{-10,50}}, color={0,127,255}));
 {% endraw %}connect({{ coupling.plant.id }}.port_b, conSto_{{ coupling.plant.id }}.port_aCon)
 {% raw %}annotation (Line(points={{10,50},{20,50},{20,32},{-12,32},{-12,20}}, color={0,127,255}));
-{% endraw %}connect(TOut_{{ coupling.id }}.port_b, TDisSup_{{ coupling.id }}.port_a)
+{% endraw %}connect(TDisRet_{{ coupling.id }}.port_b, TIn_{{ coupling.id }}.port_a)
 {% raw %}annotation (Line(points={{20,10},{24,10}}, color={0,127,255}));
 {% endraw %}connect(TDisSup_{{ coupling.id }}.port_b, {{ coupling.network.id }}.port_aDisSup)
 {% raw %}annotation (Line(points={{44,10},{50,10}}, color={0,127,255}));
@@ -24,14 +24,14 @@ connect(TIn_{{ coupling.id }}.port_b, conSto_{{ coupling.plant.id }}.port_aDis)
 {% for group_num in range(loop_order.number_of_loops) %}
   {% if graph.get_ghe_id(coupling.id) == loop_order.data[group_num].list_ghe_ids_in_group[0] %}
     {% if group_num == loop_order.number_of_loops-1 %}
-      connect(TDisRet_{{ coupling.id }}.port_b, pumDis.port_a)
+      connect(TOut_{{ coupling.id }}.port_b, pumDis.port_a)
       {% raw %}annotation (Line(points={{100,-40},{100,-74},{-72,-74},{-72,-70}}, color={0,127,255}));
       {% endraw %}
     {% else %}
       {% set ground_id = graph.couplings_by_type(coupling.network.id).network_couplings[0].network.id %}
       {% set next_borefield_id = graph.couplings_by_type(ground_id).plant_couplings[group_num+1].plant.id %}
       {% set next_dis_id = graph.couplings_by_type(next_borefield_id).network_couplings[0].network.id %}
-      connect(TDisRet_{{ coupling.id }}.port_b, TIn_{{ graph.couplings_by_type(next_dis_id).plant_couplings[0].id }}.port_a)
+      connect(TOut_{{ coupling.id }}.port_b, TDisSup_{{ graph.couplings_by_type(next_dis_id).plant_couplings[0].id }}.port_a)
       {% raw %}annotation (Line(points={{-44,-50},{-44,10},{-40,10}}, color={0,127,255}));
       {% endraw %}
     {% endif %}

--- a/geojson_modelica_translator/model_connectors/load_connectors/load_base.py
+++ b/geojson_modelica_translator/model_connectors/load_connectors/load_base.py
@@ -36,67 +36,71 @@ class LoadBase(ModelBase):
         # Second if statement is for cases of a sys-param file not including ets data
         # TODO: Decide if we're requiring sys-param file, and if all loads have an ets.
         # test_base.py and test_time_series.py test these cases
-        if (
-            system_parameters is not None
-            and self.system_parameters.get_param_by_id(self.building_id, "ets_indirect_parameters") is not None
-        ):
-            self.ets_template_data = {
-                "heat_flow_nominal": self.system_parameters.get_param_by_id(
-                    self.building_id, "ets_indirect_parameters.heat_flow_nominal"
-                ),
-                "heat_exchanger_efficiency": self.system_parameters.get_param_by_id(
-                    self.building_id, "ets_indirect_parameters.heat_exchanger_efficiency"
-                ),
-                "nominal_mass_flow_district": self.system_parameters.get_param_by_id(
-                    self.building_id, "ets_indirect_parameters.nominal_mass_flow_district"
-                ),
-                "nominal_mass_flow_building": self.system_parameters.get_param_by_id(
-                    self.building_id, "ets_indirect_parameters.nominal_mass_flow_building"
-                ),
-                "valve_pressure_drop": self.system_parameters.get_param_by_id(
-                    self.building_id, "ets_indirect_parameters.valve_pressure_drop"
-                ),
-                "heat_exchanger_secondary_pressure_drop": self.system_parameters.get_param_by_id(
-                    self.building_id, "ets_indirect_parameters.heat_exchanger_secondary_pressure_drop"
-                ),
-                "heat_exchanger_primary_pressure_drop": self.system_parameters.get_param_by_id(
-                    self.building_id, "ets_indirect_parameters.heat_exchanger_primary_pressure_drop"
-                ),
-                "cooling_supply_water_temperature_building": convert_c_to_k(
-                    self.system_parameters.get_param_by_id(
-                        self.building_id, "ets_indirect_parameters.cooling_supply_water_temperature_building"
-                    )
-                ),
-                "heating_supply_water_temperature_building": convert_c_to_k(
-                    self.system_parameters.get_param_by_id(
-                        self.building_id, "ets_indirect_parameters.heating_supply_water_temperature_building"
-                    )
-                ),
-                "delta_temp_chw_building": self.system_parameters.get_param_by_id(
-                    self.building_id, "ets_indirect_parameters.delta_temp_chw_building"
-                ),
-                "delta_temp_chw_district": self.system_parameters.get_param_by_id(
-                    self.building_id, "ets_indirect_parameters.delta_temp_chw_district"
-                ),
-                "delta_temp_hw_building": self.system_parameters.get_param_by_id(
-                    self.building_id, "ets_indirect_parameters.delta_temp_hw_building"
-                ),
-                "delta_temp_hw_district": self.system_parameters.get_param_by_id(
-                    self.building_id, "ets_indirect_parameters.delta_temp_hw_district"
-                ),
-                "cooling_controller_y_max": self.system_parameters.get_param_by_id(
-                    self.building_id, "ets_indirect_parameters.cooling_controller_y_max"
-                ),
-                "cooling_controller_y_min": self.system_parameters.get_param_by_id(
-                    self.building_id, "ets_indirect_parameters.cooling_controller_y_min"
-                ),
-                "heating_controller_y_max": self.system_parameters.get_param_by_id(
-                    self.building_id, "ets_indirect_parameters.heating_controller_y_max"
-                ),
-                "heating_controller_y_min": self.system_parameters.get_param_by_id(
-                    self.building_id, "ets_indirect_parameters.heating_controller_y_min"
-                ),
-            }
+        if system_parameters is not None:
+            if self.system_parameters.get_param_by_id(self.building_id, "ets_indirect_parameters") is not None:
+                self.ets_template_data = {
+                    "heat_flow_nominal": self.system_parameters.get_param_by_id(
+                        self.building_id, "ets_indirect_parameters.heat_flow_nominal"
+                    ),
+                    "heat_exchanger_efficiency": self.system_parameters.get_param_by_id(
+                        self.building_id, "ets_indirect_parameters.heat_exchanger_efficiency"
+                    ),
+                    "nominal_mass_flow_district": self.system_parameters.get_param_by_id(
+                        self.building_id, "ets_indirect_parameters.nominal_mass_flow_district"
+                    ),
+                    "nominal_mass_flow_building": self.system_parameters.get_param_by_id(
+                        self.building_id, "ets_indirect_parameters.nominal_mass_flow_building"
+                    ),
+                    "valve_pressure_drop": self.system_parameters.get_param_by_id(
+                        self.building_id, "ets_indirect_parameters.valve_pressure_drop"
+                    ),
+                    "heat_exchanger_secondary_pressure_drop": self.system_parameters.get_param_by_id(
+                        self.building_id, "ets_indirect_parameters.heat_exchanger_secondary_pressure_drop"
+                    ),
+                    "heat_exchanger_primary_pressure_drop": self.system_parameters.get_param_by_id(
+                        self.building_id, "ets_indirect_parameters.heat_exchanger_primary_pressure_drop"
+                    ),
+                    "cooling_supply_water_temperature_building": convert_c_to_k(
+                        self.system_parameters.get_param_by_id(
+                            self.building_id, "ets_indirect_parameters.cooling_supply_water_temperature_building"
+                        )
+                    ),
+                    "heating_supply_water_temperature_building": convert_c_to_k(
+                        self.system_parameters.get_param_by_id(
+                            self.building_id, "ets_indirect_parameters.heating_supply_water_temperature_building"
+                        )
+                    ),
+                    "delta_temp_chw_building": self.system_parameters.get_param_by_id(
+                        self.building_id, "ets_indirect_parameters.delta_temp_chw_building"
+                    ),
+                    "delta_temp_chw_district": self.system_parameters.get_param_by_id(
+                        self.building_id, "ets_indirect_parameters.delta_temp_chw_district"
+                    ),
+                    "delta_temp_hw_building": self.system_parameters.get_param_by_id(
+                        self.building_id, "ets_indirect_parameters.delta_temp_hw_building"
+                    ),
+                    "delta_temp_hw_district": self.system_parameters.get_param_by_id(
+                        self.building_id, "ets_indirect_parameters.delta_temp_hw_district"
+                    ),
+                    "cooling_controller_y_max": self.system_parameters.get_param_by_id(
+                        self.building_id, "ets_indirect_parameters.cooling_controller_y_max"
+                    ),
+                    "cooling_controller_y_min": self.system_parameters.get_param_by_id(
+                        self.building_id, "ets_indirect_parameters.cooling_controller_y_min"
+                    ),
+                    "heating_controller_y_max": self.system_parameters.get_param_by_id(
+                        self.building_id, "ets_indirect_parameters.heating_controller_y_max"
+                    ),
+                    "heating_controller_y_min": self.system_parameters.get_param_by_id(
+                        self.building_id, "ets_indirect_parameters.heating_controller_y_min"
+                    ),
+                }
+            elif self.system_parameters.get_param_by_id(self.building_id, "fifth_gen_ets_parameters") is not None:
+                self.ets_template_data = {
+                    "cop_heating": self.system_parameters.get_param_by_id(
+                        self.building_id, "fifth_gen_ets_parameters.cop_heat_pump_heating"
+                    ),
+                }
 
     def add_building(self, urbanopt_building, mapper=None):
         """Add building to the load to be translated. This is simply a helper method.

--- a/geojson_modelica_translator/model_connectors/load_connectors/templates/TimeSeriesBuildingWithETS.mot
+++ b/geojson_modelica_translator/model_connectors/load_connectors/templates/TimeSeriesBuildingWithETS.mot
@@ -3,7 +3,8 @@ within {{ project_name }}.Loads.{{ model_name }};
   "Model of a building with an internal ETS. Building loads provided as time series"
   extends Buildings.DHC.Loads.Combined.BaseClasses.PartialBuildingWithETS(
     final allowFlowReversalSer=true,
-    {% endraw %}redeclare {{ project_name }}.Loads.{{ model_name }}.TimeSeriesBuilding bui(
+    {% endraw %}COPHeaWat_nominal={{data['cop_heating']}},
+    redeclare {{ project_name }}.Loads.{{ model_name }}.TimeSeriesBuilding bui(
       {% raw %}have_hotWat=true,
       T_aHeaWat_nominal=ets.THeaWatSup_nominal,
       T_bHeaWat_nominal=ets.THeaWatRet_nominal,

--- a/geojson_modelica_translator/model_connectors/load_connectors/templates/TimeSeries_Instance.mopt
+++ b/geojson_modelica_translator/model_connectors/load_connectors/templates/TimeSeries_Instance.mopt
@@ -10,8 +10,7 @@
     delTAirHea(displayUnit="degC")=20,
     k=0.1,
     Ti=120
-    ), ets(have_hotWat = true, have_varFloEva=false),
-    COPHeaWat_nominal=2.5
+    ), ets(have_hotWat = true, have_varFloEva=false)
     {% else %}
     allowFlowReversal = true,
     T_aHeaWat_nominal(displayUnit="K")=318.15,

--- a/geojson_modelica_translator/model_connectors/load_connectors/templates/TimeSeries_Instance.mopt
+++ b/geojson_modelica_translator/model_connectors/load_connectors/templates/TimeSeries_Instance.mopt
@@ -10,7 +10,8 @@
     delTAirHea(displayUnit="degC")=20,
     k=0.1,
     Ti=120
-    ), ets(have_hotWat = true, have_varFloEva=false)
+    ), ets(have_hotWat = true, have_varFloEva=false),
+    COPHeaWat_nominal=2.5
     {% else %}
     allowFlowReversal = true,
     T_aHeaWat_nominal(displayUnit="K")=318.15,


### PR DESCRIPTION
#### Any background context you want to provide?
This PR changes the couplings to put GHEs downstream of the buildings in the same building group.
Before:
![image](https://github.com/user-attachments/assets/99bf4c4d-2426-4400-89d0-481bde6c9b5f)
After:
![image](https://github.com/user-attachments/assets/0e3d983c-c82d-4f2b-b833-4b5c3f75cca9)

#### What does this PR accomplish?
It also changes the time series building template to take heat pump heating COP from the sys_params file.

#### How should this be manually tested?
poetry run any tests with GHEs and buildings.

#### What are the relevant tickets?
Issue #675 and issue #666.

#### Screenshots (if appropriate)
