### PR TITLE
Allow null loop order

### DIFF
--- a/geojson_modelica_translator/external_package_utils.py
+++ b/geojson_modelica_translator/external_package_utils.py
@@ -7,6 +7,35 @@ from modelica_builder.modelica_mos_file import ModelicaMOS
 logger = logging.getLogger(__name__)
 
 
+def _build_default_loop_order(sys_param_data: dict) -> list | None:
+    """Build a conservative default loop-order structure from system params.
+
+    This fallback is used only when _loop_order.json is missing.
+    """
+    fg = sys_param_data.get("district_system", {}).get("fifth_generation")
+    if not fg:
+        return None
+
+    buildings = sys_param_data.get("buildings", [])
+    bldg_ids = [b.get("geojson_id") for b in buildings if b.get("geojson_id")]
+    if not bldg_ids:
+        return None
+
+    loop_group = {"list_bldg_ids_in_group": bldg_ids}
+
+    borefields = fg.get("ghe_parameters", {}).get("borefields", [])
+    ghe_ids = [b.get("ghe_id") for b in borefields if b.get("ghe_id")]
+    if ghe_ids:
+        loop_group["list_ghe_ids_in_group"] = [ghe_ids[0]]
+
+    heat_sources = fg.get("heat_source_parameters", [])
+    source_ids = [s.get("heat_source_id") for s in heat_sources if s.get("heat_source_id")]
+    if source_ids:
+        loop_group["list_source_ids_in_group"] = [source_ids[0]]
+
+    return [loop_group]
+
+
 def load_loop_order(system_parameters_file: Path) -> list:
     """Loads the loop order from a JSON file
 
@@ -17,7 +46,16 @@ def load_loop_order(system_parameters_file: Path) -> list:
     """
     loop_order_path = Path(system_parameters_file).parent / "_loop_order.json"
     if not loop_order_path.is_file():
-        raise FileNotFoundError(f"Loop order file not found at {loop_order_path}")
+        sys_param_data = json.loads(Path(system_parameters_file).read_text())
+        default_loop_order = _build_default_loop_order(sys_param_data)
+        if default_loop_order is None:
+            raise FileNotFoundError(f"Loop order file not found at {loop_order_path}")
+        loop_order_path.write_text(json.dumps(default_loop_order, indent=2))
+        logger.warning(
+            "Loop order file was missing. Wrote default loop-order structure to %s",
+            loop_order_path,
+        )
+        return default_loop_order
     return json.loads(loop_order_path.read_text())
 
 

