### PR TITLE
Fix modelica runner file ownership

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,9 @@ jobs:
         with:
           distribution: Ubuntu-24.04
           additional-packages: docker.io make python3-pip python3-venv
+      - name: Allow long filenames in Windows
+        if: runner.os == 'Windows'
+        run: git config --system core.longpaths true
       - name: Install MBL
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,17 +13,13 @@ defaults:
 
 jobs:
   test:
+    name: Test (${{ matrix.os }}, Python ${{ matrix.python-version }})
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
         python-version: ["3.10", "3.13"]
-        test_env: [python, mypy]
         mbl_tag: [v12.1.0]
-        exclude:
-          # only test mypy on linux for all versions of python
-          - os: windows-latest
-            test_env: mypy
     runs-on: ${{ matrix.os }}
     permissions: write-all
     steps:
@@ -32,6 +28,48 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install Poetry
+        uses: abatilo/actions-poetry@v4
+        with:
+          poetry-version: "latest"
+      - name: Install dependencies with Poetry
+        # poetry setuptools workaround sourced from https://github.com/python-poetry/poetry/issues/7611#issuecomment-1711443539
+        run: |
+          poetry --version
+          poetry self add setuptools
+          poetry install
+      - name: Allow long filenames in Windows
+        if: matrix.os == 'windows-latest'
+        run: git config --system core.longpaths true
+      - name: Install MBL
+        uses: actions/checkout@v6
+        with:
+          repository: lbl-srg/modelica-buildings
+          ref: ${{ matrix.mbl_tag }}
+          path: modelica-buildings
+      - name: Set MODELICAPATH
+        run: echo "MODELICAPATH=${{ github.workspace }}/modelica-buildings" >> "$GITHUB_ENV"
+      - name: Run pytest with coverage
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
+        run: make test-fast PYTEST_EXTRA_ARGS="-v --cov-report term-missing --cov ."
+      - name: Run pytest
+        if: matrix.os != 'ubuntu-latest' || matrix.python-version != '3.13'
+        run: make test-fast PYTEST_EXTRA_ARGS=-v
+
+  resource-intensive-tests:
+    name: Docker simulations and compilations
+    strategy:
+      fail-fast: false
+      matrix:
+        mbl_tag: [v12.1.0]
+    runs-on: ubuntu-latest
+    permissions: write-all
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
       - name: Display system info
         run: |
           python -c "import sys; print(sys.version)"
@@ -47,21 +85,6 @@ jobs:
           poetry --version
           poetry self add setuptools
           poetry install
-      - name: Install modelicafmt
-        run: |
-          RUNNER_SYSTEM=$(python -c 'import platform; print(platform.system())')
-          curl -SLO "https://github.com/urbanopt/modelica-fmt/releases/download/v0.2-pr.2/modelica-fmt_0.2-pr.2_${RUNNER_SYSTEM}_x86_64.tar.gz"
-          tar --exclude='README.md' --exclude='CHANGELOG.md' -xzf modelica-fmt_0.2-pr.2_${RUNNER_SYSTEM}_x86_64.tar.gz
-          chmod +x modelicafmt
-          if [[ $RUNNER_SYSTEM == 'Linux' ]]; then
-            sudo mv modelicafmt /usr/local/bin/
-          else
-            mv modelicafmt '/c/Program Files/'
-          fi
-      - name: Allow long filenames in Windows
-        if: matrix.os == 'windows-latest'
-        run: |
-          git config --system core.longpaths true
       - name: Install MBL
         uses: actions/checkout@v6
         with:
@@ -69,32 +92,69 @@ jobs:
           ref: ${{ matrix.mbl_tag }}
           path: modelica-buildings
       - name: Set MODELICAPATH
-        run: |
-          MODELICAPATH="${{ github.workspace }}/modelica-buildings"
-          cd "${MODELICAPATH}"
-          echo "Git branch is $(git branch)"
-          # export MODELICAPATH for subsequent steps
-          echo "MODELICAPATH=${MODELICAPATH}" >> $GITHUB_ENV
-      - name: Run pytest (including simulations)
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-        if: matrix.test_env == 'python' && matrix.os == 'ubuntu-latest'
-        run: poetry run pytest tests --doctest-modules -v -m 'not dymola' --cov-report term-missing --cov .
-      - name: Run Pytest (no compilation or simulation)
-        if: matrix.test_env == 'python' && matrix.os == 'windows-latest'
-        run: poetry run pytest tests --doctest-modules -v -m 'not simulation and not compilation and not dymola'
-      - name: Run pre-commit
-        run: poetry run pre-commit run --show-diff-on-failure --color=always --all-files
-      - name: Run mypy
-        if: matrix.test_env =='mypy'
-        run: poetry run mypy --exclude='modelica-buildings/' --install-types --non-interactive --show-error-codes .
+        run: echo "MODELICAPATH=${{ github.workspace }}/modelica-buildings" >> "$GITHUB_ENV"
+      # Keep this as one non-xdist invocation so Docker workloads run in series.
+      - name: Run resource-intensive tests in series
+        run: make test-resource-intensive PYTEST_EXTRA_ARGS=-v
       - name: Job Failed
         if: ${{ failure() }}
         run: |
           echo "Maybe these logs will help?"
-          ls -alt $GITHUB_WORKSPACE
-          find $GITHUB_WORKSPACE -type f -name 'stdout.log' -print | while read filename; do
+          ls -alt "$GITHUB_WORKSPACE"
+          find "$GITHUB_WORKSPACE" -type f -name 'stdout.log' -print | while read filename; do
             echo "============================================ stdout.log ========================================="
             echo "$filename"
             cat "$filename"
           done
+
+  mypy:
+    name: Mypy (Python ${{ matrix.python-version }})
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.13"]
+    runs-on: ubuntu-latest
+    permissions: write-all
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Poetry
+        uses: abatilo/actions-poetry@v4
+        with:
+          poetry-version: "latest"
+      - name: Install dependencies with Poetry
+        run: |
+          poetry self add setuptools
+          poetry install
+      - name: Run mypy
+        run: poetry run mypy --install-types --non-interactive --show-error-codes .
+
+  pre-commit:
+    name: Pre-commit
+    runs-on: ubuntu-latest
+    permissions: write-all
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - name: Install Poetry
+        uses: abatilo/actions-poetry@v4
+        with:
+          poetry-version: "latest"
+      - name: Install dependencies with Poetry
+        run: |
+          poetry self add setuptools
+          poetry install
+      - name: Install modelicafmt
+        run: |
+          curl -SLO "https://github.com/urbanopt/modelica-fmt/releases/download/v0.2-pr.2/modelica-fmt_0.2-pr.2_Linux_x86_64.tar.gz"
+          tar --exclude='README.md' --exclude='CHANGELOG.md' -xzf modelica-fmt_0.2-pr.2_Linux_x86_64.tar.gz
+          chmod +x modelicafmt
+          sudo mv modelicafmt /usr/local/bin/
+      - name: Run pre-commit
+        run: poetry run pre-commit run --show-diff-on-failure --color=always --all-files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,34 +57,45 @@ jobs:
         run: make test-fast PYTEST_EXTRA_ARGS=-v
 
   resource-intensive-tests:
-    name: Docker simulations and compilations
+    name: Docker simulations and compilations (${{ matrix.os }})
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest, windows-2025]
         mbl_tag: [v12.1.0]
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     permissions: write-all
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python 3.13
+        if: runner.os == 'Linux'
         uses: actions/setup-python@v6
         with:
           python-version: "3.13"
       - name: Display system info
+        if: runner.os == 'Linux'
         run: |
           python -c "import sys; print(sys.version)"
           docker --version
           docker compose version
       - name: Install Poetry
+        if: runner.os == 'Linux'
         uses: abatilo/actions-poetry@v4
         with:
           poetry-version: "latest"
       - name: Install dependencies with Poetry
