### PR TITLE
Add capability to pass Modelica flags to the GMT CLI

### DIFF
--- a/geojson_modelica_translator/modelica/modelica_runner.py
+++ b/geojson_modelica_translator/modelica/modelica_runner.py
@@ -130,9 +130,9 @@ class ModelicaRunner:
         if number_of_intervals:
             simulation_args += f", numberOfIntervals={number_of_intervals}"
         if output_variables:
-            simulation_args += f', variableFilter="{"|".join(output_variables.split(","))}"'
+            simulation_args += f', variableFilter="{output_variables.replace(",", "|")}"'
         if simulation_flags:
-            simulation_args += f', simflags="{" ".join(simulation_flags.split(","))}"'
+            simulation_args += f', simflags="{simulation_flags.replace(",", " ")}"'
         logger.debug(f"Arguments passed to OMC: {simulation_args}")
 
         # initialize the templating framework (Jinja2)

--- a/geojson_modelica_translator/modelica/modelica_runner.py
+++ b/geojson_modelica_translator/modelica/modelica_runner.py
@@ -173,10 +173,9 @@ class ModelicaRunner:
         mo_script = "compile_fmu" if action == "compile" else "simulate"
         if compiler_flags is not None:
             # Format compiler flags for OpenModelica
-            compiler_flags_list = compiler_flags.split(",")
-            compiler_flags_string = " && ".join(compiler_flags_list)
+            compiler_flags_for_modelica = compiler_flags.replace(",", " ")
         else:
-            compiler_flags_string = ""
+            compiler_flags_for_modelica = ""
 
         try:
             # create the command to call the open modelica compiler inside the docker image
@@ -188,7 +187,7 @@ class ModelicaRunner:
                 f"{image_name}",
                 "/bin/bash",
                 "-c",
-                f"cd mnt/shared/{model_name} && omc {mo_script}.mos {compiler_flags_string}",
+                f"cd mnt/shared/{model_name} && omc {mo_script}.mos {compiler_flags_for_modelica}",
             ]
             # execute the command that calls docker
             logger.debug(f"Calling {exec_call}")

--- a/management/uo_des.py
+++ b/management/uo_des.py
@@ -214,8 +214,15 @@ def create_model(sys_param_file: Path, geojson_feature_file: Path, project_path:
     type=str,
 )
 @click.option(
+    "-c",
+    "--compiler_flags",
+    default=None,
+    help="Comma-separated list of OpenModelica compiler flags. For advanced users only",
+    type=str,
+)
+@click.option(
     "-s",
-    "--simflags",
+    "--simulation_flags",
     default=None,
     help="Comma-separated list of OpenModelica simulation flags. For advanced users only",
     type=str,
@@ -234,7 +241,8 @@ def run_model(
     step_size: int,
     intervals: int,
     output_variables: str,
-    simflags: str,
+    compiler_flags: str,
+    simulation_flags: str,
     debug: bool,
 ):
     """Run the model
@@ -256,7 +264,8 @@ def run_model(
     :param step_size (int): step size of the simulation (seconds)
     :param number_of_intervals (int): number of intervals to run the simulation
     :param output_variables (str) Comma-separated list of specific output variables to capture from simulation
-    :param simflags (str): Comma-separated list of OpenModelica simulation flags. For advanced users only
+    :param compiler_flags (str): Comma-separated list of OpenModelica simulation flags. For advanced users only
+    :param simulation_flags (str): Comma-separated list of OpenModelica simulation flags. For advanced users only
     :param debug (bool): if True, keeps intermediate files for debugging
     """
     project_name = modelica_project.stem
@@ -279,7 +288,8 @@ def run_model(
         step_size=step_size,
         number_of_intervals=intervals,
         output_variables=output_variables,
-        simflags=simflags,
+        compiler_flags=compiler_flags,
+        simulation_flags=simulation_flags,
         debug=debug,
     )
 

--- a/tests/management/test_uo_des.py
+++ b/tests/management/test_uo_des.py
@@ -418,7 +418,7 @@ class CLIIntegrationTest(TestCase):
                 "-o",
                 ".*PPumETS,.*PHea",
                 "-c",
-                "-d=aliasConflicts",
+                "-d=aliasConflicts,-d=cgraph",
             ],
         )
 

