### PR TITLE
Improve sys-param schema for borefields

### DIFF
--- a/geojson_modelica_translator/system_parameters/system_parameter_properties.json
+++ b/geojson_modelica_translator/system_parameters/system_parameter_properties.json
@@ -952,11 +952,11 @@
           "description": "Results directory for GHE Designer. Absolute path, or relative to the sys-param file.",
           "type": "string"
         },
-        "ghe_specific_params": {
+        "borefields": {
           "description": "Specific properties for each Ground Heat Exchanger",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ghe_specific_params_def"
+            "$ref": "#/definitions/borefields_def"
           }
         },
         "pipe": {
@@ -976,10 +976,13 @@
         },
         "design": {
           "$ref": "#/definitions/design_def"
+        },
+        "borehole": {
+          "$ref": "#/definitions/borehole_def"
         }
       },
       "required": [
-        "ghe_specific_params",
+        "borefields",
         "pipe",
         "fluid",
         "grout",
@@ -1392,7 +1395,7 @@
         "undisturbed_temp"
       ]
     },
-    "ghe_specific_params_def": {
+    "borefields_def": {
       "description": "The properties associated with each Ground Heat Exchanger instance",
       "type": "object",
       "properties": {
@@ -1400,57 +1403,41 @@
           "description": "Feature ID of GHE from GeoJSON Feature File.",
           "type": "string"
         },
-        "borehole": {
-          "description": "Borehole properties for Ground Heat Exchanger sizing.",
+        "autosized_borefield": {
+          "description": "Borefield properties for Ground Heat Exchanger sizing.",
           "type": "object",
           "properties": {
-            "buried_depth": {
-              "description": "The depth below the ground surface to the top of the borehole, in meters.",
-              "type": "number",
-              "default": 1.2
-            },
-            "diameter": {
-              "description": "The diameter of the borehole, in meters.",
-              "type": "number",
-              "default": 0.15
-            },
             "number_of_boreholes": {
               "description": "Number of boreholes on the site, determined from Thermal Network sizing",
               "type": "number"
             },
-            "number_of_boreholes_autosized": {
-              "description": "True if the number of boreholes is autosized, false if set manually",
-              "type": "boolean",
-              "default": true
-            },
-            "length_of_boreholes": {
-              "description": "The length of the borehole (in meters), determined from Thermal Network sizing.",
+            "borehole_length": {
+              "description": "The length of the boreholes, in meters.",
               "type": "number"
             },
-            "length_of_boreholes_autosized": {
-              "description": "True if the length of boreholes is autosized, false if set manually",
-              "type": "boolean",
-              "default": true
+            "length_of_ghe": {
+              "description": "Horizontal surface length allowed for the ground heat exchanger, in meters.",
+              "type": "number"
+            },
+            "width_of_ghe": {
+              "description": "Horizontal surface width allowed for the ground heat exchanger, in meters.",
+              "type": "number"
             }
           },
           "required": [
-            "buried_depth",
-            "diameter",
-            "number_of_boreholes_autosized",
-            "length_of_boreholes_autosized"
+            "number_of_boreholes",
+            "borehole_length",
+            "length_of_ghe",
+            "width_of_ghe"
           ],
           "additionalProperties": true
         },
         "pre_designed_borefield": {
-          "description": "Individual borehole properties for Ground Heat Exchanger sizing.",
+          "description": "Borefield properties for Ground Heat Exchanger sizing.",
           "type": "object",
           "properties": {
-            "length_of_boreholes": {
+            "borehole_length": {
               "description": "The length of the boreholes, in meters.",
-              "type": "number"
-            },
-            "borehole_diameter": {
-              "description": "The diameter of the boreholes, in meters.",
               "type": "number"
             },
             "borehole_x_coordinates": {
@@ -1469,28 +1456,9 @@
             }
           },
           "required": [
-            "length_of_boreholes",
-            "borehole_diameter",
+            "borehole_length",
             "borehole_x_coordinates",
             "borehole_y_coordinates"
-          ]
-        },
-        "ghe_geometric_params": {
-          "description": "The length and width of the Ground Heat Exchanger determined from the GeoJSON Feature File.",
-          "type": "object",
-          "properties": {
-            "length_of_ghe": {
-              "description": "Horizontal surface length allowed for the ground heat exchanger, in meters.",
-              "type": "number"
-            },
-            "width_of_ghe": {
-              "description": "Horizontal surface width allowed for the ground heat exchanger, in meters.",
-              "type": "number"
-            }
-          },
-          "required": [
-            "length_of_ghe",
-            "width_of_ghe"
           ]
         }
       },
@@ -1502,13 +1470,12 @@
         },
         {
           "required": [
-            "borehole"
+            "autosized_borefield"
           ]
         }
       ],
       "required": [
-        "ghe_id",
-        "ghe_geometric_params"
+        "ghe_id"
       ]
     },
     "pipe_def": {
@@ -1730,6 +1697,26 @@
         "flow_type",
         "max_eft",
         "min_eft"
+      ]
+    },
+    "borehole_def": {
+      "description": "Borehole properties for Ground Heat Exchanger sizing",
+      "type": "object",
+      "properties": {
+        "buried_depth": {
+          "description": "The depth below the ground surface to the top of the borehole, in meters.",
+          "type": "number",
+          "default": 2.0
+        },
+        "diameter": {
+          "description": "The diameter of the borehole, in meters.",
+          "type": "number",
+          "default": 0.15
+        }
+      },
+      "required": [
+        "buried_depth",
+        "diameter"
       ]
     },
     "central_pump_parameters": {

--- a/tests/system_parameters/data/system_params_ghe_predesigned.json
+++ b/tests/system_parameters/data/system_params_ghe_predesigned.json
@@ -44,6 +44,23 @@
         "rho_cp": 2343493,
         "undisturbed_temp": 18.3
       },
+      "central_pump_parameters": {
+        "pump_design_head": 60000,
+        "pump_design_head_autosized": true,
+        "pump_flow_rate": 0.01,
+        "pump_flow_rate_autosized": true
+      },
+      "horizontal_piping_parameters": {
+        "hydraulic_diameter": 0.089,
+        "hydraulic_diameter_autosized": true,
+        "insulation_thickness": 0.2,
+        "insulation_conductivity": 2.3,
+        "diameter_ratio": 11,
+        "pressure_drop_per_meter": 300,
+        "roughness": 1e-06,
+        "rho_cp": 2139000,
+        "buried_depth": 1.5
+      },
       "ghe_parameters": {
         "version": "1.0",
         "ghe_dir": "tests/system_parameters/data",
@@ -82,63 +99,39 @@
           "max_eft": 35.0,
           "min_eft": 5.0
         },
-        "ghe_specific_params": [
+        "borehole": {
+          "buried_depth": 2.0,
+          "diameter": 0.15
+        },
+        "borefields": [
           {
             "ghe_id": "c432cb11-4813-40df-8dd4-e88f5de40033",
-            "ghe_geometric_params": {
-              "length_of_ghe": 100,
-              "width_of_ghe": 100
-            },
-            "borehole": {
-              "buried_depth": 2.0,
-              "diameter": 0.15,
-              "length_of_boreholes": 1.0,
-              "length_of_boreholes_autosized": true,
-              "number_of_boreholes": 5,
-              "number_of_boreholes_autosized": true
+            "pre_designed_borefield": {
+              "borehole_length": 100,
+              "borehole_x_coordinates": [
+                0,
+                0,
+                0,
+                0
+              ],
+              "borehole_y_coordinates": [
+                0,
+                10,
+                20,
+                30
+              ]
             }
           },
           {
             "ghe_id": "c432cb11-4813-40df-8dd4-e88f5de40034",
-            "ghe_geometric_params": {
+            "autosized_borefield": {
               "length_of_ghe": 100,
-              "width_of_ghe": 100
-            },
-            "pre_designed_borefield": {
-              "length_of_boreholes": 100,
-              "borehole_diameter": 0.16,
-              "borehole_x_coordinates": [
-                0.0,
-                1.0,
-                2.0,
-                3.0
-              ],
-              "borehole_y_coordinates": [
-                0.0,
-                1.0,
-                2.0,
-                3.0
-              ]
+              "width_of_ghe": 100,
+              "borehole_length": 1,
+              "number_of_boreholes": 1
             }
           }
         ]
-      },
-      "central_pump_parameters": {
-        "pump_design_head": 60000,
-        "pump_design_head_autosized": true,
-        "pump_flow_rate": 0.01,
-        "pump_flow_rate_autosized": true
-      },
-      "horizontal_piping_parameters": {
-        "hydraulic_diameter": 0.089,
-        "hydraulic_diameter_autosized": true,
-        "insulation_thickness": 0.2,
-        "insulation_conductivity": 2.3,
-        "diameter_ratio": 11,
-        "pressure_drop_per_meter": 300,
-        "roughness": 1e-06,
-        "rho_cp": 2139000,
-        "buried_depth": 1.5
       }
     }
   }


### PR DESCRIPTION
#### Any background context you want to provide?
We recently added an ability to pre-design a borefield, rather than let GHED size everything. There was at least one bug in that PR (found by running TN). We are taking the opportunity to make some other improvements and clarifications as well.

#### What does this PR accomplish?
- Update schema to have the correct fields for individual GHEs and shared data
- Provide an example sys-param file that includes a pre-designed borefield

#### How should this be manually tested?
Copy the relevant bits of the example sys-param file into the analagous file in TN and run the appropriate test there