+        if: runner.os == 'Linux'
         # poetry setuptools workaround sourced from https://github.com/python-poetry/poetry/issues/7611#issuecomment-1711443539
         run: |
           poetry --version
           poetry self add setuptools
           poetry install
+      - name: Set up WSL2 for Linux containers
+        if: runner.os == 'Windows'
+        uses: Vampire/setup-wsl@v6
+        with:
+          distribution: Ubuntu-24.04
+          additional-packages: docker.io make python3-pip python3-venv
       - name: Install MBL
         uses: actions/checkout@v6
         with:
@@ -92,10 +103,28 @@ jobs:
           ref: ${{ matrix.mbl_tag }}
           path: modelica-buildings
       - name: Set MODELICAPATH
+        if: runner.os == 'Linux'
         run: echo "MODELICAPATH=${{ github.workspace }}/modelica-buildings" >> "$GITHUB_ENV"
       # Keep this as one non-xdist invocation so Docker workloads run in series.
-      - name: Run resource-intensive tests in series
+      - name: Run resource-intensive tests in series on Linux
+        if: runner.os == 'Linux'
         run: make test-resource-intensive PYTEST_EXTRA_ARGS=-v
+      # The GMT runner image is Linux-only. On a Windows host, run it with the
+      # Linux Docker daemon in WSL2, as Docker Desktop does for local users.
+      - name: Run resource-intensive tests in series on Windows
+        if: runner.os == 'Windows'
+        shell: wsl-bash {0}
+        run: |
+          sudo service docker start
+          python3 -m venv /tmp/gmt-ci
+          /tmp/gmt-ci/bin/pip install poetry
+          export PATH="/tmp/gmt-ci/bin:$PATH"
+          export MODELICAPATH="$PWD/modelica-buildings"
+          poetry self add setuptools
+          poetry install
+          python --version
+          docker --version
+          make test-resource-intensive PYTEST_EXTRA_ARGS=-v
       - name: Job Failed
         if: ${{ failure() }}
         run: |

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,31 @@
-init:
-	pip install -r requirements.txt
+.PHONY: init test test-fast test-resource-intensive test-resource-intensive-dymola test-resources-intensive-dymola test-all
 
-test:
-	pytest
+PYTEST := poetry run pytest
+PYTEST_ARGS := tests --doctest-modules
+PYTEST_EXTRA_ARGS ?=
+FAST_TEST_MARKERS := not simulation and not compilation and not dymola
+RESOURCE_TEST_MARKERS := (simulation or compilation) and not dymola
+DYMOLA_TEST_MARKERS := dymola
+
+init:
+	poetry install
+
+# Default to the quick local feedback loop; this excludes Docker workloads.
+test: test-fast
+
+test-fast:
+	$(PYTEST) $(PYTEST_ARGS) -n auto --dist loadgroup -m '$(FAST_TEST_MARKERS)' $(PYTEST_EXTRA_ARGS)
+
+# One pytest process intentionally keeps Docker simulations and compilations serial.
+test-resource-intensive:
+	$(PYTEST) $(PYTEST_ARGS) -m '$(RESOURCE_TEST_MARKERS)' $(PYTEST_EXTRA_ARGS)
+
+# Dymola requires a local installation and license, and must run in series.
+test-resources-intensive-dymola:
+	$(PYTEST) $(PYTEST_ARGS) -m '$(DYMOLA_TEST_MARKERS)' $(PYTEST_EXTRA_ARGS)
+
+# Provide the singular spelling alongside the requested command.
+test-resource-intensive-dymola: test-resources-intensive-dymola
+
+# Run the fast suite first, then the resource-intensive suite in series.
+test-all: test-fast test-resource-intensive

--- a/docs/developer_resources.md
+++ b/docs/developer_resources.md
@@ -2,10 +2,24 @@
 
 ## Tests
 
-Tests are run with pytest, e.g.,
+Run the unit and integration tests with the following command. We recommend using `make test` to run the tests that do not require simulation or compilation.
 
 ```bash
-poetry run pytest
+make test
+```
+
+This runs tests that do not require simulation or compilation in parallel. The
+following additional targets run resource-intensive tests serially:
+
+```bash
+# OpenModelica simulations and compilations in Docker
+make test-resource-intensive
+
+# Fast tests followed by the Docker tests
+make test-all
+
+# Dymola-only tests; requires a local Dymola installation and license
+make test-resources-intensive-dymola
 ```
 
 ## Snapshot Testing
@@ -52,12 +66,12 @@ Follow the instructions below in order to configure your local environment:
 - For developers, dependency management is through [Poetry](https://python-poetry.org/docs/). Poetry can be acquired by running `pip install poetry`.
   - If you haven't already installed a virtual environment, Poetry will automatically create a simplified environment for your project.
 - Move to the GMT root directory and run `poetry install` to install the dependencies.
-- Verify that everything is installed correctly by running `poetry run pytest -m 'not compilation and not simulation and not dymola'`. This will run all the unit and integration tests.
+- Verify that everything is installed correctly by running `make test`. This runs all unit and integration tests that do not require simulation or compilation.
 - Follow the instructions below to install pre-commit.
 - To confirm that models will build and simulate, you can run
 
 ```bash
-poetry run pytest -m 'not dymola' --cov-report term-missing --cov .
+make test-all
 ```
 
 The tests should all pass assuming the libraries, Docker, and all dependencies are installed correctly on your computer. Also, there will be a set

--- a/geojson_modelica_translator/model_connectors/load_connectors/_teaser_compat.py
+++ b/geojson_modelica_translator/model_connectors/load_connectors/_teaser_compat.py
@@ -1,0 +1,15 @@
+# :copyright (c) URBANopt, Alliance for Energy Innovation, LLC, and other contributors.
+# See also https://github.com/urbanopt/geojson-modelica-translator/blob/develop/LICENSE.md
+
+"""Compatibility workarounds for importing TEASER."""
+
+from pathlib import Path
+
+# TEASER 1.3.1 creates this directory during import using a racy
+# exists-then-makedirs sequence. Ensure it exists before parallel processes
+# import TEASER simultaneously.
+Path.home().joinpath("TEASEROutput").mkdir(exist_ok=True)
+
+from teaser.project import Project  # noqa: E402
+
+__all__ = ["Project"]

--- a/geojson_modelica_translator/model_connectors/load_connectors/teaser.py
+++ b/geojson_modelica_translator/model_connectors/load_connectors/teaser.py
@@ -11,8 +11,8 @@ from tempfile import mkstemp
 import numpy as np
 from modelica_builder.model import Model
 from modelica_builder.package_parser import PackageParser
-from teaser.project import Project
 
+from geojson_modelica_translator.model_connectors.load_connectors._teaser_compat import Project
 from geojson_modelica_translator.model_connectors.load_connectors.load_base import LoadBase
 from geojson_modelica_translator.utils import ModelicaPath, convert_c_to_k, copytree
 

--- a/geojson_modelica_translator/modelica/lib/runner/README.md
+++ b/geojson_modelica_translator/modelica/lib/runner/README.md
@@ -23,11 +23,9 @@ docker build -t nrel/gmt-om-runner:<tag> .
 
 The default tag will be `nrel/gmt-om-runner:4.0.0`, which is the default version used in the modelica_runner.py file.
 
-If you run the image directly with a bind mount, pass your host UID and GID so files created inside the container stay accessible on the host:
+If you run the image directly with a bind mount, note that the image runs as `root` so it can access the pre-installed Modelica libraries under `/root/.openmodelica`.
 
-```bash
-docker run --user "$(id -u):$(id -g)" -v "$PWD:/mnt/shared/<model_name>" nrel/gmt-om-runner:4.0.0
-```
+The GMT `ModelicaRunner` passes `HOST_UID`/`HOST_GID` into the container and `chown`s the mounted `/mnt/shared/<model_name>` directory at the end of the run so generated files are accessible on the host.
 
 ### Versioning
 

--- a/geojson_modelica_translator/modelica/lib/runner/README.md
+++ b/geojson_modelica_translator/modelica/lib/runner/README.md
@@ -23,6 +23,12 @@ docker build -t nrel/gmt-om-runner:<tag> .
 
 The default tag will be `nrel/gmt-om-runner:4.0.0`, which is the default version used in the modelica_runner.py file.
 
+If you run the image directly with a bind mount, pass your host UID and GID so files created inside the container stay accessible on the host:
+
+```bash
+docker run --user "$(id -u):$(id -g)" -v "$PWD:/mnt/shared/<model_name>" nrel/gmt-om-runner:4.0.0
+```
+
 ### Versioning
 
 In GMT Runner Version 2.0.0 we detached the OM version from the GMT Runner version.

--- a/geojson_modelica_translator/modelica/modelica_runner.py
+++ b/geojson_modelica_translator/modelica/modelica_runner.py
@@ -180,11 +180,8 @@ class ModelicaRunner:
         stdout_log = open("stdout.log", "w")  # noqa: SIM115
         model_name = run_path.parts[-1]
         mo_script = "compile_fmu" if action == "compile" else "simulate"
-        if compiler_flags is not None:
-            # Format compiler flags for OpenModelica
-            compiler_flags_for_modelica = compiler_flags.replace(",", " ")
-        else:
-            compiler_flags_for_modelica = ""
+        # Split compiler flags into a list for safe argument passing (avoids shell injection)
+        compiler_flags_list = compiler_flags.split(",") if compiler_flags else []
 
         try:
             # create the command to call the open modelica compiler inside the docker image
@@ -210,13 +207,16 @@ class ModelicaRunner:
                     f"cd /mnt/shared/{model_name} && "
                     'mkdir -p "$HOME/.openmodelica/libraries" && '
                     'cp -rn /root/.openmodelica/libraries/* "$HOME/.openmodelica/libraries/" 2>/dev/null || true && '
-                    f"omc {mo_script}.mos {compiler_flags_for_modelica} ; "
+                    'omc "$1.mos" "${@:2}" ; '
                     "ret=$? ; "
                     'if [[ -n "$HOST_UID" && -n "$HOST_GID" ]]; then '
                     f'chown -R "$HOST_UID:$HOST_GID" /mnt/shared/{model_name} 2>/dev/null || true ; '
                     "fi ; "
                     "exit $ret"
                 ),
