### PR TITLE
Enable selecting output variables from Modelica simulation

### DIFF
--- a/geojson_modelica_translator/modelica/lib/runner/simulate.most
+++ b/geojson_modelica_translator/modelica/lib/runner/simulate.most
@@ -6,15 +6,6 @@ loadFile("{{ file_to_load }}");
 getErrorString();
 {% endif %}
 
-{% if use_default_time_params %}
-simulate({{ model_name }});
-{% else %}
-    {% if step_size %}
-simulate({{ model_name }}, startTime={{start_time}}, stopTime={{stop_time}}, stepSize={{step_size}});
-    {% elif number_of_intervals %}
-simulate({{ model_name }}, startTime={{start_time}}, stopTime={{stop_time}}, numberOfIntervals={{number_of_intervals}});
-    {% else %}
-simulate({{ model_name }}, startTime={{start_time}}, stopTime={{stop_time}});
-    {% endif %}
-{% endif %}
+simulate({{ simulation_args }});
+
 getErrorString();

--- a/geojson_modelica_translator/modelica/modelica_runner.py
+++ b/geojson_modelica_translator/modelica/modelica_runner.py
@@ -103,7 +103,7 @@ class ModelicaRunner:
                 stop_time (int): stop time of the simulation, in seconds
                 step_size (int): step size of the simulation, in seconds
                 number_of_intervals (int): number of intervals to run the simulation
-                output_variables (list[str]): list of Modelica output variables to produce.
+                output_variables (list[str]): limit Modelica .
         """
         # read in the start, stop, and step times
         project_in_library = kwargs.get("project_in_library", False)
@@ -112,6 +112,12 @@ class ModelicaRunner:
         step_size = kwargs.get("step_size")
         number_of_intervals = kwargs.get("number_of_intervals")
         output_variables = kwargs.get("output_variables")
+
+        if step_size and number_of_intervals:
+            logger.error("step_size and number_of_intervals are mutually exclusive. Pass one or the other, not both.")
+            raise ValueError()
+            # ValueError is raised in order to prevent the simulation from running.
+            # Text in the ValueError does not get out of our test, therefore log the message for user visibility.
 
         simulation_args = f"{model_name}"
         if start_time:
@@ -123,10 +129,7 @@ class ModelicaRunner:
         if number_of_intervals:
             simulation_args += f", numberOfIntervals={number_of_intervals}"
         if output_variables:
-            simulation_args += f", outputVariables={{{', '.join(map(str, output_variables))}}}"
-            # triple curly braces lets us use the f-string and then escape to wrap in literal curly braces
-            # Mapping enforces all output_variables elements be strings
-            # Joining puts them in the Modelica curly-brace list, not a standard Python list
+            simulation_args += f', variableFilter="{"|".join(output_variables)}"'
         logger.debug(f"Arguments passed to OMC: {simulation_args}")
 
         # initialize the templating framework (Jinja2)

--- a/management/uo_des.py
+++ b/management/uo_des.py
@@ -206,7 +206,16 @@ def create_model(sys_param_file: Path, geojson_feature_file: Path, project_path:
     help="Number of intervals to divide the simulation into (alternative to step_size)",
     type=int,
 )
-def run_model(modelica_project: Path, start_time: int, stop_time: int, step_size: int, intervals: int):
+@click.option(
+    "-o",
+    "--output_variables",
+    default=None,
+    help="Specific output variables to capture from simulation",
+    type=list[str],
+)
+def run_model(
+    modelica_project: Path, start_time: int, stop_time: int, step_size: int, intervals: int, output_variables: list[str]
+):
     """Run the model
 
     \b
