### PR TITLE
Improve schema validation messages

### DIFF
--- a/geojson_modelica_translator/system_parameters/system_parameters.py
+++ b/geojson_modelica_translator/system_parameters/system_parameters.py
@@ -145,10 +145,12 @@ class SystemParameters:
         try:
             validate(instance=self.param_template, schema=self.schema)
         except ValidationError as error:
-            logger.error("\n System Parameter Validation Error:")
-            logger.error(f"  Bad Input Location: {' -> '.join(map(str, error.path)) if error.path else 'Root'}")
-            logger.error(f"  Problematic Key: {error.path[-1] if error.path else 'N/A'}")
-            logger.error(f"  Error: {error.message}")
+            logger.error(
+                "\nSystem Parameter Validation Error:"
+                f"\nBad Input Location: {' -> '.join(map(str, error.path)) if error.path else 'Root'}"
+                f"\nProblematic Key: {error.path[-1] if error.path else 'N/A'}"
+                f"\nError: {error.message}"
+            )
             fix = "\nSuggested Fix:"
             if "required" in error.schema and isinstance(error.schema["required"], list):
                 logger.error(


### PR DESCRIPTION
#### Any background context you want to provide?
Our JSON validation of system parameters files was printing to stdout, not being captured in stderr. Logging the messages with logger.error will make these messages easier to find by other software.

#### What does this PR accomplish?
Change sys-param validation output messages from stdout to stderr.

#### How should this be manually tested?

#### What are the relevant tickets?
Resolves #748 