+                "--",
+                mo_script,
+                *compiler_flags_list,
             ]
             # execute the command that calls docker
             logger.debug(f"Calling {exec_call}")

--- a/geojson_modelica_translator/modelica/modelica_runner.py
+++ b/geojson_modelica_translator/modelica/modelica_runner.py
@@ -253,12 +253,7 @@ class ModelicaRunner:
                 f"{docker_image}",
                 "/bin/bash",
                 "-c",
-                (
-                    'omc "$1.mos" "${@:2}" ; '
-                    "ret=$? ; "
-                    f"{self._docker_post_run_permissions_command()} ; "
-                    "exit $ret"
-                ),
+                (f'omc "$1.mos" "${{@:2}}" ; ret=$? ; {self._docker_post_run_permissions_command()} ; exit $ret'),
                 "--",
                 mo_script,
                 *compiler_flags_list,

--- a/geojson_modelica_translator/modelica/modelica_runner.py
+++ b/geojson_modelica_translator/modelica/modelica_runner.py
@@ -84,11 +84,12 @@ class ModelicaRunner:
         """Return shell commands that make Docker-created outputs editable by the host user."""
         return (
             'if [[ -n "${HOST_UID:-}" && -n "${HOST_GID:-}" ]]; then '
-            'if chown -R "$HOST_UID:$HOST_GID" "$PWD" 2>/dev/null; then '
-            'chmod -R u+rwX "$PWD" 2>/dev/null || true ; '
-            "else "
-            'chmod -R a+rwX "$PWD" 2>/dev/null || true ; '
+            'for output_dir in "$PWD"/*_results; do '
+            'if [[ -e "$output_dir" ]]; then '
+            'chown -R "$HOST_UID:$HOST_GID" "$output_dir" 2>/dev/null || true ; '
+            'chmod -R u+rwX "$output_dir" 2>/dev/null || true ; '
             "fi ; "
+            "done ; "
             "fi"
         )
 

--- a/geojson_modelica_translator/modelica/modelica_runner.py
+++ b/geojson_modelica_translator/modelica/modelica_runner.py
@@ -84,12 +84,8 @@ class ModelicaRunner:
         """Return shell commands that make Docker-created outputs editable by the host user."""
         return (
             'if [[ -n "${HOST_UID:-}" && -n "${HOST_GID:-}" ]]; then '
-            'for output_dir in "$PWD"/*_results; do '
-            'if [[ -e "$output_dir" ]]; then '
-            'chown -R "$HOST_UID:$HOST_GID" "$output_dir" 2>/dev/null || true ; '
-            'chmod -R u+rwX "$output_dir" 2>/dev/null || true ; '
-            "fi ; "
-            "done ; "
+            'chown -R "$HOST_UID:$HOST_GID" "$PWD" 2>/dev/null || true ; '
+            'chmod -R u+rwX "$PWD" 2>/dev/null || true ; '
             "fi"
         )
 

--- a/geojson_modelica_translator/modelica/modelica_runner.py
+++ b/geojson_modelica_translator/modelica/modelica_runner.py
@@ -84,10 +84,10 @@ class ModelicaRunner:
         """Return shell commands that make Docker-created outputs editable by the host user."""
         return (
             'if [[ -n "${HOST_UID:-}" && -n "${HOST_GID:-}" ]]; then '
-            'if chown -R "$HOST_UID:$HOST_GID" "$HOME" 2>/dev/null; then '
-            'chmod -R u+rwX "$HOME" 2>/dev/null || true ; '
+            'if chown -R "$HOST_UID:$HOST_GID" "$PWD" 2>/dev/null; then '
+            'chmod -R u+rwX "$PWD" 2>/dev/null || true ; '
             "else "
-            'chmod -R a+rwX "$HOME" 2>/dev/null || true ; '
+            'chmod -R a+rwX "$PWD" 2>/dev/null || true ; '
             "fi ; "
             "fi"
         )
@@ -113,8 +113,6 @@ class ModelicaRunner:
             f"HOST_UID={host_uid}",
             "-e",
             f"HOST_GID={host_gid}",
-            "-e",
-            f"HOME=/mnt/shared/{model_name}",
             "-v",
             f"{run_path}:/mnt/shared/{model_name}",
             "-w",
@@ -247,8 +245,6 @@ class ModelicaRunner:
                 "run",
                 *(["-e", f"HOST_UID={host_uid}"] if host_uid is not None else []),
                 *(["-e", f"HOST_GID={host_gid}"] if host_gid is not None else []),
-                "-e",
-                f"HOME=/mnt/shared/{model_name}",
                 "-v",
                 f"{run_path}:/mnt/shared/{model_name}",
                 "-w",
