### PR TITLE
Clean up matching district generation types

### DIFF
--- a/geojson_modelica_translator/geojson_modelica_translator.py
+++ b/geojson_modelica_translator/geojson_modelica_translator.py
@@ -87,21 +87,23 @@ def _parse_couplings(geojson, sys_params, sys_param_district_type):
                             time_series_load = TimeSeries(sys_params, geojson_load)
                             # couple each time series load to distribution
                             all_couplings.append(
-                                Coupling(time_series_load, distribution, district_type="fifth_generation")
+                                Coupling(time_series_load, distribution, district_type=sys_param_district_type)
                             )
                             all_couplings.append(
-                                Coupling(time_series_load, ambient_water_stub, district_type="fifth_generation")
+                                Coupling(time_series_load, ambient_water_stub, district_type=sys_param_district_type)
                             )
                             all_couplings.append(
-                                Coupling(time_series_load, design_data, district_type="fifth_generation")
+                                Coupling(time_series_load, design_data, district_type=sys_param_district_type)
                             )
                 # couple each borefield and distribution
-                all_couplings.append(Coupling(distribution, borefield, district_type="fifth_generation"))
+                all_couplings.append(Coupling(distribution, borefield, district_type=sys_param_district_type))
                 # couple distribution and ground coupling
-                all_couplings.append(Coupling(distribution, ground_coupling, district_type="fifth_generation"))
+                all_couplings.append(Coupling(distribution, ground_coupling, district_type=sys_param_district_type))
                 # empty couple between borefield and ground
-                all_couplings.append(Coupling(ground_coupling, borefield, district_type="fifth_generation"))
-            all_couplings.append(Coupling(ambient_water_stub, ambient_water_stub, district_type="fifth_generation"))
+                all_couplings.append(Coupling(ground_coupling, borefield, district_type=sys_param_district_type))
+            all_couplings.append(
+                Coupling(ambient_water_stub, ambient_water_stub, district_type=sys_param_district_type)
+            )
         else:
             pass  # Create waste heat components & couplings
 

--- a/geojson_modelica_translator/model_connectors/couplings/coupling.py
+++ b/geojson_modelica_translator/model_connectors/couplings/coupling.py
@@ -28,10 +28,13 @@ class Coupling:
         self.district_type = district_type
         self._template_base_name = f"{model_a.model_name}_{model_b.model_name}"
 
-        if self.district_type == "fifth_generation":
-            self._template_dir = Path(__file__).parent / "5G_templates" / self._template_base_name
-        else:
-            self._template_dir = Path(__file__).parent / "templates" / self._template_base_name
+        match self.district_type:
+            case "fifth_generation":
+                self._template_dir = Path(__file__).parent / "5G_templates" / self._template_base_name
+            case "fourth_generation" | None:
+                self._template_dir = Path(__file__).parent / "templates" / self._template_base_name
+            case _:
+                raise Exception(f"Invalid district type: {self.district_type}")
         if not Path(self._template_dir).exists():
             raise Exception(f"Invalid coupling. Missing {self._template_dir} directory.")
 


### PR DESCRIPTION
#### Any background context you want to provide?

#### What does this PR accomplish?
- Explicitly selects actions for 4th & 5th generation districts. Old technique was to assume that anything non-5th-gen was 4th gen. This enables additional generations of district systems to be modeled in the future, opening up development opportunities.
- DRY up gmt.py a bit.

#### How should this be manually tested?
CI is suffcient

#### What are the relevant tickets?
Resolves #504 

#### Screenshots (if appropriate)