@@ -225,6 +234,7 @@ def run_model(modelica_project: Path, start_time: int, stop_time: int, step_size
     :param stop_time (int): stop time of the simulation (seconds of a year)
     :param step_size (int): step size of the simulation (seconds)
     :param number_of_intervals (int): number of intervals to run the simulation
+    :param output_variables (list[str] Specific Modelica variables to save from simulation)
     """
     project_name = modelica_project.stem
 
@@ -245,6 +255,7 @@ def run_model(modelica_project: Path, start_time: int, stop_time: int, step_size
         stop_time=stop_time,
         step_size=step_size,
         number_of_intervals=intervals,
+        output_variables=output_variables,
     )
 
     run_location = modelica_project.parent / project_name / f"{project_name}.Districts.DistrictEnergySystem_results"

--- a/management/uo_des.py
+++ b/management/uo_des.py
@@ -210,8 +210,15 @@ def create_model(sys_param_file: Path, geojson_feature_file: Path, project_path:
     "-o",
     "--output_variables",
     default=None,
-    help="Specific output variables to capture from simulation",
-    type=list[str],
+    help="Comma-separated list of specific output variables to capture from simulation",
+    type=str,
+)
+@click.option(
+    "-s",
+    "--simflags",
+    default=None,
+    help="Comma-separated list of OpenModelica simulation flags. For advanced users only",
+    type=str,
 )
 @click.option(
     "-d",
@@ -226,7 +233,8 @@ def run_model(
     stop_time: int,
     step_size: int,
     intervals: int,
-    output_variables: list[str],
+    output_variables: str,
+    simflags: str,
     debug: bool,
 ):
     """Run the model
@@ -247,7 +255,8 @@ def run_model(
     :param stop_time (int): stop time of the simulation (seconds of a year)
     :param step_size (int): step size of the simulation (seconds)
     :param number_of_intervals (int): number of intervals to run the simulation
-    :param output_variables (list[str] Specific Modelica variables to save from simulation)
+    :param output_variables (str) Comma-separated list of specific output variables to capture from simulation
+    :param simflags (str): Comma-separated list of OpenModelica simulation flags. For advanced users only
     :param debug (bool): if True, keeps intermediate files for debugging
     """
     project_name = modelica_project.stem
@@ -270,6 +279,7 @@ def run_model(
         step_size=step_size,
         number_of_intervals=intervals,
         output_variables=output_variables,
+        simflags=simflags,
         debug=debug,
     )
 

--- a/management/uo_des.py
+++ b/management/uo_des.py
@@ -202,7 +202,7 @@ def create_model(sys_param_file: Path, geojson_feature_file: Path, project_path:
 @click.option(
     "-i",
     "--intervals",
-    default=144,
+    default=None,
     help="Number of intervals to divide the simulation into (alternative to step_size)",
     type=int,
 )
@@ -213,8 +213,21 @@ def create_model(sys_param_file: Path, geojson_feature_file: Path, project_path:
     help="Specific output variables to capture from simulation",
     type=list[str],
 )
+@click.option(
+    "-d",
+    "--debug",
+    is_flag=True,
+    help="Keeps intermediate files for debugging if something goes wrong",
+    default=False,
+)
 def run_model(
-    modelica_project: Path, start_time: int, stop_time: int, step_size: int, intervals: int, output_variables: list[str]
+    modelica_project: Path,
+    start_time: int,
+    stop_time: int,
+    step_size: int,
+    intervals: int,
+    output_variables: list[str],
+    debug: bool,
 ):
     """Run the model
 
@@ -235,6 +248,7 @@ def run_model(
     :param step_size (int): step size of the simulation (seconds)
     :param number_of_intervals (int): number of intervals to run the simulation
     :param output_variables (list[str] Specific Modelica variables to save from simulation)
+    :param debug (bool): if True, keeps intermediate files for debugging
     """
     project_name = modelica_project.stem
 
@@ -256,6 +270,7 @@ def run_model(
         step_size=step_size,
         number_of_intervals=intervals,
         output_variables=output_variables,
+        debug=debug,
     )
 
     run_location = modelica_project.parent / project_name / f"{project_name}.Districts.DistrictEnergySystem_results"

--- a/tests/management/test_uo_des.py
+++ b/tests/management/test_uo_des.py
@@ -366,3 +366,33 @@ class CLIIntegrationTest(TestCase):
         assert (
             self.output_dir / project_name / results_dir / f"{project_name}.Districts.DistrictEnergySystem_res.mat"
         ).exists()
+
+    @pytest.mark.simulation
+    def test_cli_runs_existing_5g_model_with_specific_variables(self):
+        project_name = "modelica_project_5g"
+        results_dir = f"{project_name}.Districts.DistrictEnergySystem_results"
+        if (self.output_dir / project_name / results_dir).exists():
+            rmtree(self.output_dir / project_name / results_dir)
+
+        # run subprocess as if we're an end-user
+        self.runner.invoke(
+            cli,
+            [
+                "run-model",
+                str(self.output_dir / project_name),
+                "-a",
+                str(self.day_200_in_seconds),
+                "-z",
+                str(self.day_201_in_seconds),
+                "-x",
+                str(self.step_size_90_seconds),
+                "-o",
+                [".*PPumETS", ".*PHea"],
+            ],
+        )
+
+        # If this file exists, the cli command ran successfully
+        assert (
+            self.output_dir / project_name / results_dir / f"{project_name}.Districts.DistrictEnergySystem_res.mat"
+        ).exists()
+        # TODO: check the output file for the expected variables, and that, in this case, PPum is not in the output


### PR DESCRIPTION
#### Any background context you want to provide?
This enables selecting specific output variables for the Modelica simulation to emit, using [regex or wildcards](https://openmodelica.org/doc/OpenModelicaUsersGuide/1.24/omedit.html#output). I was also able to clean up the simulate.most templated script that we use to send the actual command to Modelica.

#### What does this PR accomplish?
Enables new filtering functionality for the Modelica simulation

#### How should this be manually tested?
Run the `tests/management/test_uo_des.py::test_cli_runs_existing_5g_model_with_specific_variables` test and manually open the results file in OM to review the output. Confirm that the `PPum` variable is not available because that test does not specifically include it in the list of variables we are interested in.

#### What are the relevant tickets?

#### Screenshots (if appropriate)