@@ -257,8 +253,6 @@ class ModelicaRunner:
                 "/bin/bash",
                 "-c",
                 (
-                    'mkdir -p "$HOME/.openmodelica/libraries" && '
-                    'cp -rn /root/.openmodelica/libraries/* "$HOME/.openmodelica/libraries/" 2>/dev/null || true ; '
                     'omc "$1.mos" "${@:2}" ; '
                     "ret=$? ; "
                     f"{self._docker_post_run_permissions_command()} ; "

--- a/geojson_modelica_translator/modelica/modelica_runner.py
+++ b/geojson_modelica_translator/modelica/modelica_runner.py
@@ -188,20 +188,35 @@ class ModelicaRunner:
 
         try:
             # create the command to call the open modelica compiler inside the docker image
-            run_user = None
+            host_uid = None
+            host_gid = None
             if hasattr(os, "getuid") and hasattr(os, "getgid"):
-                run_user = f"{os.getuid()}:{os.getgid()}"
+                host_uid = str(os.getuid())
+                host_gid = str(os.getgid())
 
             exec_call = [
                 "docker",
                 "run",
-                *(["--user", run_user] if run_user is not None else []),
+                *(["-e", f"HOST_UID={host_uid}"] if host_uid is not None else []),
+                *(["-e", f"HOST_GID={host_gid}"] if host_gid is not None else []),
+                "-e",
+                f"HOME=/mnt/shared/{model_name}",
                 "-v",
                 f"{run_path}:/mnt/shared/{model_name}",
                 f"{docker_image}",
                 "/bin/bash",
                 "-c",
-                f"cd mnt/shared/{model_name} && omc {mo_script}.mos {compiler_flags_for_modelica}",
+                (
+                    f"cd /mnt/shared/{model_name} && "
+                    'mkdir -p "$HOME/.openmodelica/libraries" && '
+                    'cp -rn /root/.openmodelica/libraries/* "$HOME/.openmodelica/libraries/" 2>/dev/null || true && '
+                    f"omc {mo_script}.mos {compiler_flags_for_modelica} ; "
+                    "ret=$? ; "
+                    'if [[ -n "$HOST_UID" && -n "$HOST_GID" ]]; then '
+                    f'chown -R "$HOST_UID:$HOST_GID" /mnt/shared/{model_name} 2>/dev/null || true ; '
+                    "fi ; "
+                    "exit $ret"
+                ),
             ]
             # execute the command that calls docker
             logger.debug(f"Calling {exec_call}")

--- a/geojson_modelica_translator/modelica/modelica_runner.py
+++ b/geojson_modelica_translator/modelica/modelica_runner.py
@@ -188,9 +188,14 @@ class ModelicaRunner:
 
         try:
             # create the command to call the open modelica compiler inside the docker image
+            run_user = None
+            if hasattr(os, "getuid") and hasattr(os, "getgid"):
+                run_user = f"{os.getuid()}:{os.getgid()}"
+
             exec_call = [
                 "docker",
                 "run",
+                *(["--user", run_user] if run_user is not None else []),
                 "-v",
                 f"{run_path}:/mnt/shared/{model_name}",
                 f"{docker_image}",

--- a/geojson_modelica_translator/modelica/modelica_runner.py
+++ b/geojson_modelica_translator/modelica/modelica_runner.py
@@ -98,9 +98,7 @@ class ModelicaRunner:
             return str(os.getuid()), str(os.getgid())
         return None, None
 
-    def _restore_docker_output_permissions(
-        self, run_path: Path, docker_image: str, stdout_log
-    ) -> None:
+    def _restore_docker_output_permissions(self, run_path: Path, docker_image: str, stdout_log) -> None:
         """Run a short Docker cleanup pass to repair ownership after interrupted runs."""
         host_uid, host_gid = self._host_user_ids()
         if host_uid is None or host_gid is None:

--- a/geojson_modelica_translator/modelica/modelica_runner.py
+++ b/geojson_modelica_translator/modelica/modelica_runner.py
@@ -234,7 +234,9 @@ class ModelicaRunner:
         model_name = run_path.parts[-1]
         mo_script = "compile_fmu" if action == "compile" else "simulate"
         # Split compiler flags into a list for safe argument passing (avoids shell injection)
-        compiler_flags_list = compiler_flags.split(",") if compiler_flags else []
+        compiler_flags_list = (
+            [flag.strip() for flag in compiler_flags.split(",") if flag.strip()] if compiler_flags else []
+        )
 
         try:
             # create the command to call the open modelica compiler inside the docker image

--- a/geojson_modelica_translator/modelica/modelica_runner.py
+++ b/geojson_modelica_translator/modelica/modelica_runner.py
@@ -80,6 +80,61 @@ class ModelicaRunner:
             )
         return new_run_path
 
+    def _docker_post_run_permissions_command(self) -> str:
+        """Return shell commands that make Docker-created outputs editable by the host user."""
+        return (
+            'if [[ -n "${HOST_UID:-}" && -n "${HOST_GID:-}" ]]; then '
+            'if chown -R "$HOST_UID:$HOST_GID" "$HOME" 2>/dev/null; then '
+            'chmod -R u+rwX "$HOME" 2>/dev/null || true ; '
+            "else "
+            'chmod -R a+rwX "$HOME" 2>/dev/null || true ; '
+            "fi ; "
+            "fi"
+        )
+
+    def _host_user_ids(self) -> tuple[str | None, str | None]:
+        """Return the host UID/GID when available for Docker output ownership repair."""
+        if hasattr(os, "getuid") and hasattr(os, "getgid"):
+            return str(os.getuid()), str(os.getgid())
+        return None, None
+
+    def _restore_docker_output_permissions(
+        self, run_path: Path, docker_image: str, stdout_log
+    ) -> None:
+        """Run a short Docker cleanup pass to repair ownership after interrupted runs."""
+        host_uid, host_gid = self._host_user_ids()
+        if host_uid is None or host_gid is None:
+            return
+
+        model_name = run_path.parts[-1]
+        exec_call = [
+            "docker",
+            "run",
+            "--rm",
+            "-e",
+            f"HOST_UID={host_uid}",
+            "-e",
+            f"HOST_GID={host_gid}",
+            "-e",
+            f"HOME=/mnt/shared/{model_name}",
+            "-v",
+            f"{run_path}:/mnt/shared/{model_name}",
+            "-w",
+            f"/mnt/shared/{model_name}",
+            f"{docker_image}",
+            "/bin/bash",
+            "-c",
+            self._docker_post_run_permissions_command(),
+        ]
+        logger.debug(f"Restoring Docker output permissions with {exec_call}")
+        subprocess.run(
+            exec_call,
+            stdout=stdout_log,
+            stderr=subprocess.STDOUT,
+            cwd=run_path,
+            check=False,
+        )
+
     def _copy_over_docker_resources(
         self, run_path: Path, filename: str | Path | None, model_name: str, **kwargs
     ) -> None:
@@ -185,11 +240,7 @@ class ModelicaRunner:
 
         try:
             # create the command to call the open modelica compiler inside the docker image
-            host_uid = None
-            host_gid = None
-            if hasattr(os, "getuid") and hasattr(os, "getgid"):
-                host_uid = str(os.getuid())
-                host_gid = str(os.getgid())
+            host_uid, host_gid = self._host_user_ids()
 
             exec_call = [
                 "docker",
@@ -200,18 +251,17 @@ class ModelicaRunner:
                 f"HOME=/mnt/shared/{model_name}",
                 "-v",
                 f"{run_path}:/mnt/shared/{model_name}",
+                "-w",
+                f"/mnt/shared/{model_name}",
                 f"{docker_image}",
                 "/bin/bash",
                 "-c",
                 (
-                    f"cd /mnt/shared/{model_name} && "
                     'mkdir -p "$HOME/.openmodelica/libraries" && '
-                    'cp -rn /root/.openmodelica/libraries/* "$HOME/.openmodelica/libraries/" 2>/dev/null || true && '
+                    'cp -rn /root/.openmodelica/libraries/* "$HOME/.openmodelica/libraries/" 2>/dev/null || true ; '
                     'omc "$1.mos" "${@:2}" ; '
                     "ret=$? ; "
-                    'if [[ -n "$HOST_UID" && -n "$HOST_GID" ]]; then '
-                    f'chown -R "$HOST_UID:$HOST_GID" /mnt/shared/{model_name} 2>/dev/null || true ; '
-                    "fi ; "
+                    f"{self._docker_post_run_permissions_command()} ; "
                     "exit $ret"
                 ),
                 "--",
@@ -234,19 +284,22 @@ class ModelicaRunner:
             logger.debug(
                 f"Subprocess command executed, waiting for completion... \nArgs used: {completed_process.args}"
             )
+            if completed_process.returncode != 0:
+                self._restore_docker_output_permissions(run_path, docker_image, stdout_log)
         except KeyboardInterrupt:
             # List all containers and their images
             docker_containers_cmd = ["docker", "ps", "--format", "{{.ID}} {{.Image}}"]
             containers_list = subprocess.check_output(docker_containers_cmd, text=True).rstrip().split("\n")
 
             # Find containers from our image
-            for container_line in containers_list:
+            for container_line in [line for line in containers_list if line]:
                 container_id, container_image = container_line.split()
                 if container_image == docker_image:
                     logger.debug(f"Killing container: {container_id} (Image: {container_image})")
                     # Kill the container
                     kill_command = f"docker kill {container_id}"
                     subprocess.run(kill_command.split(), check=True, text=True)
+            self._restore_docker_output_permissions(run_path, docker_image, stdout_log)
             # Remind user why the simulation didn't complete
             raise SystemExit("Simulation stopped by user KeyboardInterrupt")
         finally:

--- a/geojson_modelica_translator/modelica/modelica_runner.py
+++ b/geojson_modelica_translator/modelica/modelica_runner.py
@@ -284,7 +284,7 @@ class ModelicaRunner:
             logger.debug(
                 f"Subprocess command executed, waiting for completion... \nArgs used: {completed_process.args}"
             )
-            if completed_process.returncode != 0:
+            if completed_process.returncode in (130, 137):
                 self._restore_docker_output_permissions(run_path, docker_image, stdout_log)
         except KeyboardInterrupt:
             # List all containers and their images

--- a/poetry.lock
+++ b/poetry.lock
@@ -147,15 +147,15 @@ files = [
 
 [[package]]
 name = "certifi"
-version = "2026.5.20"
+version = "2026.6.17"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 groups = ["main", "dev"]
 markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
-    {file = "certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897"},
-    {file = "certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d"},
+    {file = "certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db"},
+    {file = "certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432"},
 ]
 
 [[package]]
@@ -560,15 +560,15 @@ tests = ["pytest", "pytest-cov", "pytest-xdist"]
 
 [[package]]
 name = "distlib"
-version = "0.4.0"
+version = "0.4.3"
 description = "Distribution utilities"
 optional = false
 python-versions = "*"
 groups = ["dev"]
 markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
-    {file = "distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16"},
-    {file = "distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d"},
+    {file = "distlib-0.4.3-py2.py3-none-any.whl", hash = "sha256:4b0ce306c966eb73bc3a7b6abad017c556dadd92c44701562cd528ac7fde4d5b"},
+    {file = "distlib-0.4.3.tar.gz", hash = "sha256:f152097224a0ae24be5a0f6bae1b9359af82133bce63f98a95f86cae1aede9ed"},
 ]
 
 [[package]]
@@ -592,15 +592,15 @@ test = ["pytest (>=6)"]
 
 [[package]]
 name = "filelock"
-version = "3.29.0"
+version = "3.29.4"
 description = "A platform independent file lock."
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
-    {file = "filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258"},
-    {file = "filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90"},
+    {file = "filelock-3.29.4-py3-none-any.whl", hash = "sha256:dac1648087d5115554850d113e7dd8c83ab2d38e3435dde2d4f163847e57b767"},
+    {file = "filelock-3.29.4.tar.gz", hash = "sha256:10cdb3656fc44541cdf30652a93fb10ec6b05325620eb316bd26893e4201538a"},
 ]
 
 [[package]]
