### PR TITLE
Require autosize flags in sys-param files

### DIFF
--- a/geojson_modelica_translator/system_parameters/system_parameter_properties.json
+++ b/geojson_modelica_translator/system_parameters/system_parameter_properties.json
@@ -1441,6 +1441,40 @@
           ],
           "additionalProperties": true
         },
+        "pre_designed_borefield": {
+          "description": "Individual borehole properties for Ground Heat Exchanger sizing.",
+          "type": "object",
+          "properties": {
+            "length_of_boreholes": {
+              "description": "The length of the boreholes, in meters.",
+              "type": "number"
+            },
+            "borehole_diameter": {
+              "description": "The diameter of the boreholes, in meters.",
+              "type": "number"
+            },
+            "borehole_x_coordinates": {
+              "description": "X-coordinates of the boreholes, in meters.",
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            },
+            "borehole_y_coordinates": {
+              "description": "Y-coordinate of the boreholes, in meters.",
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            }
+          },
+          "required": [
+            "length_of_boreholes",
+            "borehole_diameter",
+            "borehole_x_coordinates",
+            "borehole_y_coordinates"
+          ]
+        },
         "ghe_geometric_params": {
           "description": "The length and width of the Ground Heat Exchanger determined from the GeoJSON Feature File.",
           "type": "object",
@@ -1460,10 +1494,21 @@
           ]
         }
       },
+      "oneOf": [
+        {
+          "required": [
+            "pre_designed_borefield"
+          ]
+        },
+        {
+          "required": [
+            "borehole"
+          ]
+        }
+      ],
       "required": [
         "ghe_id",
-        "ghe_geometric_params",
-        "borehole"
+        "ghe_geometric_params"
       ]
     },
     "pipe_def": {

--- a/geojson_modelica_translator/system_parameters/system_parameter_properties.json
+++ b/geojson_modelica_translator/system_parameters/system_parameter_properties.json
@@ -1029,7 +1029,18 @@
           "description": "Pipes buried depth",
           "type": "number"
         }
-      }
+      },
+      "required": [
+        "hydraulic_diameter",
+        "hydraulic_diameter_autosized",
+        "insulation_thickness",
+        "insulation_conductivity",
+        "diameter_ratio",
+        "pressure_drop_per_meter",
+        "roughness",
+        "rho_cp",
+        "buried_depth"
+      ]
     },
     "diesel_generator_parameters": {
       "description": "Diesel generator parameters used by the microgrid model.",
@@ -1424,7 +1435,9 @@
           },
           "required": [
             "buried_depth",
-            "diameter"
+            "diameter",
+            "number_of_boreholes_autosized",
+            "length_of_boreholes_autosized"
           ],
           "additionalProperties": true
         },

--- a/tests/system_parameters/data/system_params_ghe.json
+++ b/tests/system_parameters/data/system_params_ghe.json
@@ -90,6 +90,8 @@
               "width_of_ghe": 100
             },
             "borehole": {
+              "number_of_boreholes_autosized": true,
+              "length_of_boreholes_autosized": true,
               "buried_depth": 2.0,
               "diameter": 0.15
             }
@@ -101,6 +103,8 @@
               "width_of_ghe": 100
             },
             "borehole": {
+              "number_of_boreholes_autosized": true,
+              "length_of_boreholes_autosized": true,
               "buried_depth": 10.0,
               "diameter": 0.25
             }
@@ -119,6 +123,7 @@
         "insulation_thickness": 0.2,
         "insulation_conductivity": 2.3,
         "diameter_ratio": 11,
+        "pressure_drop_per_meter": 300,
         "roughness": 1e-06,
         "rho_cp": 2139000,
         "buried_depth": 1.5

