### PR TITLE
Remove `is_ghe_start_loop` from test geojson files

### DIFF
--- a/tests/model_connectors/data/sdk_output_skeleton_13_buildings/exportGeo.json
+++ b/tests/model_connectors/data/sdk_output_skeleton_13_buildings/exportGeo.json
@@ -834,8 +834,7 @@
         "type": "ThermalJunction",
         "buildingId": "10",
         "junction_type": "DES",
-        "connection_type": "Series",
-        "is_ghe_start_loop": true
+        "connection_type": "Series"
       },
       "geometry": {
         "type": "Point",

--- a/tests/model_connectors/data/time_series_ex2.json
+++ b/tests/model_connectors/data/time_series_ex2.json
@@ -199,7 +199,6 @@
         "id": "95c1831f-3ae6-480e-910e-6d3c440b035c",
         "type": "ThermalJunction",
         "DSId": "0b575a8f-97d1-47e6-b329-7ef7566d26f2",
-        "is_ghe_start_loop": true,
         "junction_type": "DES",
         "connection_type": "Series"
       },


### PR DESCRIPTION
#### Any background context you want to provide?

Removed `is_ghe_start_loop` from schema in https://github.com/urbanopt/urbanopt-geojson-gem/pull/280 because it is how being handled automagically [in ThermalNetwork](https://github.com/NREL/ThermalNetwork/pull/58).

#### What does this PR accomplish?
- Remove this property from test geojson files

#### How should this be manually tested?
CI is sufficient

#### What are the relevant tickets?

#### Screenshots (if appropriate)