--- a/tests/management/test_uo_des.py
+++ b/tests/management/test_uo_des.py
@@ -387,12 +387,74 @@ class CLIIntegrationTest(TestCase):
                 "-x",
                 str(self.step_size_90_seconds),
                 "-o",
-                [".*PPumETS", ".*PHea"],
+                ".*PPumETS,.*PHea",
             ],
         )
 
-        # If this file exists, the cli command ran successfully
         assert (
             self.output_dir / project_name / results_dir / f"{project_name}.Districts.DistrictEnergySystem_res.mat"
         ).exists()
         # TODO: check the output file for the expected variables, and that, in this case, PPum is not in the output
+
+    @pytest.mark.simulation
+    def test_cli_runs_existing_5g_model_with_compiler_flags(self):
+        project_name = "modelica_project_5g"
+        results_dir = f"{project_name}.Districts.DistrictEnergySystem_results"
+        if (self.output_dir / project_name / results_dir).exists():
+            rmtree(self.output_dir / project_name / results_dir)
+
+        # run subprocess as if we're an end-user
+        self.runner.invoke(
+            cli,
+            [
+                "run-model",
+                str(self.output_dir / project_name),
+                "-a",
+                str(self.day_200_in_seconds),
+                "-z",
+                str(self.day_201_in_seconds),
+                "-x",
+                str(self.step_size_90_seconds),
+                "-o",
+                ".*PPumETS,.*PHea",
+                "-c",
+                "-d=aliasConflicts",
+            ],
+        )
+
+        assert (
+            self.output_dir / project_name / results_dir / f"{project_name}.Districts.DistrictEnergySystem_res.mat"
+        ).exists()
+        # TODO: check the output log file for any alias conflicts printed
+
+    @pytest.mark.simulation
+    def test_cli_runs_existing_5g_model_with_simulation_flags(self):
+        project_name = "modelica_project_5g"
+        results_dir = f"{project_name}.Districts.DistrictEnergySystem_results"
+        if (self.output_dir / project_name / results_dir).exists():
+            rmtree(self.output_dir / project_name / results_dir)
+
+        # run subprocess as if we're an end-user
+        self.runner.invoke(
+            cli,
+            [
+                "run-model",
+                str(self.output_dir / project_name),
+                "-a",
+                str(self.day_200_in_seconds),
+                "-z",
+                str(self.day_201_in_seconds),
+                "-x",
+                str(self.step_size_90_seconds),
+                "-o",
+                ".*PPumETS,.*PHea",
+                "-s",
+                "-noEventEmit,-abortSlowSimulation",
+            ],
+        )
+
+        assert (
+            self.output_dir / project_name / results_dir / f"{project_name}.Districts.DistrictEnergySystem_res.mat"
+        ).exists()
+        # TODO: check the output that the simulation had the appropriate flags applied.
+        # noEventEmit should result in smaller file size. abortSlowSimulation is to show how to pass multiple flags


### PR DESCRIPTION
#### Any background context you want to provide?
OpenModelica has many options it can accept during compilation and simulation that we weren't taking advantage of.

For usage, review the [compiler flag documentation](https://openmodelica.org/doc/OpenModelicaUsersGuide/1.24/omchelptext.html) and the [simulation flag documentation](https://openmodelica.org/doc/OpenModelicaUsersGuide/1.24/simulationflags.html). For help with the `variable_filter`, see [this documentation](https://openmodelica.org/doc/OpenModelicaUsersGuide/1.24/omedit.html#output).

#### What does this PR accomplish?
Enables compiler flags and simulation flags to be passed to the `uo_des run-model` command, which are used by OpenModelica. This enables, among many other things:
- limiting the variables in the output
- viewing additional debug info from the simulation run
- removing some non-timestep outputs
- and much more

#### How should this be manually tested?
Run one of the new tests in `tests/management/test_uo_des.py` and review the stdout.log file as well as the contents of the .mat output file from the simulation.