--- a/tests/system_parameters/data/system_params_ghe_predesigned.json
+++ b/tests/system_parameters/data/system_params_ghe_predesigned.json
@@ -1,0 +1,145 @@
+{
+  "weather": "../../data_shared/USA_CA_San.Francisco.Intl.AP.724940_TMY3.mos",
+  "buildings": [
+    {
+      "geojson_id": "0",
+      "load_model": "time_series",
+      "load_model_parameters": {
+        "time_series": {
+          "filepath": "To be populated",
+          "delta_temp_air_cooling": 10,
+          "delta_temp_air_heating": 18,
+          "has_liquid_cooling": true,
+          "has_liquid_heating": true,
+          "has_electric_cooling": false,
+          "has_electric_heating": false,
+          "max_electrical_load": 0,
+          "temp_chw_return": 12,
+          "temp_chw_supply": 7,
+          "temp_hw_return": 35,
+          "temp_hw_supply": 40,
+          "temp_setpoint_cooling": 24,
+          "temp_setpoint_heating": 20
+        }
+      },
+      "ets_model": "Fifth Gen Heat Pump",
+      "fifth_gen_ets_parameters": {
+        "chilled_water_supply_temp": 5,
+        "heating_water_supply_temp": 50,
+        "hot_water_supply_temp": 50,
+        "cop_heat_pump_heating": 2.5,
+        "cop_heat_pump_cooling": 3.5,
+        "cop_heat_pump_hot_water": 2.5,
+        "ets_pump_flow_rate": 0.0005,
+        "ets_pump_head": 10000,
+        "fan_design_flow_rate": 0.25,
+        "fan_design_head": 150
+      }
+    }
+  ],
+  "district_system": {
+    "fifth_generation": {
+      "soil": {
+        "conductivity": 2.0,
+        "rho_cp": 2343493,
+        "undisturbed_temp": 18.3
+      },
+      "ghe_parameters": {
+        "version": "1.0",
+        "ghe_dir": "tests/system_parameters/data",
+        "fluid": {
+          "fluid_name": "Water",
+          "concentration_percent": 0.0,
+          "temperature": 20
+        },
+        "grout": {
+          "conductivity": 1.0,
+          "rho_cp": 3901000
+        },
+        "pipe": {
+          "inner_diameter": 0.0216,
+          "outer_diameter": 0.0266,
+          "shank_spacing": 0.0323,
+          "roughness": 1e-06,
+          "conductivity": 0.4,
+          "rho_cp": 1542000,
+          "arrangement": "singleutube"
+        },
+        "simulation": {
+          "num_months": 240
+        },
+        "geometric_constraints": {
+          "b_min": 3.0,
+          "b_max": 10.0,
+          "max_height": 135.0,
+          "min_height": 60.0,
+          "method": "rectangle"
+        },
+        "design": {
+          "method": "AREAPROPORTIONAL",
+          "flow_rate": 0.2,
+          "flow_type": "borehole",
+          "max_eft": 35.0,
+          "min_eft": 5.0
+        },
+        "ghe_specific_params": [
+          {
+            "ghe_id": "c432cb11-4813-40df-8dd4-e88f5de40033",
+            "ghe_geometric_params": {
+              "length_of_ghe": 100,
+              "width_of_ghe": 100
+            },
+            "borehole": {
+              "buried_depth": 2.0,
+              "diameter": 0.15,
+              "length_of_boreholes": 1.0,
+              "length_of_boreholes_autosized": true,
+              "number_of_boreholes": 5,
+              "number_of_boreholes_autosized": true
+            }
+          },
+          {
+            "ghe_id": "c432cb11-4813-40df-8dd4-e88f5de40034",
+            "ghe_geometric_params": {
+              "length_of_ghe": 100,
+              "width_of_ghe": 100
+            },
+            "pre_designed_borefield": {
+              "length_of_boreholes": 100,
+              "borehole_diameter": 0.16,
+              "borehole_x_coordinates": [
+                0.0,
+                1.0,
+                2.0,
+                3.0
+              ],
+              "borehole_y_coordinates": [
+                0.0,
+                1.0,
+                2.0,
+                3.0
+              ]
+            }
+          }
+        ]
+      },
+      "central_pump_parameters": {
+        "pump_design_head": 60000,
+        "pump_design_head_autosized": true,
+        "pump_flow_rate": 0.01,
+        "pump_flow_rate_autosized": true
+      },
+      "horizontal_piping_parameters": {
+        "hydraulic_diameter": 0.089,
+        "hydraulic_diameter_autosized": true,
+        "insulation_thickness": 0.2,
+        "insulation_conductivity": 2.3,
+        "diameter_ratio": 11,
+        "pressure_drop_per_meter": 300,
+        "roughness": 1e-06,
+        "rho_cp": 2139000,
+        "buried_depth": 1.5
+      }
+    }
+  }
+}

--- a/tests/system_parameters/test_system_parameters.py
+++ b/tests/system_parameters/test_system_parameters.py
@@ -279,7 +279,12 @@ class SystemParametersTest(unittest.TestCase):
         value = sdp.get_param_by_id("c432cb11-4813-40df-8dd4-e88f5de40033", "borehole")
 
         # Assert
-        assert value == {"buried_depth": 2.0, "diameter": 0.15}
+        assert value == {
+            "number_of_boreholes_autosized": True,
+            "length_of_boreholes_autosized": True,
+            "buried_depth": 2.0,
+            "diameter": 0.15,
+        }
 
         # Act
         second_ghe_borehole = sdp.get_param_by_id("c432cb11-4813-40df-8dd4-e88f5de40034", "borehole")


### PR DESCRIPTION
#### Any background context you want to provide?
To help ThermalNetwork decide when to autosize GHE components, we now require the `autosized` flags to be present in the sys-param file.

#### What does this PR accomplish?
- Update the schema to require autosize flags in sys-params
- Update a test file and test with the newly required fields

#### How should this be manually tested?
CI can test the validity of the schema, that's all that's happening with this here, for now.
