### PR TITLE
Create a dependabot config file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"


### PR DESCRIPTION
#### Any background context you want to provide?
Dependabot seems like a useful tool for watching security vulnerabilities in dependencies. However, without any configuration, it was a bit of a hassle and we ignored it. This is the config file SEED uses for dependabot, figured we should try it here.

#### What does this PR accomplish?
Create a config file for dependabot

#### How should this be manually tested?
If you have admin rights to this repo, check the security settings for dependabot.
