### PR TITLE
Handle all-caps soil-temp stations, like Frankfurt

### DIFF
--- a/geojson_modelica_translator/model_connectors/networks/ground_coupling.py
+++ b/geojson_modelica_translator/model_connectors/networks/ground_coupling.py
@@ -85,16 +85,23 @@ class GroundCoupling(NetworkBase):
         coefs = pd.read_csv(Path(__file__).parent / "data" / "Soil_temp_coefficients.csv")
         matching_rows = coefs[coefs.apply(lambda row: row.astype(str).str.contains(station_name).any(), axis=1)]
         if len(matching_rows) == 0:
-            raise ValueError(
-                "No matching weather station has been found. Please check your weather file name format."
-                "(e.g., USA_NY_Buffalo-Greater.Buffalo.Intl.AP.725280_TMY3.mos)"
-            )
-        else:
-            template_data["surface_temp"] = matching_rows["Ts,avg, C"].iloc[0] + 273.15
-            template_data["first_amplitude"] = matching_rows["Ts,amplitude,1, C"].iloc[0]
-            template_data["second_amplitude"] = matching_rows["Ts,amplitude,2, C"].iloc[0]
-            template_data["first_phase_lag"] = matching_rows["PL1"].iloc[0]
-            template_data["second_phase_lag"] = matching_rows["PL2"].iloc[0]
+            # Some of the stations in the coefs df are in all caps, so try that as well.
+            # Also try to match only the first word of the station name.
+            station_name = station_name.split()[0]
+            matching_rows = coefs[
+                coefs.apply(lambda row: row.astype(str).str.contains(station_name.upper()).any(), axis=1)
+            ]
+            # If still no match, raise an error
+            if len(matching_rows) == 0:
+                raise ValueError(
+                    "No matching weather station has been found. Please check your weather file name format."
+                    "(e.g., USA_NY_Buffalo-Greater.Buffalo.Intl.AP.725280_TMY3.mos)"
+                )
+        template_data["surface_temp"] = matching_rows["Ts,avg, C"].iloc[0] + 273.15
+        template_data["first_amplitude"] = matching_rows["Ts,amplitude,1, C"].iloc[0]
+        template_data["second_amplitude"] = matching_rows["Ts,amplitude,2, C"].iloc[0]
+        template_data["first_phase_lag"] = matching_rows["PL1"].iloc[0]
+        template_data["second_phase_lag"] = matching_rows["PL2"].iloc[0]
 
         # create horizontal piping package paths
         b_modelica_path = ModelicaPath(self.ground_coupling_name, scaffold.networks_path.files_dir, True)


### PR DESCRIPTION
#### Any background context you want to provide?
Some weather file names weren't being parsed correctly when looking up soil temp coefficients. Frankfurt was the first example we found of this. This handles those cases.

#### What does this PR accomplish?
If soil temp coeff lookup fails, try using only the first word of the station and capitalizing it. If that still doesn't work, error as before.

#### How should this be manually tested?
Build a demo project with the uo-cli, using with the [Frankfurt weather file](https://energyplus.net/weather-location/europe_wmo_region_6/DEU/DEU_Frankfurt.am.Main.106370_IWEC). Go through the default baseline workflow, and `uo_des create-model`. If that works successfully (it did on my machine! 😄 ) we're good to go

#### What are the relevant tickets?

#### Screenshots (if appropriate)