@@ -779,15 +779,15 @@ license = ["ukkonen"]
 
 [[package]]
 name = "idna"
-version = "3.17"
+version = "3.18"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.9"
 groups = ["main", "dev"]
 markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
-    {file = "idna-3.17-py3-none-any.whl", hash = "sha256:466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c"},
-    {file = "idna-3.17.tar.gz", hash = "sha256:5eb0cb53bc467c12eadcf6de83163ad8527cec9416f44b9b61b19caedad2b87f"},
+    {file = "idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2"},
+    {file = "idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848"},
 ]
 
 [package.extras]
@@ -1531,15 +1531,15 @@ python-legacy = ["mkdocstrings-python-legacy (>=0.2.1)"]
 
 [[package]]
 name = "mkdocstrings-python"
-version = "2.0.3"
+version = "2.0.4"
 description = "A Python handler for mkdocstrings."
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
-    {file = "mkdocstrings_python-2.0.3-py3-none-any.whl", hash = "sha256:0b83513478bdfd803ff05aa43e9b1fca9dd22bcd9471f09ca6257f009bc5ee12"},
-    {file = "mkdocstrings_python-2.0.3.tar.gz", hash = "sha256:c518632751cc869439b31c9d3177678ad2bfa5c21b79b863956ad68fc92c13b8"},
+    {file = "mkdocstrings_python-2.0.4-py3-none-any.whl", hash = "sha256:fd87c173e1e719a85997b6d4f852cdc55f36710e0ed08da3a7bd9abe79c9db00"},
+    {file = "mkdocstrings_python-2.0.4.tar.gz", hash = "sha256:58c73c5d358e64e9b1673447663f4a2f8a8941e392e225fc0a0c893758cc452f"},
 ]
 
 [package.dependencies]
@@ -2110,15 +2110,15 @@ diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pytest"
-version = "9.0.3"
+version = "9.1.0"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["main", "dev"]
 markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
-    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
-    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
+    {file = "pytest-9.1.0-py3-none-any.whl", hash = "sha256:8ebb0e7888bdf2bdfc602ec51f8f62d50200af37356c74e503c79a94f5c81f32"},
+    {file = "pytest-9.1.0.tar.gz", hash = "sha256:41dd9148c08072446394cefd3d79701701335a9f4cae69ba92e39f6c7f5c061c"},
 ]
 
 [package.dependencies]
@@ -2172,15 +2172,15 @@ six = ">=1.5"
 
 [[package]]
 name = "python-discovery"
-version = "1.4.0"
+version = "1.4.2"
 description = "Python interpreter discovery"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
 markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
-    {file = "python_discovery-1.4.0-py3-none-any.whl", hash = "sha256:26ed78d703e234879a66244c7d4114563fb13ec5cd30a2d1357e5fb4850782da"},
-    {file = "python_discovery-1.4.0.tar.gz", hash = "sha256:eb8bc7daad3c226c147e45bb4e970a1feb1bf4048ee178e6db59e197b8010ce3"},
+    {file = "python_discovery-1.4.2-py3-none-any.whl", hash = "sha256:475803f53b7b2ed6e490e27373f9d8340f7d2eebf9acdaf645d7d714c97bb500"},
+    {file = "python_discovery-1.4.2.tar.gz", hash = "sha256:8f3746c4b4968d22afbb97d36e1a0e5b66e6c0f297290f2e95f05b9b8bf18690"},
 ]
 
 [package.dependencies]
@@ -2683,15 +2683,15 @@ files = [
 
 [[package]]
 name = "syrupy"
-version = "5.2.0"
+version = "5.3.2"
 description = "Pytest Snapshot Test Utility"
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
-    {file = "syrupy-5.2.0-py3-none-any.whl", hash = "sha256:798cb493a6e20f4839e58ea8f10eb1b0d85684c676442f79786e219bf32618e6"},
-    {file = "syrupy-5.2.0.tar.gz", hash = "sha256:0e6b7abf1e04f060f6c797bed8bca96f2468954168328041e02634a68fc11ff0"},
+    {file = "syrupy-5.3.2-py3-none-any.whl", hash = "sha256:a4cb08f07342655816c16b6b3aef5f6af8859ef5fbad6a57d0e2c20c0f8be54c"},
+    {file = "syrupy-5.3.2.tar.gz", hash = "sha256:d4c9d4badb165a5694dcd869812717d899a8aa0b6f14f842437cb57c4ce09b3a"},
 ]
 
 [package.dependencies]
