### PR TITLE
Expose skipping weather download

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,7 @@ tests/output
 tests/*/microgrid_output
 tests/output_ets
 tests/*/output
+tests/**/weather
 tests/modelica/data/packages/*/*.mat
 tests/modelica/data/packages/*/*.txt
 tests/modelica/data/packages/*/*.c

--- a/management/uo_des.py
+++ b/management/uo_des.py
@@ -54,6 +54,13 @@ def cli():
     help="If specified, microgrid inputs will be added to system parameters file",
     default=False,
 )
+@click.option(
+    "-w",
+    "--skip_weather_download",
+    is_flag=True,
+    help="If specified, weather files will not be downloaded",
+    default=False,
+)
 def build_sys_param(
     model_type: str,
     sys_param_filename: Path,
@@ -62,6 +69,7 @@ def build_sys_param(
     district_type: str,
     overwrite: bool,
     microgrid: bool,
+    skip_weather_download: bool,
 ):
     """Create system parameters file using uo_sdk output
 
@@ -101,6 +109,7 @@ def build_sys_param(
         district_type=district_type,
         overwrite=overwrite,
         microgrid=microgrid,
+        skip_weather_download=skip_weather_download,
     )
 
     if Path(sys_param_filename).exists():

--- a/ruff.toml
+++ b/ruff.toml
@@ -14,7 +14,7 @@ extend-ignore-names = ["test_*"]
 [lint.pylint]
 # system_parameters.py has many file lookups that necessitate nested statements & branches
 # Raise the allowed limits the least possible amount https://docs.astral.sh/ruff/settings/#pylint-max-branches
-max-statements = 60
+max-statements = 65
 max-branches = 24
 
 [lint.per-file-ignores]

--- a/tests/system_parameters/test_system_parameters.py
+++ b/tests/system_parameters/test_system_parameters.py
@@ -16,9 +16,10 @@ class SystemParametersTest(unittest.TestCase):
     def setUp(self):
         self.data_dir = Path(__file__).parent / "data"
         self.output_dir = Path(__file__).parent / "output"
-        self.weather_dir = self.output_dir / "weatherfiles"
         self.scenario_dir = self.data_dir / "sdk_output_skeleton" / "run" / "baseline_15min"
+        self.weather_dir = self.scenario_dir.parent.parent / "weather"
         self.microgrid_scenario_dir = self.data_dir / "sdk_microgrid_output_skeleton" / "run" / "reopt_scenario"
+        self.microgrid_weather_dir = self.microgrid_scenario_dir.parent.parent / "weather"
         self.microgrid_feature_file = self.data_dir / "sdk_microgrid_output_skeleton" / "example_project.json"
         self.microgrid_output_dir = Path(__file__).parent / "microgrid_output"
         self.feature_file = self.data_dir / "sdk_output_skeleton" / "example_project.json"
@@ -33,7 +34,8 @@ class SystemParametersTest(unittest.TestCase):
         self.output_dir.mkdir(parents=True)
         if self.weather_dir.exists():
             rmtree(self.weather_dir)
-        self.weather_dir.mkdir(parents=True)
+        if self.microgrid_weather_dir.exists():
+            rmtree(self.microgrid_weather_dir)
         if self.microgrid_output_dir.exists():
             rmtree(self.microgrid_output_dir)
         self.microgrid_output_dir.mkdir(parents=True)


### PR DESCRIPTION
#### Any background context you want to provide?
In cases where a user wants to run UO without an internet connection, they will need to provide their own epw & mos weather files. This not only exposes the existing functionality to the cli, we now also look in multiple common locations in the users' project folder for weather.

#### What does this PR accomplish?
- Expose `skip_weather_download` to the cli
- Look for weather in multiple locations, not just the dir the sys-param file is in
- Update existing tests to work with the new weather location ideas

#### How should this be manually tested?
Run the cli by hand, with the new `-w` flag.
- Is `-w` a good short flag for weather? It's to skip downloading and use an existing file

I tried logging when we download and when we use a local file (which would have been useful for testing), and it wasn't showing on my stdout. Not sure why, so I am ignoring that for now.