--- a/geojson_modelica_translator/external_package_utils.py
+++ b/geojson_modelica_translator/external_package_utils.py
@@ -78,8 +78,17 @@ def set_loop_order_data_in_template_params(
             if dict_feature == feature:
                 ordered_pipe_list.append(pipe_length)
 
-    template_params["globals"]["lDis"] = str(ordered_pipe_list[:-1]).replace("[", "{").replace("]", "}")
-    template_params["globals"]["lEnd"] = ordered_pipe_list[-1]
+    if ordered_pipe_list:
+        template_params["globals"]["lDis"] = str(ordered_pipe_list[:-1]).replace("[", "{").replace("]", "}")
+        template_params["globals"]["lEnd"] = ordered_pipe_list[-1]
+    else:
+        logger.warning(
+            "No thermal connector lengths matched loop-order features; using zero-length lDis and lEnd=0."
+        )
+        num_buildings = template_params.get("sys_params", {}).get("num_buildings", 0)
+        ldis_count = max(int(num_buildings) - 1, 0)
+        template_params["globals"]["lDis"] = f"fill(0, {ldis_count})"
+        template_params["globals"]["lEnd"] = 0
     return template_params
 
 

--- a/geojson_modelica_translator/external_package_utils.py
+++ b/geojson_modelica_translator/external_package_utils.py
@@ -74,19 +74,16 @@ def set_loop_order_data_in_template_params(
             ordered_feature_list.extend(loop["list_source_ids_in_group"])
 
     for feature in ordered_feature_list:
-        for dict_feature, pipe_length in dict_of_pipe_lengths.items():
-            if dict_feature == feature:
-                ordered_pipe_list.append(pipe_length)
+        pipe_length = dict_of_pipe_lengths.get(feature)
+        if pipe_length is not None:
+            ordered_pipe_list.append(pipe_length)
 
     if ordered_pipe_list:
         template_params["globals"]["lDis"] = str(ordered_pipe_list[:-1]).replace("[", "{").replace("]", "}")
         template_params["globals"]["lEnd"] = ordered_pipe_list[-1]
     else:
-        logger.warning(
-            "No thermal connector lengths matched loop-order features; using zero-length lDis and lEnd=0."
-        )
-        num_buildings = template_params.get("sys_params", {}).get("num_buildings", 0)
-        ldis_count = max(int(num_buildings) - 1, 0)
+        logger.warning("No thermal connector lengths matched loop-order features; using zero-length lDis and lEnd=0.")
+        ldis_count = max(get_num_buildings_in_loop_order(loop_order) - 1, 0)
         template_params["globals"]["lDis"] = f"fill(0, {ldis_count})"
         template_params["globals"]["lEnd"] = 0
     return template_params

--- a/geojson_modelica_translator/model_connectors/couplings/5G_templates/Borefield_WasteHeatRecovery/ConnectStatements.mopt
+++ b/geojson_modelica_translator/model_connectors/couplings/5G_templates/Borefield_WasteHeatRecovery/ConnectStatements.mopt
@@ -64,9 +64,12 @@ connect(TIn_wasHea_{{ coupling.id }}.port_b, conPla_{{ waste_heat_id }}.port_aDi
     {% else %}
       {% set next_dis_coupling_id = graph.couplings_by_type(ground_id).network_couplings[group_num+1].id %}
       {% set next_dis_id = graph.get_other_model(next_dis_coupling_id, ground_id).id %}
-      connect(TOut_wasHea_{{ coupling.id }}.port_b, TDisSup_{{ graph.couplings_by_type(next_dis_id).plant_couplings[0].id }}.port_a)
-      {% raw %}annotation (Line(points={{50,-130},{60,-130},{60,-80},{-44,-80},{-44,-70}}, color={0,127,255}));
-      {% endraw %}
+      {% set next_dis_couplings = graph.couplings_by_type(next_dis_id) %}
+      {% if next_dis_couplings.plant_couplings is defined and next_dis_couplings.plant_couplings|length > 0 %}
+        connect(TOut_wasHea_{{ coupling.id }}.port_b, TDisSup_{{ next_dis_couplings.plant_couplings[0].id }}.port_a)
+        {% raw %}annotation (Line(points={{50,-130},{60,-130},{60,-80},{-44,-80},{-44,-70}}, color={0,127,255}));
+        {% endraw %}
+      {% endif %}
     {% endif %}
   {% endif %}
 {% endfor %}

--- a/geojson_modelica_translator/model_connectors/couplings/5G_templates/TimeSeries_UnidirectionalSeries/ConnectStatements.mopt
+++ b/geojson_modelica_translator/model_connectors/couplings/5G_templates/TimeSeries_UnidirectionalSeries/ConnectStatements.mopt
@@ -1,13 +1,16 @@
 // Timeseries load and network coupling connections
 {% for group_num in range(loop_order.number_of_loops) %}
+  {% set plant_id = none %}
+  {% set get_id_func = none %}
   {% if loop_order.data[group_num].list_ghe_ids_in_group is defined %}
     {% set plant_id = loop_order.data[group_num].list_ghe_ids_in_group[0] %}
     {% set get_id_func = graph.get_ghe_id %}
-  {% else %}
+  {% elif loop_order.data[group_num].list_source_ids_in_group is defined %}
     {% set plant_id = loop_order.data[group_num].list_source_ids_in_group[0] %}
     {% set get_id_func = graph.get_source_id %}
   {% endif %}
-  {% if get_id_func(graph.couplings_by_type(coupling.network.id).plant_couplings[0].id) == plant_id %}
+  {% set network_couplings = graph.couplings_by_type(coupling.network.id) %}
+  {% if plant_id is not none and network_couplings.plant_couplings is defined and network_couplings.plant_couplings|length > 0 and get_id_func(network_couplings.plant_couplings[0].id) == plant_id %}
     {% for bldg_num in range(loop_order.data[group_num].list_bldg_ids_in_group|length) %}
       {% if loop_order.data[group_num].list_bldg_ids_in_group[bldg_num][0].isnumeric() %}
         {% set bldg_id = "TimeSerLoa_B" ~ loop_order.data[group_num].list_bldg_ids_in_group[bldg_num] %}

--- a/geojson_modelica_translator/model_connectors/couplings/5G_templates/UnidirectionalSeries_Borefield/ConnectStatements.mopt
+++ b/geojson_modelica_translator/model_connectors/couplings/5G_templates/UnidirectionalSeries_Borefield/ConnectStatements.mopt
@@ -35,9 +35,12 @@ connect(TIn_{{ coupling.id }}.port_b, conSto_{{ coupling.plant.id }}.port_aDis)
           {% set ground_id = graph.couplings_by_type(coupling.network.id).network_couplings[0].network.id %}
           {% set next_dis_coupling_id = graph.couplings_by_type(ground_id).network_couplings[group_num+1].id %}
           {% set next_dis_id = graph.get_other_model(next_dis_coupling_id, ground_id).id %}
-          connect(TOut_{{ coupling.id }}.port_b, TDisSup_{{ graph.couplings_by_type(next_dis_id).plant_couplings[0].id }}.port_a)
-          {% raw %}annotation (Line(points={{-44,-50},{-44,10},{-40,10}}, color={0,127,255}));
-          {% endraw %}
+          {% set next_dis_couplings = graph.couplings_by_type(next_dis_id) %}
+          {% if next_dis_couplings.plant_couplings is defined and next_dis_couplings.plant_couplings|length > 0 %}
+            connect(TOut_{{ coupling.id }}.port_b, TDisSup_{{ next_dis_couplings.plant_couplings[0].id }}.port_a)
+            {% raw %}annotation (Line(points={{-44,-50},{-44,10},{-40,10}}, color={0,127,255}));
+            {% endraw %}
+          {% endif %}
         {% endif %}
       {% endif %}
     {% endif %}

--- a/geojson_modelica_translator/model_connectors/couplings/5G_templates/UnidirectionalSeries_GroundCoupling/ConnectStatements.mopt
+++ b/geojson_modelica_translator/model_connectors/couplings/5G_templates/UnidirectionalSeries_GroundCoupling/ConnectStatements.mopt
@@ -1,14 +1,17 @@
 // Connections between ground coupling and distribution
 {% for group_num in range(loop_order.number_of_loops) %}
   {% set dis_id = graph.get_other_model(coupling.id, coupling.network.id).id %}
+  {% set plant_id = none %}
+  {% set get_id_func = none %}
   {% if loop_order.data[group_num].list_ghe_ids_in_group is defined %}
     {% set plant_id = loop_order.data[group_num].list_ghe_ids_in_group[0] %}
     {% set get_id_func = graph.get_ghe_id %}
-  {% else %}
+  {% elif loop_order.data[group_num].list_source_ids_in_group is defined %}
     {% set plant_id = loop_order.data[group_num].list_source_ids_in_group[0] %}
     {% set get_id_func = graph.get_source_id %}
   {% endif %}
-  {% if get_id_func(graph.couplings_by_type(dis_id).plant_couplings[0].id) == plant_id %}
+  {% set dis_couplings = graph.couplings_by_type(dis_id) %}
+  {% if plant_id is not none and dis_couplings.plant_couplings is defined and dis_couplings.plant_couplings|length > 0 and get_id_func(dis_couplings.plant_couplings[0].id) == plant_id %}
     {% if group_num == 0 %}
       connect({{ dis_id }}.heatPortGro, {{ coupling.network.id }}.ports[1,1:{{ 1+loop_order.data[0].list_bldg_ids_in_group|length }}])
     {% else %}

--- a/geojson_modelica_translator/model_connectors/couplings/5G_templates/UnidirectionalSeries_WasteHeatRecovery/ConnectStatements.mopt
+++ b/geojson_modelica_translator/model_connectors/couplings/5G_templates/UnidirectionalSeries_WasteHeatRecovery/ConnectStatements.mopt
@@ -72,9 +72,12 @@ connect(TIn_wasHea_{{ coupling.id }}.port_b, conPla_{{ coupling.plant.id }}.port
           {% set ground_id = graph.couplings_by_type(coupling.network.id).network_couplings[0].network.id %}
           {% set next_dis_coupling_id = graph.couplings_by_type(ground_id).network_couplings[group_num+1].id %}
           {% set next_dis_id = graph.get_other_model(next_dis_coupling_id, ground_id).id %}
-          connect(TOut_wasHea_{{ coupling.id }}.port_b, TDisSup_{{ graph.couplings_by_type(next_dis_id).plant_couplings[0].id }}.port_a)
-          {% raw %}annotation (Line(points={{50,-130},{60,-130},{60,-80},{-44,-80},{-44,-70}}, color={0,127,255}));
-          {% endraw %}
+          {% set next_dis_couplings = graph.couplings_by_type(next_dis_id) %}
+          {% if next_dis_couplings.plant_couplings is defined and next_dis_couplings.plant_couplings|length > 0 %}
+            connect(TOut_wasHea_{{ coupling.id }}.port_b, TDisSup_{{ next_dis_couplings.plant_couplings[0].id }}.port_a)
+            {% raw %}annotation (Line(points={{50,-130},{60,-130},{60,-80},{-44,-80},{-44,-70}}, color={0,127,255}));
+            {% endraw %}
+          {% endif %}
         {% endif %}
       {% endif %}
     {% endif %}

--- a/geojson_modelica_translator/model_connectors/couplings/5G_templates/WasteHeatRecovery_Borefield/ConnectStatements.mopt
+++ b/geojson_modelica_translator/model_connectors/couplings/5G_templates/WasteHeatRecovery_Borefield/ConnectStatements.mopt
@@ -36,9 +36,12 @@ connect(TIn_{{ coupling.id }}.port_b, conSto_{{ borefield_id }}.port_aDis)
     {% else %}
       {% set next_dis_coupling_id = graph.couplings_by_type(ground_id).network_couplings[group_num+1].id %}
       {% set next_dis_id = graph.get_other_model(next_dis_coupling_id, ground_id).id %}
-      connect(TOut_{{ coupling.id }}.port_b, TDisSup_{{ graph.couplings_by_type(next_dis_id).plant_couplings[0].id }}.port_a)
-      {% raw %}annotation (Line(points={{-44,-50},{-44,10},{-40,10}}, color={0,127,255}));
-      {% endraw %}
+      {% set next_dis_couplings = graph.couplings_by_type(next_dis_id) %}
+      {% if next_dis_couplings.plant_couplings is defined and next_dis_couplings.plant_couplings|length > 0 %}
+        connect(TOut_{{ coupling.id }}.port_b, TDisSup_{{ next_dis_couplings.plant_couplings[0].id }}.port_a)
+        {% raw %}annotation (Line(points={{-44,-50},{-44,10},{-40,10}}, color={0,127,255}));
+        {% endraw %}
+      {% endif %}
     {% endif %}
   {% endif %}
 {% endfor %}

--- a/geojson_modelica_translator/model_connectors/districts/district.py
+++ b/geojson_modelica_translator/model_connectors/districts/district.py
@@ -122,7 +122,9 @@ class District:
                     num_boreholes = len(borefield["pre_designed_borefield"]["borehole_x_coordinates"])
                 number_of_boreholes_dict[ghe_id] = num_boreholes
             common_template_params["number_of_boreholes"] = number_of_boreholes_dict
-            common_template_params["max_number_of_boreholes"] = max(number_of_boreholes_dict.values())
+            # Allow 5G systems that have ghe_parameters defined but no borefields listed.
+            # A zero default avoids crashing on max([]) and keeps template math deterministic.
+            common_template_params["max_number_of_boreholes"] = max(number_of_boreholes_dict.values(), default=0)
 
             # load loop order info from ThermalNetwork
             loop_order = load_loop_order(self.system_parameters.filename)

--- a/geojson_modelica_translator/model_connectors/load_connectors/time_series.py
+++ b/geojson_modelica_translator/model_connectors/load_connectors/time_series.py
@@ -172,10 +172,16 @@ class TimeSeries(LoadBase):
         :param scaffold: Scaffold object, Scaffold of the entire directory of the project.
         :return: None
         """
-        # Create the building-specific package within Loads
+        # Create the building-specific package within Loads. Build the order from
+        # actual model files so package.order stays in sync with generated files.
         b_modelica_path = os.path.join(scaffold.loads_path.files_dir, self.building_name)
+        order_files = sorted(
+            os.path.splitext(fname)[0]
+            for fname in os.listdir(b_modelica_path)
+            if fname.endswith(".mo") and fname != "package.mo"
+        )
         new_package = PackageParser.new_from_template(
-            b_modelica_path, self.building_name, self.template_files_to_include, within=f"{scaffold.project_name}.Loads"
+            b_modelica_path, self.building_name, order_files, within=f"{scaffold.project_name}.Loads"
         )
         new_package.save()
 

--- a/geojson_modelica_translator/model_connectors/networks/templates/GroundCoupling_Instance.mopt
+++ b/geojson_modelica_translator/model_connectors/networks/templates/GroundCoupling_Instance.mopt
@@ -1,5 +1,8 @@
+{% set model_couplings = graph.couplings_by_type(model.id) %}
 {{ model.modelica_type }} {{ model.id }}(
-  soiDat={{graph.couplings_by_type(model.id).plant_couplings[0].plant.id}}.borFieDat.soiDat,
+    {% if model_couplings.plant_couplings is defined and model_couplings.plant_couplings|length > 0 %}
+    soiDat={{ model_couplings.plant_couplings[0].plant.id }}.borFieDat.soiDat,
+    {% endif %}
   len=cat(
       1,
       datDes.lDis,

--- a/geojson_modelica_translator/model_connectors/networks/templates/UnidirectionalSeries_Instance.mopt
+++ b/geojson_modelica_translator/model_connectors/networks/templates/UnidirectionalSeries_Instance.mopt
@@ -6,14 +6,17 @@
   {% if sys_params.district_system.fifth_generation.ghe_parameters is defined %}
     ,
     {% for group_num in range(loop_order.number_of_loops) %}
+      {% set plant_id = none %}
+      {% set get_id_func = none %}
       {% if loop_order.data[group_num].list_ghe_ids_in_group is defined %}
         {% set plant_id = loop_order.data[group_num].list_ghe_ids_in_group[0] %}
         {% set get_id_func = graph.get_ghe_id %}
-      {% else %}
+      {% elif loop_order.data[group_num].list_source_ids_in_group is defined %}
         {% set plant_id = loop_order.data[group_num].list_source_ids_in_group[0] %}
         {% set get_id_func = graph.get_source_id %}
       {% endif %}
-      {% if get_id_func(graph.couplings_by_type(model.id).plant_couplings[0].id) == plant_id %}
+      {% set model_couplings = graph.couplings_by_type(model.id) %}
+      {% if plant_id is not none and model_couplings.plant_couplings is defined and model_couplings.plant_couplings|length > 0 and get_id_func(model_couplings.plant_couplings[0].id) == plant_id %}
         final nCon= {{ loop_order.data[group_num].list_bldg_ids_in_group|length }},
         {% if group_num == 0 %}
           final mCon_flow_nominal=datDes.mCon_flow_nominal[1:{{ loop_order.data[0].list_bldg_ids_in_group|length }}],

--- a/tests/model_connectors/test_5g_template_guards.py
+++ b/tests/model_connectors/test_5g_template_guards.py
@@ -1,0 +1,136 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+from jinja2 import Environment, FileSystemLoader, StrictUndefined
+
+from geojson_modelica_translator.jinja_filters import ALL_CUSTOM_FILTERS
+
+
+def _render_template(template_path: Path, **context) -> str:
+    env = Environment(loader=FileSystemLoader(template_path.parent), undefined=StrictUndefined)
+    env.filters.update(ALL_CUSTOM_FILTERS)
+    return env.get_template(template_path.name).render(context)
+
+
+class _GraphStub:
+    def __init__(self, couplings=None):
+        self._couplings = couplings or {}
+
+    def couplings_by_type(self, model_id):
+        return self._couplings.get(model_id, SimpleNamespace())
+
+    def get_other_model(self, coupling_id, network_id):
+        return SimpleNamespace(id="Dis_NoPlant")
+
+    def get_ghe_id(self, coupling_id):
+        return "ghe-1"
+
+    def get_source_id(self, coupling_id):
+        return "src-1"
+
+
+def test_time_series_unidirectional_series_skips_when_network_has_no_plant_couplings():
+    template_path = (
+        Path(__file__).parents[2]
+        / "geojson_modelica_translator"
+        / "model_connectors"
+        / "couplings"
+        / "5G_templates"
+        / "TimeSeries_UnidirectionalSeries"
+        / "ConnectStatements.mopt"
+    )
+
+    graph = _GraphStub(couplings={"UniNet_1": SimpleNamespace()})
+    loop_order = SimpleNamespace(number_of_loops=1, data=[{"list_bldg_ids_in_group": ["bldg-1"]}])
+    coupling = {"id": "CPL_1", "network": {"id": "UniNet_1"}, "load": {"id": "TimeSerLoa_bldg-1"}}
+
+    rendered = _render_template(template_path, graph=graph, loop_order=loop_order, coupling=coupling)
+
+    assert "connect(UniNet_1.ports_bCon" not in rendered
+    assert "connect(THeaWatSupMinSet_CPL_1.y" in rendered
+
+
+def test_unidirectional_series_ground_coupling_skips_when_distribution_has_no_plant_couplings():
+    template_path = (
+        Path(__file__).parents[2]
+        / "geojson_modelica_translator"
+        / "model_connectors"
+        / "couplings"
+        / "5G_templates"
+        / "UnidirectionalSeries_GroundCoupling"
+        / "ConnectStatements.mopt"
+    )
+
+    graph = _GraphStub(couplings={"Dis_NoPlant": SimpleNamespace()})
+    loop_order = SimpleNamespace(
+        number_of_loops=1,
+        data=[{"list_bldg_ids_in_group": ["bldg-1"], "list_ghe_ids_in_group": ["ghe-1"]}],
+    )
+    coupling = {"id": "CPL_2", "network": {"id": "GroCou_1"}}
+
+    rendered = _render_template(template_path, graph=graph, loop_order=loop_order, coupling=coupling)
+
+    assert "connect(Dis_NoPlant.heatPortGro" not in rendered
+    assert "annotation" in rendered
+
+
+def test_ground_coupling_instance_omits_soidat_without_plant_couplings():
+    template_path = (
+        Path(__file__).parents[2]
+        / "geojson_modelica_translator"
+        / "model_connectors"
+        / "networks"
+        / "templates"
+        / "GroundCoupling_Instance.mopt"
+    )
+
+    graph = _GraphStub(couplings={"GroCou_1": SimpleNamespace()})
+    model = {"id": "GroCou_1", "modelica_type": "Networks.GroundCoupling"}
+    sys_params = {
+        "district_system": {
+            "fifth_generation": {
+                "horizontal_piping_parameters": {
+                    "hydraulic_diameter": 0.2,
+                    "diameter_ratio": 2.6,
+                    "insulation_thickness": 0.05,
+                }
+            }
+        }
+    }
+
+    rendered = _render_template(template_path, graph=graph, model=model, sys_params=sys_params)
+
+    assert "soiDat=" not in rendered
+    assert "len=cat(" in rendered
+
+
+def test_unidirectional_series_instance_skips_loop_parameters_without_plant_couplings():
+    template_path = (
+        Path(__file__).parents[2]
+        / "geojson_modelica_translator"
+        / "model_connectors"
+        / "networks"
+        / "templates"
+        / "UnidirectionalSeries_Instance.mopt"
+    )
+
+    graph = _GraphStub(couplings={"UniNet_1": SimpleNamespace()})
+    model = {"id": "UniNet_1", "modelica_type": "Networks.UnidirectionalSeries"}
+    loop_order = SimpleNamespace(
+        number_of_loops=1,
+        data=[{"list_bldg_ids_in_group": ["bldg-1"], "list_ghe_ids_in_group": ["ghe-1"]}],
+    )
+    sys_params = {"district_system": {"fifth_generation": {"ghe_parameters": {}}}}
+    globals_ctx = {"medium_w": "MediumW"}
+
+    rendered = _render_template(
+        template_path,
+        graph=graph,
+        model=model,
+        loop_order=loop_order,
+        sys_params=sys_params,
+        globals=globals_ctx,
+    )
+
+    assert "final nCon=" not in rendered
+    assert "final allowFlowReversal=allowFlowReversalSer" in rendered

--- a/tests/model_connectors/test_external_package_utils.py
+++ b/tests/model_connectors/test_external_package_utils.py
@@ -1,0 +1,19 @@
+from geojson_modelica_translator.external_package_utils import set_loop_order_data_in_template_params
+
+
+def test_set_loop_order_data_handles_no_matching_pipe_lengths():
+    template_params = {"globals": {}}
+    feature_properties = [
+        {
+            "type": "Building",
+            "id": "bldg-1",
+        }
+    ]
+    loop_order = [{"list_bldg_ids_in_group": ["bldg-1"]}]
+
+    result = set_loop_order_data_in_template_params(template_params, feature_properties, loop_order)
+
+    assert result["globals"]["lDis"] == "fill(0, 0)"
+    assert result["globals"]["lEnd"] == 0
+    assert result["loop_order"]["number_of_loops"] == 1
+    assert result["loop_order"]["number_of_sources"] == 0

--- a/tests/model_connectors/test_external_package_utils.py
+++ b/tests/model_connectors/test_external_package_utils.py
@@ -1,4 +1,4 @@
-"""Tests for loop-order template parameter helpers in external_package_utils.
+"""Tests for loop-order helpers in external_package_utils.
 
 This module verifies fallback behavior in
 set_loop_order_data_in_template_params when no matching thermal connector
@@ -9,7 +9,10 @@ lengths are found. It ensures the function:
 3. Sizes fallback lDis from the number of buildings in loop_order.
 """
 
-from geojson_modelica_translator.external_package_utils import set_loop_order_data_in_template_params
+import json
+from pathlib import Path
+
+from geojson_modelica_translator.external_package_utils import load_loop_order, set_loop_order_data_in_template_params
 
 
 def test_set_loop_order_data_handles_no_matching_pipe_lengths():
@@ -44,3 +47,43 @@ def test_set_loop_order_data_fallback_ldis_size_uses_loop_order_buildings():
 
     assert result["globals"]["lDis"] == "fill(0, 2)"
     assert result["globals"]["lEnd"] == 0
+
+
+def test_load_loop_order_writes_default_for_missing_file(tmp_path: Path):
+    sys_params_path = tmp_path / "sys_params_5g.json"
+    sys_params = {
+        "district_system": {
+            "fifth_generation": {
+                "ghe_parameters": {"borefields": [{"ghe_id": "ghe-1"}]},
+                "heat_source_parameters": [{"heat_source_id": "hs-1"}],
+            }
+        },
+        "buildings": [{"geojson_id": "bldg-1"}, {"geojson_id": "bldg-2"}],
+    }
+    sys_params_path.write_text(json.dumps(sys_params, indent=2))
+
+    loop_order = load_loop_order(sys_params_path)
+
+    assert loop_order == [
+        {
+            "list_bldg_ids_in_group": ["bldg-1", "bldg-2"],
+            "list_ghe_ids_in_group": ["ghe-1"],
+            "list_source_ids_in_group": ["hs-1"],
+        }
+    ]
+    assert (tmp_path / "_loop_order.json").exists()
+
+
+def test_load_loop_order_raises_for_non_5g_when_missing(tmp_path: Path):
+    sys_params_path = tmp_path / "sys_params_4g.json"
+    sys_params = {
+        "district_system": {"fourth_generation": {}},
+        "buildings": [{"geojson_id": "bldg-1"}],
+    }
+    sys_params_path.write_text(json.dumps(sys_params, indent=2))
+
+    try:
+        load_loop_order(sys_params_path)
+        raise AssertionError("Expected FileNotFoundError for missing loop order in non-5G params")
+    except FileNotFoundError:
+        pass

--- a/tests/model_connectors/test_external_package_utils.py
+++ b/tests/model_connectors/test_external_package_utils.py
@@ -1,3 +1,14 @@
+"""Tests for loop-order template parameter helpers in external_package_utils.
+
+This module verifies fallback behavior in
+set_loop_order_data_in_template_params when no matching thermal connector
+lengths are found. It ensures the function:
+
+1. Produces deterministic zero-length defaults for lDis and lEnd.
+2. Preserves loop-order metadata counts.
+3. Sizes fallback lDis from the number of buildings in loop_order.
+"""
+
 from geojson_modelica_translator.external_package_utils import set_loop_order_data_in_template_params
 
 
@@ -17,3 +28,19 @@ def test_set_loop_order_data_handles_no_matching_pipe_lengths():
     assert result["globals"]["lEnd"] == 0
     assert result["loop_order"]["number_of_loops"] == 1
     assert result["loop_order"]["number_of_sources"] == 0
+
+
+def test_set_loop_order_data_fallback_ldis_size_uses_loop_order_buildings():
+    template_params = {"globals": {}}
+    feature_properties = [
+        {
+            "type": "Building",
+            "id": "bldg-1",
+        }
+    ]
+    loop_order = [{"list_bldg_ids_in_group": ["bldg-1", "bldg-2", "bldg-3"]}]
+
+    result = set_loop_order_data_in_template_params(template_params, feature_properties, loop_order)
+
+    assert result["globals"]["lDis"] == "fill(0, 2)"
+    assert result["globals"]["lEnd"] == 0


### PR DESCRIPTION
#### Any background context you want to provide?

This pull request enhances the robustness and correctness of the 5G network Modelica template generation, especially when handling edge cases where connections or plant couplings may be missing. It introduces additional guards in Jinja templates to prevent invalid Modelica code, improves fallback behavior for template parameters, and adds comprehensive tests to ensure correct template rendering in these scenarios.

#### What does this PR accomplish?

* Added checks in multiple Jinja templates (e.g., `UnidirectionalSeries_GroundCoupling/ConnectStatements.mopt`, `TimeSeries_UnidirectionalSeries/ConnectStatements.mopt`, `UnidirectionalSeries_Borefield/ConnectStatements.mopt`, etc.) to ensure that plant couplings exist and are non-empty before generating connection statements, preventing invalid Modelica code when plant couplings are missing. [[1]](diffhunk://#diff-17a255dc0422b6731432b02462da795a409c49a523415dbeb850b79badffa947R4-R14) [[2]](diffhunk://#diff-cafd0054f2d07281a7e46eef81c7dd1001b6502e9dee72e2a12aba8238956eb1R3-R13) [[3]](diffhunk://#diff-a78236f6d7287f457127810a2dab2d66983accd2706cbc6881178e695dcf96ceL38-R47) [[4]](diffhunk://#diff-d41e1ce432d21705721f03e7abf111c090c43339b22dbac769156abf6984f16bL67-R74) [[5]](diffhunk://#diff-b721b8647596a1dbb63e1a7aca4d054b76ad8c42534bfd1dc299861557732990L75-R84) [[6]](diffhunk://#diff-29fae800b0677ef0e4e8b23f4ca8c2293c842400293ecaa77b7cde6a8a5dff93L39-R46)
* Updated `GroundCoupling_Instance.mopt` and `UnidirectionalSeries_Instance.mopt` to only include certain parameters (like `soiDat` and loop parameters) if plant couplings are present, avoiding reference errors in the generated Modelica. [[1]](diffhunk://#diff-531fc8f68304c93b2f7047b296e04360fbbf3e00c6422c02f6bb5338de6725d3R1-R5) [[2]](diffhunk://#diff-ced0147bab74a42f070596c4507153e9e3f788e4dde3cbedff5cb37278c95118R9-R19)

* Modified `set_loop_order_data_in_template_params` in `external_package_utils.py` to provide deterministic zero-length defaults for `lDis` and `lEnd` when no matching thermal connector lengths are found, preventing crashes and ensuring template math remains valid.
* Updated `district.py` to allow `max_number_of_boreholes` to default to zero if no borefields are listed, avoiding errors with `max([])`.

* Improved the `post_process` method in `time_series.py` to dynamically build the Modelica package order from actual model files, ensuring the package order stays in sync with generated files.

#### How should this be manually tested?
Unit tests
#### What are the relevant tickets?

#### Screenshots (if appropriate)