@@ -2825,22 +2825,22 @@ zstd = ["backports-zstd (>=1.0.0)"]
 
 [[package]]
 name = "virtualenv"
-version = "21.4.1"
+version = "21.5.1"
 description = "Virtual Python Environment builder"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["dev"]
 markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
-    {file = "virtualenv-21.4.1-py3-none-any.whl", hash = "sha256:caf4ff72d1b4039057f41d8e8466e859513d67c0400d9c6b62c02c9d1ebc3e12"},
-    {file = "virtualenv-21.4.1.tar.gz", hash = "sha256:2ca543c713b72840ceffd94e9bdedfbd09a661defa1f7f69e5429ad4059442e2"},
+    {file = "virtualenv-21.5.1-py3-none-any.whl", hash = "sha256:55aa670b67bbfb991b03fda39bd3276d92c419d702376e98c5df1c9989a26783"},
+    {file = "virtualenv-21.5.1.tar.gz", hash = "sha256:dca3bf98275a59c652b69d68e73433e597d977c2da9198882479d1a7188009c8"},
 ]
 
 [package.dependencies]
 distlib = ">=0.3.7,<1"
 filelock = {version = ">=3.24.2,<4", markers = "python_version >= \"3.10\""}
 platformdirs = ">=3.9.1,<5"
-python-discovery = ">=1.4"
+python-discovery = ">=1.4.2"
 typing-extensions = {version = ">=4.13.2", markers = "python_version < \"3.11\""}
 
 [[package]]

--- a/poetry.lock
+++ b/poetry.lock
@@ -591,6 +591,22 @@ typing-extensions = {version = ">=4.6.0", markers = "python_version < \"3.13\""}
 test = ["pytest (>=6)"]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+description = "execnet: rapid multi-Python deployment"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
+files = [
+    {file = "execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec"},
+    {file = "execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd"},
+]
+
+[package.extras]
+testing = ["hatch", "pre-commit", "pytest", "tox"]
+
+[[package]]
 name = "filelock"
 version = "3.29.4"
 description = "A platform independent file lock."
@@ -2155,6 +2171,28 @@ pytest = ">=7"
 testing = ["process-tests", "pytest-xdist", "virtualenv"]
 
 [[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+description = "pytest xdist plugin for distributed testing, most importantly across multiple CPUs"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
+files = [
+    {file = "pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88"},
+    {file = "pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1"},
+]
+
+[package.dependencies]
+execnet = ">=2.1"
+pytest = ">=7.0.0"
+
+[package.extras]
+psutil = ["psutil (>=3.0)"]
+setproctitle = ["setproctitle"]
+testing = ["filelock"]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"
@@ -2890,4 +2928,4 @@ watchmedo = ["PyYAML (>=3.10)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10, <3.14"
-content-hash = "998362e21c421884d3662ee139b656d42a3ac4854c1c785393e57f80aecbf624"
+content-hash = "edd75fd66e180bb2f55ffc1ce16d88628eeb01edd4dd4236ae219a665109fb4e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ mypy = ">=1.17,<3.0"
 pre-commit = "^4.0"
 pytest = ">=8.3,<10.0"
 pytest-cov = ">=6,<8"
+pytest-xdist = ">=3.6,<4.0"
 syrupy = ">=4.8,<6.0"
 # documentation - these are used during development of docs, not deployment
 markdown-include = "^0.8.1"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,20 +1,5 @@
-# content of pytest.ini
-# setup.cfg files should use [tool:pytest] section instead
 [metadata]
 description-file = README.md
-
-[tool:pytest]
-addopts =
-    --cov geojson_modelica_translator --cov-report term-missing
-    --verbose
-    -s
-norecursedirs =
-    dist
-    build
-    modelica-buildings
-    src
-    output
-testpaths = tests
 
 [build_sphinx]
 source_dir = docs

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,12 +2,37 @@
 # See also https://github.com/urbanopt/geojson-modelica-translator/blob/develop/LICENSE.md
 
 # -*- coding: utf-8 -*-
-"""
-Dummy conftest.py.
+"""Shared pytest configuration."""
 
-If you don't know what this is for, just leave it empty.
-Read more about conftest.py under:
-https://pytest.org/latest/plugins.html
-"""
+from pathlib import Path
 
-# import pytest
+import pytest
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    """Keep tests that share files on the same xdist worker.
+
+    Resource-intensive tests use one group so they remain serial even if a
+    developer invokes pytest with xdist directly. Other tests are grouped by
+    module, except translator tests, which share a common output directory.
+    """
+    tests_root = Path(__file__).parent
+    shared_waste_heat_paths = {
+        Path("management/test_uo_des.py"),
+        Path("model_connectors/test_waste_heat_district.py"),
+    }
+
+    for item in items:
+        if any(item.get_closest_marker(marker) for marker in ("simulation", "compilation", "dymola")):
+            group = "resource-intensive"
+        else:
+            relative_path = item.path.relative_to(tests_root)
+            if relative_path.parts[0] == "geojson_modelica_translator":
+                group = "geojson-modelica-translator"
+            elif relative_path in shared_waste_heat_paths:
+                group = "shared-waste-heat"
+            else:
+                group = str(relative_path)
+
+        item.add_marker(pytest.mark.xdist_group(name=group))

--- a/tests/management/test_uo_des.py
+++ b/tests/management/test_uo_des.py
@@ -44,6 +44,43 @@ class CLIIntegrationTest(TestCase):
         self.day_200_plus_a_thousand = 17280000 + 1000  # in seconds
         self.step_size_one_second = 1  # in seconds
 
+    def ensure_model_exists(
+        self,
+        project_name: str,
+        sys_param_path: Path,
+        scenario_file_path: Path,
+        feature_file_path: Path,
+        district_type: str = "4G",
+    ) -> None:
+        """Create the model required by a simulation test when it is not already present."""
+        project_path = self.output_dir / project_name
+        if (project_path / "package.mo").exists():
+            return
+
+        sys_param_path.unlink(missing_ok=True)
+        build_result = self.runner.invoke(
+            cli,
+            [
+                "build-sys-param",
+                str(sys_param_path),
+                str(scenario_file_path),
+                str(feature_file_path),
+                district_type,
+            ],
+        )
+        assert build_result.exit_code == 0, build_result.output
+
+        create_result = self.runner.invoke(
+            cli,
+            [
+                "create-model",
+                str(sys_param_path),
+                str(feature_file_path),
+                str(project_path),
+            ],
+        )
+        assert create_result.exit_code == 0, create_result.output
+
     def test_cli_builds_sys_params(self):
         self.sys_param_path.unlink(missing_ok=True)
 
@@ -407,6 +444,12 @@ class CLIIntegrationTest(TestCase):
     @pytest.mark.simulation
     def test_cli_runs_existing_4g_model(self):
         project_name = "modelica_project_4g"
+        self.ensure_model_exists(
+            project_name,
+            self.sys_param_path,
+            self.scenario_file_path,
+            self.feature_file_path,
+        )
         results_dir = f"{project_name}.Districts.DistrictEnergySystem_results"
         if (self.output_dir / project_name / results_dir).exists():
             rmtree(self.output_dir / project_name / results_dir)
@@ -434,6 +477,13 @@ class CLIIntegrationTest(TestCase):
     @pytest.mark.simulation
     def test_cli_runs_existing_5g_model(self):
         project_name = "modelica_project_5g"
+        self.ensure_model_exists(
+            project_name,
+            self.sys_param_path,
+            self.scenario_file_path,
+            self.feature_file_path_ghe,
+            "5G_ghe",
+        )
         results_dir = f"{project_name}.Districts.DistrictEnergySystem_results"
         if (self.output_dir / project_name / results_dir).exists():
             rmtree(self.output_dir / project_name / results_dir)
@@ -461,6 +511,13 @@ class CLIIntegrationTest(TestCase):
     @pytest.mark.simulation
     def test_cli_runs_existing_5g_model_with_specific_variables(self):
         project_name = "modelica_project_5g"
+        self.ensure_model_exists(
+            project_name,
+            self.sys_param_path,
+            self.scenario_file_path,
+            self.feature_file_path_ghe,
+            "5G_ghe",
+        )
         results_dir = f"{project_name}.Districts.DistrictEnergySystem_results"
         if (self.output_dir / project_name / results_dir).exists():
             rmtree(self.output_dir / project_name / results_dir)
@@ -490,6 +547,13 @@ class CLIIntegrationTest(TestCase):
     @pytest.mark.simulation
     def test_cli_runs_existing_5g_model_with_compiler_flags(self):
         project_name = "modelica_project_5g"
+        self.ensure_model_exists(
+            project_name,
+            self.sys_param_path,
+            self.scenario_file_path,
+            self.feature_file_path_ghe,
+            "5G_ghe",
+        )
         results_dir = f"{project_name}.Districts.DistrictEnergySystem_results"
         if (self.output_dir / project_name / results_dir).exists():
             rmtree(self.output_dir / project_name / results_dir)
@@ -521,6 +585,13 @@ class CLIIntegrationTest(TestCase):
     @pytest.mark.simulation
     def test_cli_runs_existing_5g_model_with_simulation_flags(self):
         project_name = "modelica_project_5g"
+        self.ensure_model_exists(
+            project_name,
+            self.sys_param_path,
+            self.scenario_file_path,
+            self.feature_file_path_ghe,
+            "5G_ghe",
+        )
         results_dir = f"{project_name}.Districts.DistrictEnergySystem_results"
         if (self.output_dir / project_name / results_dir).exists():
             rmtree(self.output_dir / project_name / results_dir)
@@ -553,6 +624,13 @@ class CLIIntegrationTest(TestCase):
     @pytest.mark.simulation
     def test_cli_runs_existing_waste_heat_model(self):
         project_name = "modelica_project_waste_heat"
+        self.ensure_model_exists(
+            project_name,
+            self.sys_param_path_waste_heat,
+            self.scenario_file_path_waste_heat,
+            self.feature_file_path_waste_heat,
+            "5G_ghe",
+        )
         results_dir = f"{project_name}.Districts.DistrictEnergySystem_results"
         if (self.output_dir / project_name / results_dir).exists():
             rmtree(self.output_dir / project_name / results_dir)

--- a/tests/modelica/test_modelica_runner.py
+++ b/tests/modelica/test_modelica_runner.py
@@ -8,6 +8,7 @@ import platform
 import shutil
 import unittest
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -62,6 +63,68 @@ class ModelicaRunnerTest(unittest.TestCase):
         with pytest.raises(SystemExit) as exc:
             mr.run_in_docker("compile", "no_file", file_to_load=file_to_run)
         assert f"File not found to run {file_to_run}" == str(exc.value)
+
+    def test_docker_command_restores_permissions_after_failed_omc(self):
+        mr = ModelicaRunner.__new__(ModelicaRunner)
+        mr._host_user_ids = lambda: ("501", "20")
+        completed_process = MagicMock(returncode=42)
+        completed_process.args = []
+
+        with patch(
+            "geojson_modelica_translator.modelica.modelica_runner.subprocess.run",
+            return_value=completed_process,
+        ) as run_mock:
+            exitcode = mr._subprocess_call_to_docker(
+                Path(self.run_path),
+                "compile_and_run",
+                "flag1,flag2",
+            )
+
+        assert exitcode == 42
+        run_calls = [call.args[0] for call in run_mock.call_args_list]
+        exec_call = run_calls[0]
+        script = exec_call[exec_call.index("-c") + 1]
+        assert exec_call[exec_call.index("-w") + 1] == f"/mnt/shared/{Path(self.run_path).name}"
+        assert exec_call[-4:] == ["--", "simulate", "flag1", "flag2"]
+        assert 'omc "$1.mos" "${@:2}" ; ret=$? ;' in script
+        assert 'chown -R "$HOST_UID:$HOST_GID" "$HOME"' in script
+        assert 'chmod -R a+rwX "$HOME"' in script
+        cleanup_call = run_calls[1]
+        assert "--rm" in cleanup_call
+        assert cleanup_call[cleanup_call.index("-w") + 1] == f"/mnt/shared/{Path(self.run_path).name}"
+
+    def test_docker_interrupt_restores_permissions_before_exiting(self):
+        mr = ModelicaRunner.__new__(ModelicaRunner)
+        mr._host_user_ids = lambda: ("501", "20")
+        docker_image = "nrel/gmt-om-runner:test"
+        completed_process = MagicMock(returncode=0)
+        completed_process.args = []
+
+        with (
+            patch(
+                "geojson_modelica_translator.modelica.modelica_runner.subprocess.run",
+                side_effect=[KeyboardInterrupt, completed_process, completed_process],
+            ) as run_mock,
+            patch(
+                "geojson_modelica_translator.modelica.modelica_runner.subprocess.check_output",
+                return_value=f"container-id {docker_image}\n",
+            ),
+            pytest.raises(SystemExit) as exc,
+        ):
+            mr._subprocess_call_to_docker(
+                Path(self.run_path),
+                "compile_and_run",
+                docker_image=docker_image,
+            )
+
+        assert str(exc.value) == "Simulation stopped by user KeyboardInterrupt"
+        run_calls = [call.args[0] for call in run_mock.call_args_list]
+        assert run_calls[1] == ["docker", "kill", "container-id"]
+        cleanup_call = run_calls[2]
+        cleanup_script = cleanup_call[cleanup_call.index("-c") + 1]
+        assert "--rm" in cleanup_call
+        assert cleanup_call[cleanup_call.index("-w") + 1] == f"/mnt/shared/{Path(self.run_path).name}"
+        assert 'chown -R "$HOST_UID:$HOST_GID" "$HOME"' in cleanup_script
 
     @pytest.mark.compilation
     def test_compile_bouncing_ball_in_docker(self):

--- a/tests/modelica/test_modelica_runner.py
+++ b/tests/modelica/test_modelica_runner.py
@@ -87,9 +87,8 @@ class ModelicaRunnerTest(unittest.TestCase):
         assert exec_call[exec_call.index("-w") + 1] == f"/mnt/shared/{Path(self.run_path).name}"
         assert exec_call[-4:] == ["--", "simulate", "flag1", "flag2"]
         assert 'omc "$1.mos" "${@:2}" ; ret=$? ;' in script
-        assert 'for output_dir in "$PWD"/*_results; do' in script
-        assert 'chown -R "$HOST_UID:$HOST_GID" "$output_dir"' in script
-        assert 'chmod -R u+rwX "$output_dir"' in script
+        assert 'chown -R "$HOST_UID:$HOST_GID" "$PWD"' in script
+        assert 'chmod -R u+rwX "$PWD"' in script
         assert 'chmod -R a+rwX "$PWD"' not in script
         assert len(run_calls) == 1
 
@@ -124,8 +123,8 @@ class ModelicaRunnerTest(unittest.TestCase):
         cleanup_script = cleanup_call[cleanup_call.index("-c") + 1]
         assert "--rm" in cleanup_call
         assert cleanup_call[cleanup_call.index("-w") + 1] == f"/mnt/shared/{Path(self.run_path).name}"
-        assert 'for output_dir in "$PWD"/*_results; do' in cleanup_script
-        assert 'chown -R "$HOST_UID:$HOST_GID" "$output_dir"' in cleanup_script
+        assert 'chown -R "$HOST_UID:$HOST_GID" "$PWD"' in cleanup_script
+        assert 'chmod -R u+rwX "$PWD"' in cleanup_script
 
     @pytest.mark.compilation
     def test_compile_bouncing_ball_in_docker(self):

--- a/tests/modelica/test_modelica_runner.py
+++ b/tests/modelica/test_modelica_runner.py
@@ -87,8 +87,8 @@ class ModelicaRunnerTest(unittest.TestCase):
         assert exec_call[exec_call.index("-w") + 1] == f"/mnt/shared/{Path(self.run_path).name}"
         assert exec_call[-4:] == ["--", "simulate", "flag1", "flag2"]
         assert 'omc "$1.mos" "${@:2}" ; ret=$? ;' in script
-        assert 'chown -R "$HOST_UID:$HOST_GID" "$HOME"' in script
-        assert 'chmod -R a+rwX "$HOME"' in script
+        assert 'chown -R "$HOST_UID:$HOST_GID" "$PWD"' in script
+        assert 'chmod -R a+rwX "$PWD"' in script
         cleanup_call = run_calls[1]
         assert "--rm" in cleanup_call
         assert cleanup_call[cleanup_call.index("-w") + 1] == f"/mnt/shared/{Path(self.run_path).name}"
@@ -124,7 +124,7 @@ class ModelicaRunnerTest(unittest.TestCase):
         cleanup_script = cleanup_call[cleanup_call.index("-c") + 1]
         assert "--rm" in cleanup_call
         assert cleanup_call[cleanup_call.index("-w") + 1] == f"/mnt/shared/{Path(self.run_path).name}"
-        assert 'chown -R "$HOST_UID:$HOST_GID" "$HOME"' in cleanup_script
+        assert 'chown -R "$HOST_UID:$HOST_GID" "$PWD"' in cleanup_script
 
     @pytest.mark.compilation
     def test_compile_bouncing_ball_in_docker(self):

--- a/tests/modelica/test_modelica_runner.py
+++ b/tests/modelica/test_modelica_runner.py
@@ -83,6 +83,9 @@ class ModelicaRunnerTest(unittest.TestCase):
             # logger.info(f.read())
         assert not os.path.exists(os.path.join(results_path, "compile_fmu.mos"))
         assert not os.path.exists(os.path.join(results_path, "simulate.mos"))
+        if platform.system() == "Linux":
+            assert os.stat(os.path.join(results_path, "stdout.log")).st_uid == os.getuid()
+            assert os.stat(os.path.join(results_path, "BouncingBall.fmu")).st_uid == os.getuid()
 
     @pytest.mark.simulation
     def test_simulate_bouncing_ball_in_docker(self):
@@ -97,6 +100,9 @@ class ModelicaRunnerTest(unittest.TestCase):
         assert os.path.exists(os.path.join(results_path, "stdout.log"))
         assert os.path.exists(os.path.join(results_path, "BouncingBall_res.mat"))
         assert not os.path.exists(os.path.join(results_path, "om_docker.sh"))
+        if platform.system() == "Linux":
+            assert os.stat(os.path.join(results_path, "stdout.log")).st_uid == os.getuid()
+            assert os.stat(os.path.join(results_path, "BouncingBall_res.mat")).st_uid == os.getuid()
 
     @pytest.mark.simulation
     @pytest.mark.xfail(reason="Older docker image may fail on CI")
@@ -146,6 +152,8 @@ class ModelicaRunnerTest(unittest.TestCase):
         assert (Path(results_path) / "stdout.log").exists()
         fmu_basename = model_name.split(".")[-1]
         assert (Path(results_path).parent / f"{fmu_basename}.fmu").exists()
+        if platform.system() == "Linux":
+            assert (Path(results_path) / "stdout.log").stat().st_uid == os.getuid()
 
     @pytest.mark.simulation
     def test_simulate_msl_in_docker(self):
@@ -161,6 +169,9 @@ class ModelicaRunnerTest(unittest.TestCase):
         assert success
         assert os.path.exists(os.path.join(results_path, "stdout.log"))
         assert os.path.exists(os.path.join(results_path, f"{model_name}_res.mat"))
+        if platform.system() == "Linux":
+            assert os.stat(os.path.join(results_path, "stdout.log")).st_uid == os.getuid()
+            assert os.stat(os.path.join(results_path, f"{model_name}_res.mat")).st_uid == os.getuid()
 
     @pytest.mark.simulation
     def test_simulate_msl_with_start_times_in_docker(self):
@@ -176,6 +187,9 @@ class ModelicaRunnerTest(unittest.TestCase):
         assert success
         assert os.path.exists(os.path.join(results_path, "stdout.log"))
         assert os.path.exists(os.path.join(results_path, f"{model_name}_res.mat"))
+        if platform.system() == "Linux":
+            assert os.stat(os.path.join(results_path, "stdout.log")).st_uid == os.getuid()
+            assert os.stat(os.path.join(results_path, f"{model_name}_res.mat")).st_uid == os.getuid()
 
     @pytest.mark.simulation
     def test_simulate_msl_with_intervals_in_docker(self):
@@ -191,6 +205,9 @@ class ModelicaRunnerTest(unittest.TestCase):
         assert success
         assert (results_path / "stdout.log").exists()
         assert (results_path / f"{model_name}_res.mat").exists()
+        if platform.system() == "Linux":
+            assert (results_path / "stdout.log").stat().st_uid == os.getuid()
+            assert (results_path / f"{model_name}_res.mat").stat().st_uid == os.getuid()
 
     @pytest.mark.simulation
     def test_simulate_mbl_pid_in_docker(self):

--- a/tests/modelica/test_modelica_runner.py
+++ b/tests/modelica/test_modelica_runner.py
@@ -87,11 +87,11 @@ class ModelicaRunnerTest(unittest.TestCase):
         assert exec_call[exec_call.index("-w") + 1] == f"/mnt/shared/{Path(self.run_path).name}"
         assert exec_call[-4:] == ["--", "simulate", "flag1", "flag2"]
         assert 'omc "$1.mos" "${@:2}" ; ret=$? ;' in script
-        assert 'chown -R "$HOST_UID:$HOST_GID" "$PWD"' in script
-        assert 'chmod -R a+rwX "$PWD"' in script
-        cleanup_call = run_calls[1]
-        assert "--rm" in cleanup_call
-        assert cleanup_call[cleanup_call.index("-w") + 1] == f"/mnt/shared/{Path(self.run_path).name}"
+        assert 'for output_dir in "$PWD"/*_results; do' in script
+        assert 'chown -R "$HOST_UID:$HOST_GID" "$output_dir"' in script
+        assert 'chmod -R u+rwX "$output_dir"' in script
+        assert 'chmod -R a+rwX "$PWD"' not in script
+        assert len(run_calls) == 1
 
     def test_docker_interrupt_restores_permissions_before_exiting(self):
         mr = ModelicaRunner.__new__(ModelicaRunner)
@@ -124,7 +124,8 @@ class ModelicaRunnerTest(unittest.TestCase):
         cleanup_script = cleanup_call[cleanup_call.index("-c") + 1]
         assert "--rm" in cleanup_call
         assert cleanup_call[cleanup_call.index("-w") + 1] == f"/mnt/shared/{Path(self.run_path).name}"
-        assert 'chown -R "$HOST_UID:$HOST_GID" "$PWD"' in cleanup_script
+        assert 'for output_dir in "$PWD"/*_results; do' in cleanup_script
+        assert 'chown -R "$HOST_UID:$HOST_GID" "$output_dir"' in cleanup_script
 
     @pytest.mark.compilation
     def test_compile_bouncing_ball_in_docker(self):


### PR DESCRIPTION
#### Any background context you want to provide?
When running on a host bound system, the /tmp files that are generated by Modelica are owned by the modelica container. Therefore the owner is unable to delete the files, if needed.

#### What does this PR accomplish?

Pass the user to the container.

#### How should this be manually tested?

#### What are the relevant tickets?

#### Screenshots (if appropriate)
